### PR TITLE
Restore watcher on remove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG=flagd:latest
+IMG ?= flagd:latest
 PHONY: .docker-build .build .run
 PREFIX=/usr/local
 guard-%:
@@ -13,6 +13,8 @@ generate: guard-GOPATH
 	${GOPATH}/bin/oapi-codegen --config=./config/open_api_gen_config.yml ./schemas/openapi/provider.yml
 docker-build: generate
 	docker buildx build --platform="linux/ppc64le,linux/s390x,linux/amd64,linux/arm64" -t ${IMG} .
+docker-push: generate
+	docker buildx build --push --platform="linux/ppc64le,linux/s390x,linux/amd64,linux/arm64" -t ${IMG} .
 build: generate
 	go build -o flagd
 run: generate

--- a/pkg/sync/filepath_sync.go
+++ b/pkg/sync/filepath_sync.go
@@ -50,6 +50,13 @@ func (fs *FilePathSync) Notify(w chan<- INotify) {
 				case fsnotify.Write:
 					evtType = E_EVENT_TYPE_MODIFY
 				case fsnotify.Remove:
+					// K8s exposes config maps as symlinks.
+					// Updates cause a remove event, we need to re-add the watcher in this case.
+					err = watcher.Add(fs.URI)
+					if (err != nil) {
+						log.Println("Error restoring watcher:", err)
+						log.Fatal(err)
+					}
 					evtType = E_EVENT_TYPE_DELETE
 				}
 				log.Infof("Filepath notifier event: %s %s", event.Name, event.Op.String())


### PR DESCRIPTION
Closes: https://github.com/open-feature/flagd/issues/42

@AlexsJones I found this issue which seems to have to do with the way K8s exposes configmaps when treated as volumes. The file is actually a symlink which is moved when the configmap is changed. This fires the remove event, which removes our watcher.

The solution seems to be to simply add the watcher back. This resolves the issue in my local cluster. @beeme1mr will confirm on his GKE cluster as well.