### PR TITLE
Fix CI in PRs from forks, scan local image

### DIFF
--- a/.github/workflows/build-push-oci.yaml
+++ b/.github/workflows/build-push-oci.yaml
@@ -1,10 +1,7 @@
-name: build-oci
+name: build-push-oci
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
 
@@ -50,22 +47,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ !(github.event && github.event.pull_request && github.event.pull_request.head.repo.fork) }} # don't push in forks for now: https://github.com/open-feature/flagd/issues/52
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Run Trivy vulnerability scanner
-        if: ${{ !(github.event && github.event.pull_request && github.event.pull_request.head.repo.fork) }} # don't run in forks for now: https://github.com/open-feature/flagd/issues/52
-        uses: aquasecurity/trivy-action@2a2157eb22c08c9a1fac99263430307b8d1bc7a2
-        with:
-          image-ref: ${{ steps.meta.outputs.tags }}
-          format: "template"
-          template: "@/contrib/sarif.tpl"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: ${{ !(github.event && github.event.pull_request && github.event.pull_request.head.repo.fork) }} # don't run in forks for now: https://github.com/open-feature/flagd/issues/52
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/build-scan-oci.yaml
+++ b/.github/workflows/build-scan-oci.yaml
@@ -1,0 +1,46 @@
+name: build-scan-oci
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-local:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          outputs: type=docker,dest=${{ github.workspace }}/flagd-local.tar
+          tags: flagd-local:test
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          input: /github/workspace/flagd-local.tar
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
This PR does trivy scanning with a local image instead of from a pushed image.

It also removes the scanning in main, because if this is merged nothing that hasn't been scanned should get that far.