### PR TITLE
Add linters + pre-commit

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: build-oci
 
 on:
   push:

--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -13,19 +13,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  Lint:
-    runs-on: ubuntu-latest
-    env:
-      GOPATH: /home/runner/work/open-feature/flagd
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup go
-        uses: actions/setup-go@v1
-        with:
-          go-version: '^1.16.0'
-      - run: make generate
-      - run: make lint
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -7,12 +7,25 @@ on:
   pull_request:
     branches:
     - main
-   
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/work/open-feature/flagd
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '^1.16.0'
+      - run: make generate
+      - run: make lint
   docker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -1,0 +1,24 @@
+name: code-checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/work/open-feature/flagd
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '^1.16.0'
+      - run: make generate
+      - run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __debug_bin
 flagd
 .vscode
 dist/
+bin/
 
 # ignore generated code
 pkg/generated/*.gen.*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,51 @@
+run:
+  skip-dirs:
+    - (^|/)bin($|/)
+    - (^|/)examples($|/)
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - dupl
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - revive
+    - gosec
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - prealloc
+    - rowserrcheck
+    - exportloopref
+    - stylecheck
+    - unconvert
+    - unparam
+    - whitespace
+    - gofumpt
+linters-settings:
+  funlen:
+    statements: 50
+  golint:
+    min-confidence: 0.6
+issues:
+  exclude:
+    - pkg/generated
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - funlen
+        - maligned
+        - noctx
+        - scopelint
+        - bodyclose
+        - lll
+        - goconst
+        - gocognit
+        - gocyclo
+        - dupl
+        - staticcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/Bahjat/pre-commit-golang
+    rev: v1.0.1
+    hooks:
+      - id: gofumpt
+
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.46.2
+    hooks:
+      - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ uninstall:
 	systemctl stop flagd
 	rm /etc/systemd/system/flagd.service
 	rm -f $(DESTDIR)$(PREFIX)/bin/flagd
+lint:
+	mkdir -p ./bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest # Install linters
+	./bin/golangci-lint run --deadline=3m --timeout=3m ./... # Run linters

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,9 +11,10 @@ import (
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "flagd",
-	Short: "Flagd is a simple command line tool for fetching and presenting feature flags to services. It is designed to conform to Open Feature schema for flag definitions.",
-	Long:  ``,
+	Use: "flagd",
+	Short: "Flagd is a simple command line tool for fetching and presenting feature flags to services. " +
+		"It is designed to conform to Open Feature schema for flag definitions.",
+	Long: ``,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -36,7 +37,6 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.agent.yaml)")
-
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/eval/ievaluator.go
+++ b/pkg/eval/ievaluator.go
@@ -1,7 +1,8 @@
 package eval
 
 /*
-IEvaluator implementations store the state of the flags, do parsing and validation of the flag state and evaluate flags in response to handlers.
+IEvaluator implementations store the state of the flags,
+do parsing and validation of the flag state and evaluate flags in response to handlers.
 */
 type IEvaluator interface {
 	// TODO: add context param when rule evaluator is implemented

--- a/pkg/eval/json_evaluator.go
+++ b/pkg/eval/json_evaluator.go
@@ -14,11 +14,11 @@ import (
 //go:embed flagd-definitions.json
 var schema string
 
-type JsonEvaluator struct {
+type JSONEvaluator struct {
 	state Flags
 }
 
-func (je *JsonEvaluator) GetState () (string, error) {
+func (je *JSONEvaluator) GetState() (string, error) {
 	bytes, err := json.Marshal(&je.state)
 	if err != nil {
 		return "", err
@@ -26,58 +26,63 @@ func (je *JsonEvaluator) GetState () (string, error) {
 	return string(bytes), nil
 }
 
-func (je *JsonEvaluator) SetState (state string) error {
+func (je *JSONEvaluator) SetState(state string) error {
 	schemaLoader := gojsonschema.NewStringLoader(schema)
 	flagStringLoader := gojsonschema.NewStringLoader(state)
 	result, err := gojsonschema.Validate(schemaLoader, flagStringLoader)
 	if err != nil {
 		return err
 	} else if !result.Valid() {
-		err := errors.New("Invalid JSON file.")
+		err := errors.New("invalid JSON file")
 		log.Error(err)
 		return err
 	}
-	json.Unmarshal([]byte(state), &je.state)
+	_ = json.Unmarshal([]byte(state), &je.state)
 	return nil
 }
 
-func (je *JsonEvaluator) ResolveBooleanValue (flagKey string, defaultValue bool) (value bool, reason string, err error) {
-  variant := je.state.Flags[flagKey].DefaultVariant
-	val, ok := je.state.Flags[flagKey].Variants[variant].(bool);
-	if (!ok) {
+func (je *JSONEvaluator) ResolveBooleanValue(flagKey string, defaultValue bool) (value bool, reason string, err error) {
+	variant := je.state.Flags[flagKey].DefaultVariant
+	val, ok := je.state.Flags[flagKey].Variants[variant].(bool)
+	if !ok {
 		log.Errorf("Error converting %s to bool", flagKey)
 		return defaultValue, model.ErrorReason, errors.New(model.TypeMismatchErrorCode)
 	}
 	return val, model.StaticReason, nil
 }
 
-func (je *JsonEvaluator) ResolveStringValue (flagKey string, defaultValue string) (value string, reason string, err error) {
-  variant := je.state.Flags[flagKey].DefaultVariant
-	val, ok := je.state.Flags[flagKey].Variants[variant].(string);
-	if (!ok) {
+func (je *JSONEvaluator) ResolveStringValue(flagKey string, defaultValue string) (
+	govalue string, reason string, err error,
+) {
+	variant := je.state.Flags[flagKey].DefaultVariant
+	val, ok := je.state.Flags[flagKey].Variants[variant].(string)
+	if !ok {
 		log.Errorf("Error converting %s to string", flagKey)
 		return defaultValue, model.ErrorReason, errors.New(model.TypeMismatchErrorCode)
 	}
 	return val, model.StaticReason, nil
 }
 
-func (je *JsonEvaluator) ResolveNumberValue (flagKey string, defaultValue float32) (value float32, reason string, err error) {
-  variant := je.state.Flags[flagKey].DefaultVariant
-	val, ok := je.state.Flags[flagKey].Variants[variant].(float64);
-	if (!ok) {
+func (je *JSONEvaluator) ResolveNumberValue(flagKey string, defaultValue float32) (
+	value float32, reason string, err error,
+) {
+	variant := je.state.Flags[flagKey].DefaultVariant
+	val, ok := je.state.Flags[flagKey].Variants[variant].(float64)
+	if !ok {
 		log.Errorf("Error converting %s to float32", flagKey)
 		return defaultValue, model.ErrorReason, errors.New(model.TypeMismatchErrorCode)
 	}
 	return float32(val), model.StaticReason, nil
 }
 
-func (je *JsonEvaluator) ResolveObjectValue (flagKey string, defaultValue map[string]interface{}) (value map[string]interface{}, reason string, err error) {
-  variant := je.state.Flags[flagKey].DefaultVariant
-	val, ok := je.state.Flags[flagKey].Variants[variant].(map[string]interface{});
-	if (!ok) {
+func (je *JSONEvaluator) ResolveObjectValue(flagKey string, defaultValue map[string]interface{}) (
+	value map[string]interface{}, reason string, err error,
+) {
+	variant := je.state.Flags[flagKey].DefaultVariant
+	val, ok := je.state.Flags[flagKey].Variants[variant].(map[string]interface{})
+	if !ok {
 		log.Errorf(fmt.Sprintf("Error converting %s to object", flagKey))
 		return defaultValue, model.ErrorReason, errors.New(model.TypeMismatchErrorCode)
 	}
 	return val, model.StaticReason, nil
 }
-

--- a/pkg/eval/json_evaluator.model.go
+++ b/pkg/eval/json_evaluator.model.go
@@ -6,7 +6,7 @@ type Flags struct {
 
 // we could make this more type-safe with generics when we upgrade to 1.18.
 type Flag struct {
-	State string `json:"state"`
-	DefaultVariant string	`json:"defaultVariant"`
-	Variants map[string]interface{} `json:"variants"`
+	State          string                 `json:"state"`
+	DefaultVariant string                 `json:"defaultVariant"`
+	Variants       map[string]interface{} `json:"variants"`
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -21,13 +21,12 @@ func updateState(syncr sync.ISync) error {
 		return err
 	}
 	mu.Lock()
-	ev.SetState(msg)
+	_ = ev.SetState(msg)
 	mu.Unlock()
 	return nil
 }
 
-func Start(syncr sync.ISync, server service.IService, evaluator eval.IEvaluator, ctx context.Context) {
-
+func Start(ctx context.Context, syncr sync.ISync, server service.IService, evaluator eval.IEvaluator) {
 	ev = evaluator
 
 	if err := updateState(syncr); err != nil {
@@ -45,22 +44,22 @@ func Start(syncr sync.ISync, server service.IService, evaluator eval.IEvaluator,
 				return
 			case w := <-syncNotifier:
 				switch w.GetEvent().EventType {
-				case sync.E_EVENT_TYPE_CREATE:
+				case sync.EEventTypeCreate:
 					log.Info("New configuration created")
 					if err := updateState(syncr); err != nil {
 						log.Error(err)
 					}
-				case sync.E_EVENT_TYPE_MODIFY:
+				case sync.EEventTypeModify:
 					log.Info("Configuration modified")
 					if err := updateState(syncr); err != nil {
 						log.Error(err)
 					}
-				case sync.E_EVENT_TYPE_DELETE:
+				case sync.EEventTypeDelete:
 					log.Info("Configuration deleted")
 				}
 			}
 		}
 	}()
 
-	go server.Serve(ev, ctx)
+	go func() { _ = server.Serve(ctx, ev) }()
 }

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -12,12 +12,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type HttpServiceConfiguration struct {
+type HTTPServiceConfiguration struct {
 	Port int32
 }
 
-type HttpService struct {
-	HttpServiceConfiguration *HttpServiceConfiguration
+type HTTPService struct {
+	HTTPServiceConfiguration *HTTPServiceConfiguration
 }
 
 type Server struct {
@@ -26,74 +26,83 @@ type Server struct {
 
 // implement the generated ServerInterface.
 // TODO: might be able to simplify some of this with generics.
-// TODO: add improved, more RESTful error handling, we should inspect the returned ErrorCode and respond with a matching HTTP status code. 
-func (s Server) ResolveBoolean(w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveBooleanParams) {
+// TODO: add improved, more RESTful error handling, we should inspect
+// the returned ErrorCode and respond with a matching HTTP status code.
+func (s Server) ResolveBoolean(
+	w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveBooleanParams,
+) {
 	result, reason, err := s.eval.ResolveBooleanValue(flagKey, params.DefaultValue)
-	if (err != nil) {
-		message := err.Error();
+	if err != nil {
+		message := err.Error()
 		log.Error(message)
 		w.WriteHeader(500)
-		json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
+		_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
 			ErrorCode: &message,
-			Reason: &reason,
+			Reason:    &reason,
 		})
-		return;
+		return
 	}
-	json.NewEncoder(w).Encode(gen.ResolutionDetailsBoolean{
-		Value: result,
+	_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsBoolean{
+		Value:  result,
 		Reason: &reason,
 	})
 }
 
-func (s Server) ResolveString(w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveStringParams) {
+func (s Server) ResolveString(
+	w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveStringParams,
+) {
 	result, reason, err := s.eval.ResolveStringValue(flagKey, params.DefaultValue)
-	if (err != nil) {
-		message := err.Error();
+	if err != nil {
+		message := err.Error()
 		log.Error(message)
 		w.WriteHeader(500)
-		json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
+		_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
 			ErrorCode: &message,
-			Reason: &reason,
+			Reason:    &reason,
 		})
-		return;
+		return
 	}
-	json.NewEncoder(w).Encode(gen.ResolutionDetailsString{
-		Value: result,
+	_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsString{
+		Value:  result,
 		Reason: &reason,
 	})
 }
 
-func (s Server) ResolveNumber(w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveNumberParams) {
+func (s Server) ResolveNumber(
+	w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveNumberParams,
+) {
 	result, reason, err := s.eval.ResolveNumberValue(flagKey, params.DefaultValue)
-	if (err != nil) {
-		message := err.Error();
+	if err != nil {
+		message := err.Error()
 		log.Error(message)
 		w.WriteHeader(500)
-		json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
+		_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
 			ErrorCode: &message,
-			Reason: &reason,
+			Reason:    &reason,
 		})
-		return;
+		return
 	}
-	json.NewEncoder(w).Encode(gen.ResolutionDetailsNumber{
-		Value: result,
+	_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsNumber{
+		Value:  result,
 		Reason: &reason,
 	})
 }
 
-func (s Server) ResolveObject(w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveObjectParams) {
+func (s Server) ResolveObject(
+	w http.ResponseWriter, r *http.Request, flagKey gen.FlagKey, params gen.ResolveObjectParams,
+) {
 	result, reason, err := s.eval.ResolveObjectValue(flagKey, params.DefaultValue.AdditionalProperties)
-	if (err != nil) {
-		message := err.Error();
+	if err != nil {
+		message := err.Error()
 		log.Error(message)
 		w.WriteHeader(500)
-		json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
+		_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsWithError{
 			ErrorCode: &message,
-			Reason: &reason,
+			Reason:    &reason,
 		})
-		return;
+		return
 	}
-	json.NewEncoder(w).Encode(gen.ResolutionDetailsObject{
+	_ = json.NewEncoder(w).Encode(gen.ResolutionDetailsObject{
 		Value: gen.ResolutionDetailsObject_Value{
 			AdditionalProperties: result,
 		},
@@ -101,13 +110,13 @@ func (s Server) ResolveObject(w http.ResponseWriter, r *http.Request, flagKey ge
 	})
 }
 
-func (h *HttpService) Serve(eval eval.IEvaluator, ctx context.Context) error {
-	if h.HttpServiceConfiguration == nil {
+func (h *HTTPService) Serve(ctx context.Context, eval eval.IEvaluator) error {
+	if h.HTTPServiceConfiguration == nil {
 		return errors.New("http service configuration has not been initialised")
 	}
-	http.Handle("/", gen.Handler(Server{ eval }))
-	http.ListenAndServe(fmt.Sprintf(":%d", h.HttpServiceConfiguration.Port), nil)
+	http.Handle("/", gen.Handler(Server{eval}))
+	_ = http.ListenAndServe(fmt.Sprintf(":%d", h.HTTPServiceConfiguration.Port), nil)
 
-	<- ctx.Done()
+	<-ctx.Done()
 	return nil
 }

--- a/pkg/service/iservice.go
+++ b/pkg/service/iservice.go
@@ -6,12 +6,11 @@ import (
 	"github.com/open-feature/flagd/pkg/eval"
 )
 
-type IServiceConfiguration interface {
-}
+type IServiceConfiguration interface{}
 
 /*
 IService implementations define handlers for a particular transport, which call the IEvaluator implementation.
 */
 type IService interface {
-	Serve(eval eval.IEvaluator, ctx context.Context) error
+	Serve(ctx context.Context, eval eval.IEvaluator) error
 }

--- a/pkg/sync/filepath_sync.go
+++ b/pkg/sync/filepath_sync.go
@@ -43,21 +43,21 @@ func (fs *FilePathSync) Notify(w chan<- INotify) {
 					log.Info("Filepath notifier closed")
 					return
 				}
-				var evtType E_EVENT_TYPE
+				var evtType EEventType
 				switch event.Op {
 				case fsnotify.Create:
-					evtType = E_EVENT_TYPE_CREATE
+					evtType = EEventTypeCreate
 				case fsnotify.Write:
-					evtType = E_EVENT_TYPE_MODIFY
+					evtType = EEventTypeModify
 				case fsnotify.Remove:
 					// K8s exposes config maps as symlinks.
 					// Updates cause a remove event, we need to re-add the watcher in this case.
 					err = watcher.Add(fs.URI)
-					if (err != nil) {
-						log.Println("Error restoring watcher: %s", err.Error())
+					if err != nil {
+						log.Printf("Error restoring watcher: %s\n", err.Error())
 						log.Fatal(err)
 					}
-					evtType = E_EVENT_TYPE_DELETE
+					evtType = EEventTypeDelete
 				}
 				log.Infof("Filepath notifier event: %s %s", event.Name, event.Op.String())
 				w <- &Notifier{
@@ -76,7 +76,8 @@ func (fs *FilePathSync) Notify(w chan<- INotify) {
 	}()
 	err = watcher.Add(fs.URI)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 	<-done
 }

--- a/pkg/sync/inotify.go
+++ b/pkg/sync/inotify.go
@@ -4,16 +4,16 @@ type INotify interface {
 	GetEvent() Event
 }
 
-type E_EVENT_TYPE int32
+type EEventType int32
 
 const (
-	E_EVENT_TYPE_CREATE = iota
-	E_EVENT_TYPE_MODIFY = 1
-	E_EVENT_TYPE_DELETE = 2
+	EEventTypeCreate = iota
+	EEventTypeModify = 1
+	EEventTypeDelete = 2
 )
 
 type Event struct {
-	EventType E_EVENT_TYPE
+	EventType EEventType
 }
 
 type Notifier struct {

--- a/pkg/sync/isync.go
+++ b/pkg/sync/isync.go
@@ -1,7 +1,8 @@
 package sync
 
 /*
-ISync implementations watch for changes in the flag source (HTTP backend, local file, s3 bucket), and fetch the latest values.
+ISync implementations watch for changes in the flag source
+(HTTP backend, local file, s3 bucket), and fetch the latest values.
 */
 type ISync interface {
 	Fetch() (string, error)


### PR DESCRIPTION
This pull request adds the support of `golangci-lint` which is a pretty standard linter for golang.
It will help to have a uniform way of writing go code in the repository.

I have also fixed all the issue that were raised by the linters.
The only one I have ignore is the one related to the hashing solution because I guess you have used `sha1` for a reason.

`golangci-lint` will also be run with github action.

There is also a `pre-commit` configuration to be used with https://pre-commit.com/ that will run `golangci-lint` and `gofumpt` at each commit.
Note that you have to install the pre-commit hook with the command `pre-commit install` to have this feature.