### PR TITLE
go install linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __debug_bin
 flagd
 .vscode
 dist/
-bin/
 
 # ignore generated code
 pkg/generated/*.gen.*

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,5 @@ uninstall:
 	rm /etc/systemd/system/flagd.service
 	rm -f $(DESTDIR)$(PREFIX)/bin/flagd
 lint:
-	mkdir -p ./bin
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest # Install linters
-	./bin/golangci-lint run --deadline=3m --timeout=3m ./... # Run linters
+	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m ./... # Run linters


### PR DESCRIPTION
Just a small change here to install the linter bin via `go install` to the `GOPATH` instead of piping curl to the shell, which always makes me nervous.