### PR TITLE
JSON evaluator using generics

### DIFF
--- a/pkg/eval/ievaluator.go
+++ b/pkg/eval/ievaluator.go
@@ -21,5 +21,5 @@ type IEvaluator interface {
 		context *structpb.Struct) (value float32, variant string, reason string, err error)
 	ResolveObjectValue(
 		flagKey string,
-		context *structpb.Struct) (value map[string]interface{}, variant string, reasons string, err error)
+		context *structpb.Struct) (value map[string]any, variant string, reasons string, err error)
 }

--- a/pkg/eval/json_evaluator.go
+++ b/pkg/eval/json_evaluator.go
@@ -61,8 +61,8 @@ func resolve[T any](key string, context *structpb.Struct,
 	value T,
 	variant string,
 	reason string,
-	err error) {
-
+	err error,
+) {
 	variant, reason, err = variantEval(key, context)
 	if err != nil {
 		return value, variant, reason, err

--- a/pkg/eval/json_evaluator_model.go
+++ b/pkg/eval/json_evaluator_model.go
@@ -19,10 +19,9 @@ func (f Flags) Merge(ff Flags) Flags {
 	return result
 }
 
-// we could make this more type-safe with generics when we upgrade to 1.18.
 type Flag struct {
-	State          string                 `json:"state"`
-	DefaultVariant string                 `json:"defaultVariant"`
-	Variants       map[string]interface{} `json:"variants"`
-	Targeting      json.RawMessage        `json:"targeting"`
+	State          string          `json:"state"`
+	DefaultVariant string          `json:"defaultVariant"`
+	Variants       map[string]any  `json:"variants"`
+	Targeting      json.RawMessage `json:"targeting"`
 }

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/open-feature/flagd/pkg/eval"
@@ -46,7 +47,8 @@ func (s *HTTPService) Serve(ctx context.Context, eval eval.IEvaluator) error {
 	}
 
 	server := http.Server{
-		Handler: mux,
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", s.HTTPServiceConfiguration.Port))


### PR DESCRIPTION
- Replaced `interface{}` with `any` (go 1.18)
- Changed variable name (`bytes` -> `data`) due to lint warning about collision with imported package name
- Re-use the evaluate logic to reduce code duplication in resolveX functions

BTW, saw we are not handling errors "the go way" (defining hard coded strings instead of typed errors)
Didn't tackle it within this PR but would like to hear if there is any specific reason I'm missing of choosing this option.