### PR TITLE
refactor: Static reason type removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ curl -X POST "localhost:8013/flags/myBoolFlag/resolve/boolean"
 Result:
 
 ```sh
-{"value":true,"reason":"STATIC","variant":"on"}
+{"value":true,"reason":"DEFAULT","variant":"on"}
 ```
 
 <br />
@@ -58,7 +58,7 @@ curl -X POST "localhost:8013/flags/myStringFlag/resolve/string"
 Result:
 
 ```sh
-{"value":"val1","reason":"STATIC","variant":"key1"}
+{"value":"val1","reason":"DEFAULT","variant":"key1"}
 ```
 
 <br />
@@ -74,7 +74,7 @@ curl -X POST "localhost:8013/flags/myIntFlag/resolve/int"
 Result:
 
 ```sh
-{"value":"1","reason":"STATIC","variant":"one"}
+{"value":"1","reason":"DEFAULT","variant":"one"}
 ```
 
 [Why is this `int` response a `string`?](./docs/http_int_response.md)
@@ -92,7 +92,7 @@ curl -X POST "localhost:8013/flags/myFloatFlag/resolve/float"
 Result:
 
 ```sh
-{"value":1.23,"reason":"STATIC","variant":"one"}
+{"value":1.23,"reason":"DEFAULT","variant":"one"}
 ```
 
 <br />
@@ -108,7 +108,7 @@ curl -X POST "localhost:8013/flags/myObjectFlag/resolve/object"
 Result:
 
 ```sh
-{"value":{"key":"val"},"reason":"STATIC","variant":"object1"}
+{"value":{"key":"val"},"reason":"DEFAULT","variant":"object1"}
 ```
 
 <br />
@@ -173,7 +173,7 @@ This enables you to use an upgraded connection for the previous example requests
 
 ```
 curl -X POST "https://localhost:8013/flags/myBoolFlag/resolve/boolean"
-// {"value":true,"reason":"STATIC","variant":"on"}
+// {"value":true,"reason":"DEFAULT","variant":"on"}
 ```
 
 ## Multiple source example

--- a/docs/http_int_response.md
+++ b/docs/http_int_response.md
@@ -8,7 +8,7 @@ curl -X POST "localhost:8013/flags/myIntFlag/resolve/int"
 ```
 Result:
 ```sh
-{"value":"1","reason":"STATIC","variant":"one"}
+{"value":"1","reason":"DEFAULT","variant":"one"}
 ```
 When interacting directly with the flagD http(s) api and requesting an `int` the response type will be a `string`. This behaviour is introduced by [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway), which uses [proto3 json mapping](https://developers.google.com/protocol-buffers/docs/proto3#json) to build the response object. If a number value is required, and none of the provided SDK's can be used, then it is recommended to use the `float64` endpoint instead:  
 <br />
@@ -18,5 +18,5 @@ curl -X POST "localhost:8013/flags/myIntFlag/resolve/float"
 ```
 Result:
 ```sh
-{"value":1.23,"reason":"STATIC","variant":"one"}
+{"value":1.23,"reason":"DEFAULT","variant":"one"}
 ```

--- a/pkg/eval/fractional_evaluation_test.go
+++ b/pkg/eval/fractional_evaluation_test.go
@@ -202,7 +202,7 @@ func TestFractionalEvaluation(t *testing.T) {
 			context:         &structpb.Struct{},
 			expectedVariant: "red",
 			expectedValue:   "#FF0000",
-			expectedReason:  model.StaticReason,
+			expectedReason:  model.DefaultReason,
 		},
 		"fallback to default variant if invalid variant as result of fractional evaluation": {
 			flags: Flags{
@@ -236,7 +236,7 @@ func TestFractionalEvaluation(t *testing.T) {
 			}},
 			expectedVariant: "red",
 			expectedValue:   "#FF0000",
-			expectedReason:  model.StaticReason,
+			expectedReason:  model.DefaultReason,
 		},
 		"fallback to default variant if percentages don't sum to 100": {
 			flags: Flags{
@@ -274,7 +274,7 @@ func TestFractionalEvaluation(t *testing.T) {
 			}},
 			expectedVariant: "red",
 			expectedValue:   "#FF0000",
-			expectedReason:  model.StaticReason,
+			expectedReason:  model.DefaultReason,
 		},
 	}
 

--- a/pkg/eval/json_evaluator.go
+++ b/pkg/eval/json_evaluator.go
@@ -188,7 +188,7 @@ func (je *JSONEvaluator) evaluateVariant(
 	}
 
 	// if it's not a valid variant, use the default (static) value
-	return je.state.Flags[flagKey].DefaultVariant, model.StaticReason, nil
+	return je.state.Flags[flagKey].DefaultVariant, model.DefaultReason, nil
 }
 
 // validateDefaultVariants returns an error if any of the default variants aren't valid

--- a/pkg/eval/json_evaluator.go
+++ b/pkg/eval/json_evaluator.go
@@ -187,7 +187,7 @@ func (je *JSONEvaluator) evaluateVariant(
 		return variant, model.TargetingMatchReason, nil
 	}
 
-	// if it's not a valid variant, use the default (static) value
+	// if it's not a valid variant, use the default value
 	return je.state.Flags[flagKey].DefaultVariant, model.DefaultReason, nil
 }
 

--- a/pkg/eval/json_evaluator_test.go
+++ b/pkg/eval/json_evaluator_test.go
@@ -326,7 +326,7 @@ func TestResolveBooleanValue(t *testing.T) {
 		reason    string
 		errorCode string
 	}{
-		{StaticBoolFlag, nil, StaticBoolValue, model.StaticReason, ""},
+		{StaticBoolFlag, nil, StaticBoolValue, model.DefaultReason, ""},
 		{DynamicBoolFlag, map[string]interface{}{ColorProp: ColorValue}, StaticBoolValue, model.TargetingMatchReason, ""},
 		{StaticObjectFlag, nil, StaticBoolValue, model.ErrorReason, model.TypeMismatchErrorCode},
 		{MissingFlag, nil, StaticBoolValue, model.ErrorReason, model.FlagNotFoundErrorCode},
@@ -365,7 +365,7 @@ func TestResolveStringValue(t *testing.T) {
 		reason    string
 		errorCode string
 	}{
-		{StaticStringFlag, nil, StaticStringValue, model.StaticReason, ""},
+		{StaticStringFlag, nil, StaticStringValue, model.DefaultReason, ""},
 		{DynamicStringFlag, map[string]interface{}{ColorProp: ColorValue}, DynamicStringValue, model.TargetingMatchReason, ""},
 		{StaticObjectFlag, nil, "", model.ErrorReason, model.TypeMismatchErrorCode},
 		{MissingFlag, nil, "", model.ErrorReason, model.FlagNotFoundErrorCode},
@@ -405,7 +405,7 @@ func TestResolveFloatValue(t *testing.T) {
 		reason    string
 		errorCode string
 	}{
-		{StaticFloatFlag, nil, StaticFloatValue, model.StaticReason, ""},
+		{StaticFloatFlag, nil, StaticFloatValue, model.DefaultReason, ""},
 		{DynamicFloatFlag, map[string]interface{}{ColorProp: ColorValue}, DynamicFloatValue, model.TargetingMatchReason, ""},
 		{StaticObjectFlag, nil, 13, model.ErrorReason, model.TypeMismatchErrorCode},
 		{MissingFlag, nil, 13, model.ErrorReason, model.FlagNotFoundErrorCode},
@@ -445,7 +445,7 @@ func TestResolveIntValue(t *testing.T) {
 		reason    string
 		errorCode string
 	}{
-		{StaticIntFlag, nil, StaticIntValue, model.StaticReason, ""},
+		{StaticIntFlag, nil, StaticIntValue, model.DefaultReason, ""},
 		{DynamicIntFlag, map[string]interface{}{ColorProp: ColorValue}, DynamicIntValue, model.TargetingMatchReason, ""},
 		{StaticObjectFlag, nil, 13, model.ErrorReason, model.TypeMismatchErrorCode},
 		{MissingFlag, nil, 13, model.ErrorReason, model.FlagNotFoundErrorCode},
@@ -485,7 +485,7 @@ func TestResolveObjectValue(t *testing.T) {
 		reason    string
 		errorCode string
 	}{
-		{StaticObjectFlag, nil, StaticObjectValue, model.StaticReason, ""},
+		{StaticObjectFlag, nil, StaticObjectValue, model.DefaultReason, ""},
 		{DynamicObjectFlag, map[string]interface{}{ColorProp: ColorValue}, DynamicObjectValue, model.TargetingMatchReason, ""},
 		{StaticBoolFlag, nil, "{}", model.ErrorReason, model.TypeMismatchErrorCode},
 		{MissingFlag, nil, "{}", model.ErrorReason, model.FlagNotFoundErrorCode},

--- a/pkg/model/reason.go
+++ b/pkg/model/reason.go
@@ -5,7 +5,6 @@ const (
 	SplitReason          = "SPLIT"
 	DisabledReason       = "DISABLED"
 	DefaultReason        = "DEFAULT"
-	StaticReason         = "STATIC"
 	UnknownReason        = "UNKNOWN"
 	ErrorReason          = "ERROR"
 )

--- a/pkg/service/grpc_service_test.go
+++ b/pkg/service/grpc_service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/open-feature/flagd/pkg/model"
 	service "github.com/open-feature/flagd/pkg/service"
 	log "github.com/sirupsen/logrus"
 	gen "go.buf.build/open-feature/flagd-server/open-feature/flagd/schema/v1"
@@ -56,7 +57,7 @@ func TestGRPCService_UnixConnection(t *testing.T) {
 			evalFields: evalFields{
 				result:  true,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			req: &gen.ResolveBooleanRequest{
@@ -65,7 +66,7 @@ func TestGRPCService_UnixConnection(t *testing.T) {
 			},
 			want: &gen.ResolveBooleanResponse{
 				Value:   true,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -130,7 +131,7 @@ func TestGRPCService_ResolveBoolean(t *testing.T) {
 			evalFields: resolveBooleanEvalFields{
 				result:  true,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveBooleanFunctionArgs{
@@ -142,7 +143,7 @@ func TestGRPCService_ResolveBoolean(t *testing.T) {
 			},
 			want: &gen.ResolveBooleanResponse{
 				Value:   true,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -197,7 +198,7 @@ func BenchmarkGRPCService_ResolveBoolean(b *testing.B) {
 			evalFields: resolveBooleanEvalFields{
 				result:  true,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveBooleanFunctionArgs{
@@ -209,7 +210,7 @@ func BenchmarkGRPCService_ResolveBoolean(b *testing.B) {
 			},
 			want: &gen.ResolveBooleanResponse{
 				Value:   true,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -283,7 +284,7 @@ func TestGRPCService_ResolveString(t *testing.T) {
 			evalFields: resolveStringEvalFields{
 				result:  "true",
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveStringFunctionArgs{
@@ -295,7 +296,7 @@ func TestGRPCService_ResolveString(t *testing.T) {
 			},
 			want: &gen.ResolveStringResponse{
 				Value:   "true",
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -350,7 +351,7 @@ func BenchmarkGRPCService_ResolveString(b *testing.B) {
 			evalFields: resolveStringEvalFields{
 				result:  "true",
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveStringFunctionArgs{
@@ -362,7 +363,7 @@ func BenchmarkGRPCService_ResolveString(b *testing.B) {
 			},
 			want: &gen.ResolveStringResponse{
 				Value:   "true",
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -436,7 +437,7 @@ func TestGRPCService_ResolveFloat(t *testing.T) {
 			evalFields: resolveFloatEvalFields{
 				result:  12,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveFloatFunctionArgs{
@@ -448,7 +449,7 @@ func TestGRPCService_ResolveFloat(t *testing.T) {
 			},
 			want: &gen.ResolveFloatResponse{
 				Value:   12,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -503,7 +504,7 @@ func BenchmarkGRPCService_ResolveFloat(b *testing.B) {
 			evalFields: resolveFloatEvalFields{
 				result:  12,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveFloatFunctionArgs{
@@ -515,7 +516,7 @@ func BenchmarkGRPCService_ResolveFloat(b *testing.B) {
 			},
 			want: &gen.ResolveFloatResponse{
 				Value:   12,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -589,7 +590,7 @@ func TestGRPCService_ResolveInt(t *testing.T) {
 			evalFields: resolveIntEvalFields{
 				result:  12,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveIntFunctionArgs{
@@ -601,7 +602,7 @@ func TestGRPCService_ResolveInt(t *testing.T) {
 			},
 			want: &gen.ResolveIntResponse{
 				Value:   12,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -656,7 +657,7 @@ func BenchmarkGRPCService_ResolveInt(b *testing.B) {
 			evalFields: resolveIntEvalFields{
 				result:  12,
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveIntFunctionArgs{
@@ -668,7 +669,7 @@ func BenchmarkGRPCService_ResolveInt(b *testing.B) {
 			},
 			want: &gen.ResolveIntResponse{
 				Value:   12,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -744,7 +745,7 @@ func TestGRPCService_ResolveObject(t *testing.T) {
 					"food": "bars",
 				},
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveObjectFunctionArgs{
@@ -756,7 +757,7 @@ func TestGRPCService_ResolveObject(t *testing.T) {
 			},
 			want: &gen.ResolveObjectResponse{
 				Value:   nil,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,
@@ -823,7 +824,7 @@ func BenchmarkGRPCService_ResolveObject(b *testing.B) {
 					"food": "bars",
 				},
 				variant: "on",
-				reason:  "STATIC",
+				reason:  model.DefaultReason,
 				err:     nil,
 			},
 			functionArgs: resolveObjectFunctionArgs{
@@ -835,7 +836,7 @@ func BenchmarkGRPCService_ResolveObject(b *testing.B) {
 			},
 			want: &gen.ResolveObjectResponse{
 				Value:   nil,
-				Reason:  "STATIC",
+				Reason:  model.DefaultReason,
 				Variant: "on",
 			},
 			wantErr: nil,


### PR DESCRIPTION

Todd: This particular "reason" never made it into the spec, and only the node sdk implements it. I think it's value is minimal. I struggle a bit to find a good differentiation between DEFAULT and STATIC .

I propose removing this and replacing all instances of it with DEFAULT. If you guys think there's significant value in it though, we can make a spec change... I just think the ROI is low at this point.