### PR TITLE
Draft: fix for reflector warning temporarily

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/open-feature/flagd
 
 go 1.18
 
+replace k8s.io/client-go@v0.25.2 => k8s.io/client-go v0.0.0-20221010195331-f515a4cb9fa9
+
 require (
 	github.com/bufbuild/connect-go v0.5.0
 	github.com/deepmap/oapi-codegen v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/bufbuild/connect-go v0.5.0 h1:JFbWPWpasBqzM5h/awoRhAXmLERZQlQ5xTn42uf
 github.com/bufbuild/connect-go v0.5.0/go.mod h1:ZEtBnQ7J/m7bvWOW+H8T/+hKQCzPVfhhhICuvtcnjlI=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/pkg/sync/kubernetes/featureflagconfiguration/clientset.go
+++ b/pkg/sync/kubernetes/featureflagconfiguration/clientset.go
@@ -43,6 +43,7 @@ func createFuncHandler(obj interface{}, object client.ObjectKey, c chan<- sync.I
 }
 
 func updateFuncHandler(oldObj interface{}, newObj interface{}, object client.ObjectKey, c chan<- sync.INotify) error {
+
 	if reflect.TypeOf(oldObj) != reflect.TypeOf(&ffv1alpha1.FeatureFlagConfiguration{}) {
 		return errors.New("old object is not a FeatureFlagConfiguration")
 	}


### PR DESCRIPTION
Fixes
```
W1011 10:26:43.711946   26126 reflector.go:347] pkg/mod/k8s.io/client-go@v0.25.2/tools/cache/reflector.go:169: watch of *v1alpha1.FeatureFlagConfiguration ended with: an error on the server ("unable to decode an event from the watch stream: unable to decode watch event: no kind \"FeatureFlagConfiguration\" is registered for the internal version of group \"core.openfeature.dev\" in scheme \"pkg/runtime/scheme.go:100\"") has prevented the request from succeeding
{"component":"runtime","level":"info","msg":"configuration change: update hex-color end-to-end","time":"2022-10-11T10:26:45+01:00"}
```

I wouldn't describe this as a long term solution but it works for now 