### PR TITLE
fix: omitempty targeting field in Flag structure

### DIFF
--- a/pkg/eval/json_evaluator_model.go
+++ b/pkg/eval/json_evaluator_model.go
@@ -68,6 +68,6 @@ type Flag struct {
 	State          string          `json:"state"`
 	DefaultVariant string          `json:"defaultVariant"`
 	Variants       map[string]any  `json:"variants"`
-	Targeting      json.RawMessage `json:"targeting"`
+	Targeting      json.RawMessage `json:"targeting,omitempty"`
 	Source         string          `json:"source"`
 }


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Added omitempty to the json tags of the `targeting` field in the `Flag` structure.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #246 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

