### PR TITLE
chore: add sbom generation for releases

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,9 +55,11 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Build
         uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
@@ -75,6 +77,11 @@ jobs:
             COMMIT=${{ github.sha }}
             DATE=${{ steps.date.outputs.date }}
 
+      - name: SBOM for latest image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
+          artifact-name: ${{ format('{0}-{1}-sbom.spdx',env.IMAGE_NAME, needs.release-please.outputs.release_tag_name) }}
   go-release:
     needs: release-please
     runs-on: ubuntu-latest
@@ -89,6 +96,9 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
           go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+      - name: Set up syft
+        uses: anchore/sbom-action/download-syft@v0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,12 +14,11 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}
+# Generate SBOM per each archive
+sboms:
+  - artifacts: archive
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## This PR

Fixes #329 

Adding SBOM generation through go releaser. SBOM is generated per archive (see image for reference).

Along with the PR, changing deprecated archive naming [1]

<img width="311" alt="image" src="https://user-images.githubusercontent.com/8186721/215213330-42191446-f72f-41ff-a202-03155203149d.png">

## How to test 

Install goreleaser [2] and run following command tog get artefacts & sbom generates in local dist folder 

`goreleaser release --skip-publish --skip-validate  --rm-dist`


[1] - https://goreleaser.com/deprecations/#archivesreplacements
[2] - https://goreleaser.com/install/ 