### PR TITLE
feat: flagd image signing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -77,6 +77,18 @@ jobs:
             COMMIT=${{ github.sha }}
             DATE=${{ steps.date.outputs.date }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: "v2.8.1"
+
+      - name: Sign image with a key
+        run: |
+          cosign sign --key env://COSIGN_PRIVATE_KEY  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
+        env:
+          COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+          COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
       - name: SBOM for latest image
         uses: anchore/sbom-action@06e109483e6aa305a2b2395eabae554e51530e1d # v0
         with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,6 +7,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   DEFAULT_GO_VERSION: 1.19.3
+  PUBLIC_KEY_FILE: publicKey.pub
 
 name: Run Release Please
 jobs:
@@ -79,15 +80,19 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: "v2.8.1"
 
-      - name: Sign image with a key
+      - name: Sign the image
         run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
+          cosign sign --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
+          cosign public-key --key env://COSIGN_PRIVATE_KEY --outfile ${{ env.PUBLIC_KEY_FILE }}
         env:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+
+      - name: Bundle release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.PUBLIC_KEY_FILE }}
 
       - name: SBOM for latest image
         uses: anchore/sbom-action@06e109483e6aa305a2b2395eabae554e51530e1d # v0


### PR DESCRIPTION
## This PR

fixes #328

Introduce image signing for flagd. Signature is pushed to OCR repository and public key will get added to release artefacts under the name `publicKey.pub` (referred through variable PUBLIC_KEY_FILE in GH action)

**NOTE** - Require COSIGN_PRIVATE_KEY & COSIGN_PASSWORD secrets to be created. And decide how to expose public key 

