### PR TITLE
fix: send datasync on remove fs events

### DIFF
--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -61,6 +61,8 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 			case fsnotify.Create, fsnotify.Write:
 				fs.sendDataSync(ctx, event, dataSync)
 			case fsnotify.Remove:
+				// Counterintuively, remove events are the only meanful ones seen in K8s.
+				// At the point the remove event is fired, we have our new data, so we can send it down the channel.
 				fs.sendDataSync(ctx, event, dataSync)
 
 				// K8s exposes config maps as symlinks.


### PR DESCRIPTION
Looks like during a refactor, we accidentally removed the "meat" of the remove handler.

In K8S, we never get write events, just remove. It's necessary to send the data for these as well.

Also extracted some duplicated code into a func.