### PR TITLE
ci: set homebrew download URL

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -107,6 +107,7 @@ jobs:
         with:
           formula-name: flagd
           tag-name: ${{ needs.release-please.outputs.release_tag_name }}
+          download-url: https://github.com/${{ github.repository }}.git
           commit-message: |
             {{formulaName}} {{version}}
 


### PR DESCRIPTION
## This PR

- Adds a `download-url` to the Homebrew release action

### Related Issues

Fixes #345 

### Notes

The bump homebrew formula action takes an optional download url. By setting this value to a git-based URL, the action should update the tag and reversion.

https://github.com/mislav/bump-homebrew-formula-action#how-it-works

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>

