### PR TITLE
fix: use event.Has func for file change notification handling (increased stability across OS)

### DIFF
--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -57,10 +57,9 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 
 			fs.Logger.Info(fmt.Sprintf("filepath event: %s %s", event.Name, event.Op.String()))
 
-			switch event.Op {
-			case fsnotify.Create, fsnotify.Write:
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 				fs.sendDataSync(ctx, event, dataSync)
-			case fsnotify.Remove:
+			} else if event.Has(fsnotify.Remove) {
 				// Counterintuively, remove events are the only meanful ones seen in K8s.
 				// At the point the remove event is fired, we have our new data, so we can send it down the channel.
 				fs.sendDataSync(ctx, event, dataSync)

--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -57,6 +57,8 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 
 			fs.Logger.Info(fmt.Sprintf("filepath event: %s %s", event.Name, event.Op.String()))
 
+                        // event.Op is bitmask and some systems may send multiple operations at once
+                        // event.Has(...) checks that the bitmask contains the particular event (among others)
 			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 				fs.sendDataSync(ctx, event, dataSync)
 			} else if event.Has(fsnotify.Remove) {

--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -57,7 +57,7 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 
 			fs.Logger.Info(fmt.Sprintf("filepath event: %s %s", event.Name, event.Op.String()))
 
-                        // event.Op is bitmask and some systems may send multiple operations at once
+                        // event.Op is a bitmask and some systems may send multiple operations at once
                         // event.Has(...) checks that the bitmask contains the particular event (among others)
 			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 				fs.sendDataSync(ctx, event, dataSync)

--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -61,6 +61,7 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 				fs.sendDataSync(ctx, event, dataSync)
 			} else if event.Has(fsnotify.Remove) {
 				// Counterintuively, remove events are the only meanful ones seen in K8s.
+				// K8s handles mounted ConfigMap updates by modifying symbolic links, which is an atomic operation.
 				// At the point the remove event is fired, we have our new data, so we can send it down the channel.
 				fs.sendDataSync(ctx, event, dataSync)
 

--- a/pkg/sync/file/filepath_sync.go
+++ b/pkg/sync/file/filepath_sync.go
@@ -57,8 +57,8 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 
 			fs.Logger.Info(fmt.Sprintf("filepath event: %s %s", event.Name, event.Op.String()))
 
-                        // event.Op is a bitmask and some systems may send multiple operations at once
-                        // event.Has(...) checks that the bitmask contains the particular event (among others)
+			// event.Op is a bitmask and some systems may send multiple operations at once
+			// event.Has(...) checks that the bitmask contains the particular event (among others)
 			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 				fs.sendDataSync(ctx, event, dataSync)
 			} else if event.Has(fsnotify.Remove) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Uses event.Has func for file change notification handling (instead of direct comparison). This is the correct approach as [expressed directly in fsnotify's code](https://github.com/fsnotify/fsnotify/blob/main/fsnotify.go#L39).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #313 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

