### PR TITLE
fix: set ResolveObject reason

### DIFF
--- a/pkg/service/connect_service.go
+++ b/pkg/service/connect_service.go
@@ -405,6 +405,7 @@ func (s *ConnectService) ResolveObject(
 		variant,
 		reason,
 	))
+	res.Msg.Reason = reason
 	res.Msg.Value = val
 	res.Msg.Variant = variant
 	return res, nil


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Reinstate setting of ResolveObject's reason

Discovered as [integration tests PR](https://github.com/open-feature/flagd/pull/312) started failing. In future this kind of thing will be picked up as a pipeline failure (all the more reason to get to the bottom of the snyk security issue).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

