### PR TITLE
chore: add @kavindu-dodan to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @AlexsJones @james-milligan @toddbaert
+* @AlexsJones @james-milligan @toddbaert @kavindu-dodan


### PR DESCRIPTION
@Kavindu-Dodan has contributed multiple significant changes and proposals to flagd:

- multiple refactors: https://github.com/open-feature/flagd/pull/291, https://github.com/open-feature/flagd/pull/307
- ci/security improvements: https://github.com/open-feature/flagd/pull/338, https://github.com/open-feature/flagd/pull/337
- architectural proposals (some of which got some attention from outside parties!): https://github.com/open-feature/ofep/pull/45, https://github.com/open-feature/schemas/pull/78, https://github.com/open-feature/flagd/issues/249#issuecomment-1413590567
- load testing: https://github.com/open-feature/flagd/pull/225
- documentation improvements

For these reasons, I believe he should be made a CODEOWNER in this repository.

NOTE: before this is merged, @Kavindu-Dodan should be added with at least `maintainer` permissions to the repo.