### PR TITLE
fix: error handling of Serve/ServeTLS funcs

### DIFF
--- a/pkg/service/connect_service.go
+++ b/pkg/service/connect_service.go
@@ -78,11 +78,13 @@ func (s *ConnectService) Serve(ctx context.Context, eval eval.IEvaluator) error 
 		}
 		close(errChan)
 	}()
-	<-ctx.Done()
-	if err := s.server.Shutdown(ctx); err != nil {
+
+	select {
+	case err := <-errChan:
 		return err
+	case <-ctx.Done():
+		return s.server.Shutdown(ctx)
 	}
-	return <-errChan
 }
 
 func (s *ConnectService) setupServer() (net.Listener, error) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes error handling of Serve/ServeTLS being deferred until flagd shutdown.
If an error occurred from one of these functions, it'd be ignored until shutdown.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

