### PR TITLE
fix: fix race in http sync test

### DIFF
--- a/pkg/sync/http/http_sync.go
+++ b/pkg/sync/http/http_sync.go
@@ -44,8 +44,6 @@ func (hs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 		return err
 	}
 
-	dataSync <- sync.DataSync{FlagData: fetch, Source: hs.URI, Type: sync.ALL}
-
 	_ = hs.Cron.AddFunc("*/5 * * * *", func() {
 		body, err := hs.fetchBodyFromURL(ctx, hs.URI)
 		if err != nil {
@@ -82,6 +80,9 @@ func (hs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 	})
 
 	hs.Cron.Start()
+
+	dataSync <- sync.DataSync{FlagData: fetch, Source: hs.URI, Type: sync.ALL}
+
 	<-ctx.Done()
 	hs.Cron.Stop()
 


### PR DESCRIPTION
In the `TestSimpleSync` test we are asserting that `hs.Cron.AddFunc` and `hs.Cron.Start` are called by the time the `dataSync` is sent. This is a race, because these methods are actually called after the first send. I get failures here ~25% of the time (seems like @skyerus does too).

This changes things to add the handler and start the cron _before_ the first send, which makes things deterministic.