### PR TITLE
chore: attach image sbom to release artefacts

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -89,17 +89,24 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
 
-      - name: Bundle release assets
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          tag_name: ${{ needs.release-please.outputs.release_tag_name }}
-          files: ${{ env.PUBLIC_KEY_FILE }}
+      - name: Generate image SBOM file name
+        id: image-sbom-file-gen
+        run: echo "IMG_SBOM_FILE=${{ format('flagd-{0}-sbom.spdx', needs.release-please.outputs.release_tag_name) }}" >> $GITHUB_OUTPUT
 
       - name: SBOM for latest image
         uses: anchore/sbom-action@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
-          artifact-name: ${{ format('flagd-{0}-sbom.spdx', needs.release-please.outputs.release_tag_name) }}
+          artifact-name: ${{ steps.image-sbom-file-gen.outputs.IMG_SBOM_FILE }}
+
+      - name: Bundle release assets
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          tag_name: ${{ needs.release-please.outputs.release_tag_name }}
+          files: |
+            ${{ env.PUBLIC_KEY_FILE }}
+            ${{ steps.image-sbom-file-gen.outputs.IMG_SBOM_FILE }}
+
   go-release:
     needs: release-please
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attach release image sbom to release artefacts. Right now, sbom is generated and stored with release action 