### PR TITLE
feat: Add version to startup message

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -92,6 +93,8 @@ var startCmd = &cobra.Command{
 		}
 		logger := logger.NewLogger(l, Debug)
 		rtLogger := logger.WithFields(zap.String("component", "start"))
+
+		rtLogger.Info(fmt.Sprintf("flagd version: %s (%s), built at: %s", Version, Commit, Date))
 
 		if viper.GetString(syncProviderFlagName) != "" {
 			rtLogger.Warn("DEPRECATED: The --sync-provider flag has been deprecated. " +


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds version to flagd startup message
### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #428

### Notes
Running flagd from main branch:
... 

2023-02-23T17:44:37.503-0300    info    file/filepath_sync.go:32        Starting filepath sync notifier {"component": "sync", "sync": "filepath"}
2023-02-23T17:44:37.503-0300    info    service/connect_service.go:110  metrics listening at 8014       {"component": "service"}
...

Running flagd from this PR branch:
... 

2023-02-23T17:47:26.504-0300    info    cmd/start.go:97 flagd version: dev (15ef000), built at: 2023-02-23T17:47:20Z   {"component": "start"}
2023-02-23T17:47:26.504-0300    info    file/filepath_sync.go:32        Starting filepath sync notifier {"component": "sync", "sync": "filepath"}
...