### PR TITLE
docs: Remove Snap badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
   <a href="https://goreportcard.com/report/github.com/open-feature/flagd">
     <img src="https://goreportcard.com/badge/github.com/open-feature/flagd">
   </a>
-  <a href="https://snapcraft.io/flagd">
-  <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" width=100px;/>
 </a>
 </p>
 

--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -21,10 +21,6 @@ There are many ways to get started with flagd. Choose the method that best serve
 
 1. Download pre-built binaries from https://github.com/open-feature/flagd/releases
 
-### Snapcraft
-
-Install via Snapcraft, documentation can be found here: https://snapcraft.io/flagd
-
 ### Systemd service
 
 Documentation for installing flagd as a systemd service can be found [here](../other_resources/systemd_service.md)


### PR DESCRIPTION
## This PR

- remove snap from the docs

### Related Issues

Fixes #489 

### Notes

I left the Snap configuration and Release Please configuration. That should make it easy to readd when the release process is automated.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>
