### PR TITLE
chore: enable brew formula version bump

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -213,22 +213,20 @@ jobs:
           files: |
             ./sbom.xml
             ./*.tar.gz
-  # TODO: Update the Homebrew build process
-  # https://github.com/Homebrew/homebrew-core/blob/master/Formula/flagd.rb
-  # homebrew:
-  #   name: Bump homebrew-core formula
-  #   needs: release-please
-  #   runs-on: ubuntu-latest
-  #   # Only run on non-forked flagd releases
-  #   if: ${{ github.repository_owner == 'openfeature' && needs.release-please.outputs.flagd_tag_name }}
-  #   steps:
-  #     - uses: mislav/bump-homebrew-formula-action@v2
-  #       with:
-  #         formula-name: flagd
-  #         tag-name: ${{ needs.release-please.outputs.flagd_tag_name }}
-  #         download-url: https://github.com/${{ github.repository }}.git
-  #         commit-message: |
-  #           {{formulaName}} {{version}}
-  #           Created by https://github.com/mislav/bump-homebrew-formula-action
-  #       env:
-  #         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+  homebrew:
+   name: Bump homebrew-core formula
+   needs: release-please
+   runs-on: ubuntu-latest
+   # Only run on non-forked flagd releases
+   if: ${{ github.repository_owner == 'openfeature' && needs.release-please.outputs.flagd_tag_name }}
+   steps:
+     - uses: mislav/bump-homebrew-formula-action@v2
+       with:
+         formula-name: flagd
+         tag-name: ${{ needs.release-please.outputs.flagd_tag_name }}
+         download-url: https://github.com/${{ github.repository }}.git
+         commit-message: |
+           {{formulaName}} {{version}}
+           Created by https://github.com/mislav/bump-homebrew-formula-action
+       env:
+         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## This PR

Re-enable the brew formula version bump. No changes are needed as we have all the necessary outputs, unchanged from the refactoring efforts. 