### PR TITLE
docs: ensure proper rendering with docusaurus

### DIFF
--- a/docs/other_resources/high_level_architecture.md
+++ b/docs/other_resources/high_level_architecture.md
@@ -17,7 +17,7 @@ It also performs the feature flag evaluations based on evaluation requests comin
 
 The Runtime stays in between these components and coordinates operations.
 
-<img src="../images/of-flagd-0.png" width="560">
+<img src="../images/of-flagd-0.png" width="560" />
 
 ## Sync component
 
@@ -31,7 +31,7 @@ The update provided by sync implementation is pushed to the evaluator engine, wh
 Change notifications generated in the
 process gets pushed to event subscribers.
 
-<img src="../images/of-flagd-1.png" width="560">
+<img src="../images/of-flagd-1.png" width="560" />
 
 ## Readiness & Liveness probes
 


### PR DESCRIPTION
I am not sure why, but docusaurus does not like unclosed `<img>` tags. It will render an error, and the page can not be rendered.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

