### PR TITLE
docs: update go binary install instructions

### DIFF
--- a/docs/usage/getting_started.md
+++ b/docs/usage/getting_started.md
@@ -15,8 +15,8 @@ Choose the method that best serves your requirements to get started.
 
 ### Go binary
 
-1. Install Go 1.18 or above
-1. run `go install github.com/open-feature/flagd@latest`
+1. Install Go 1.19 or above
+1. run `go install github.com/open-feature/flagd/flagd@latest`
 
 ### Release binary
 


### PR DESCRIPTION
## This PR

- bump minimum go version to 1.19 in the binary install instructions
- update the URL in the binary install instructions

