### PR TITLE
fix: fixing silent lint failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/flagd
 lint:
 	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m $(module)/...;)
+	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m $(module)/... || exit;)
 install-mockgen:
 	go install github.com/golang/mock/mockgen@v1.6.0
 mockgen: install-mockgen

--- a/core/pkg/eval/json_evaluator.go
+++ b/core/pkg/eval/json_evaluator.go
@@ -292,11 +292,8 @@ func (je *JSONEvaluator) configToFlags(config string, newFlags *Flags) error {
 	if err != nil {
 		return fmt.Errorf("unmarshalling provided configurations: %w", err)
 	}
-	if err := validateDefaultVariants(newFlags); err != nil {
-		return err
-	}
 
-	return nil
+	return validateDefaultVariants(newFlags)
 }
 
 // validateDefaultVariants returns an error if any of the default variants aren't valid

--- a/core/pkg/runtime/runtime.go
+++ b/core/pkg/runtime/runtime.go
@@ -98,10 +98,7 @@ func (r *Runtime) Start() error {
 		})
 	})
 	<-gCtx.Done()
-	if err := g.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return g.Wait()
 }
 
 func (r *Runtime) isReady() bool {

--- a/core/pkg/service/flag-evaluation/connect_service.go
+++ b/core/pkg/service/flag-evaluation/connect_service.go
@@ -101,7 +101,7 @@ func (s *ConnectService) setupServer(svcConf service.Configuration) (net.Listene
 	path, handler := schemaConnectV1.NewServiceHandler(fes)
 	mux.Handle(path, handler)
 
-	mdlw := middleware.NewHttpMetric(middleware.Config{
+	mdlw := middleware.NewHTTPMetric(middleware.Config{
 		Service:        "openfeature/flagd",
 		MetricRecorder: s.Metrics,
 		Logger:         s.Logger,

--- a/core/pkg/service/flag-evaluation/flag_evaluator.go
+++ b/core/pkg/service/flag-evaluation/flag_evaluator.go
@@ -30,7 +30,9 @@ type eventingConfiguration struct {
 	subs map[interface{}]chan service.Notification
 }
 
-func NewFlagEvaluationService(log *logger.Logger, eval eval.IEvaluator, metricsRecorder *otel.MetricsRecorder) *FlagEvaluationService {
+func NewFlagEvaluationService(log *logger.Logger,
+	eval eval.IEvaluator, metricsRecorder *otel.MetricsRecorder,
+) *FlagEvaluationService {
 	return &FlagEvaluationService{
 		logger:  log,
 		eval:    eval,
@@ -43,7 +45,7 @@ func NewFlagEvaluationService(log *logger.Logger, eval eval.IEvaluator, metricsR
 }
 
 func (s *FlagEvaluationService) ResolveAll(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveAllRequest],
 ) (*connect.Response[schemaV1.ResolveAllResponse], error) {
 	reqID := xid.New().String()
@@ -173,7 +175,7 @@ func resolve[T constraints](
 }
 
 func (s *FlagEvaluationService) ResolveBoolean(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveBooleanRequest],
 ) (*connect.Response[schemaV1.ResolveBooleanResponse], error) {
 	res := connect.NewResponse(&schemaV1.ResolveBooleanResponse{})
@@ -185,7 +187,7 @@ func (s *FlagEvaluationService) ResolveBoolean(
 }
 
 func (s *FlagEvaluationService) ResolveString(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveStringRequest],
 ) (*connect.Response[schemaV1.ResolveStringResponse], error) {
 	res := connect.NewResponse(&schemaV1.ResolveStringResponse{})
@@ -197,7 +199,7 @@ func (s *FlagEvaluationService) ResolveString(
 }
 
 func (s *FlagEvaluationService) ResolveInt(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveIntRequest],
 ) (*connect.Response[schemaV1.ResolveIntResponse], error) {
 	res := connect.NewResponse(&schemaV1.ResolveIntResponse{})
@@ -209,7 +211,7 @@ func (s *FlagEvaluationService) ResolveInt(
 }
 
 func (s *FlagEvaluationService) ResolveFloat(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveFloatRequest],
 ) (*connect.Response[schemaV1.ResolveFloatResponse], error) {
 	res := connect.NewResponse(&schemaV1.ResolveFloatResponse{})
@@ -221,7 +223,7 @@ func (s *FlagEvaluationService) ResolveFloat(
 }
 
 func (s *FlagEvaluationService) ResolveObject(
-	ctx context.Context,
+	_ context.Context,
 	req *connect.Request[schemaV1.ResolveObjectRequest],
 ) (*connect.Response[schemaV1.ResolveObjectResponse], error) {
 	res := connect.NewResponse(&schemaV1.ResolveObjectResponse{})

--- a/core/pkg/service/middleware/http_metrics.go
+++ b/core/pkg/service/middleware/http_metrics.go
@@ -27,7 +27,7 @@ type Middleware struct {
 	cfg Config
 }
 
-func NewHttpMetric(cfg Config) Middleware {
+func NewHTTPMetric(cfg Config) Middleware {
 	cfg.defaults()
 	m := Middleware{
 		cfg: cfg,

--- a/core/pkg/service/middleware/http_metrics_test.go
+++ b/core/pkg/service/middleware/http_metrics_test.go
@@ -18,7 +18,7 @@ func TestMiddlewareExposesMetrics(t *testing.T) {
 	const svcName = "mySvc"
 	exp := metric.NewManualReader()
 	l, _ := logger.NewZapLogger(zapcore.DebugLevel, "")
-	m := NewHttpMetric(Config{
+	m := NewHTTPMetric(Config{
 		MetricRecorder: otel.NewOTelRecorder(exp, svcName),
 		Service:        svcName,
 		Logger:         logger.NewLogger(l, true),
@@ -128,7 +128,7 @@ func TestMeasure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// test the middleware correctly
 			rep := tt.rep
-			m := NewHttpMetric(Config{
+			m := NewHTTPMetric(Config{
 				MetricRecorder:     otel.NewOTelRecorder(exp, tt.name),
 				Service:            tt.name,
 				Logger:             logger.NewLogger(l, true),
@@ -196,7 +196,7 @@ func TestNewHttpMetric(t *testing.T) {
 	const groupedStatus = false
 	const disableMeasureSize = false
 
-	mdw := NewHttpMetric(Config{
+	mdw := NewHTTPMetric(Config{
 		MetricRecorder:     otel.NewOTelRecorder(exp, svcName),
 		Logger:             log,
 		Service:            svcName,

--- a/core/pkg/sync-store/sync_store.go
+++ b/core/pkg/sync-store/sync_store.go
@@ -94,7 +94,7 @@ func (s *SyncStore) FetchAllFlags(ctx context.Context, key interface{}, target s
 }
 
 // RegisterSubscription starts a new subscription to the target resource.
-// Once the subscription is set an ALL sync event will be recieved via the DataSync chan.
+// Once the subscription is set an ALL sync event will be received via the DataSync chan.
 func (s *SyncStore) RegisterSubscription(
 	ctx context.Context,
 	target string,

--- a/core/pkg/sync-store/sync_store_test.go
+++ b/core/pkg/sync-store/sync_store_test.go
@@ -30,7 +30,7 @@ func newMockSync() *syncMock {
 	}
 }
 
-func (s *syncMock) Init(ctx context.Context) error {
+func (s *syncMock) Init(_ context.Context) error {
 	return s.initError
 }
 
@@ -47,7 +47,7 @@ func (s *syncMock) Sync(ctx context.Context, dataSync chan<- isync.DataSync) err
 	}
 }
 
-func (s *syncMock) ReSync(ctx context.Context, dataSync chan<- isync.DataSync) error {
+func (s *syncMock) ReSync(_ context.Context, dataSync chan<- isync.DataSync) error {
 	if s.resyncData != nil {
 		dataSync <- *s.resyncData
 	}
@@ -59,7 +59,7 @@ type syncBuilderMock struct {
 	initError error
 }
 
-func (s *syncBuilderMock) SyncFromURI(uri string, logger *logger.Logger) (isync.ISync, error) {
+func (s *syncBuilderMock) SyncFromURI(_ string, _ *logger.Logger) (isync.ISync, error) {
 	return s.mock, s.initError
 }
 
@@ -258,7 +258,7 @@ func Test_watchResource_SyncErrorOnClose(t *testing.T) {
 	syncStore.mu.Unlock()
 }
 
-func Test_watchResource_SyncHandlerDoesNotExist(t *testing.T) {
+func Test_watchResource_SyncHandlerDoesNotExist(_ *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	syncStore := NewSyncStore(ctx, logger.NewLogger(nil, false))

--- a/core/pkg/sync/file/filepath_sync.go
+++ b/core/pkg/sync/file/filepath_sync.go
@@ -34,7 +34,7 @@ func (fs *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error
 	return nil
 }
 
-func (fs *Sync) Init(ctx context.Context) error {
+func (fs *Sync) Init(_ context.Context) error {
 	fs.Logger.Info("Starting filepath sync notifier")
 	w, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/core/pkg/sync/grpc/credentials/builder.go
+++ b/core/pkg/sync/grpc/credentials/builder.go
@@ -4,10 +4,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"os"
 	"strings"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (

--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -2,13 +2,13 @@ package grpc
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	credentials2 "github.com/open-feature/flagd/core/pkg/sync/grpc/credentials"
 	"math"
 	"strings"
 	msync "sync"
 	"time"
+
+	credentials2 "github.com/open-feature/flagd/core/pkg/sync/grpc/credentials"
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/sync/v1/syncv1grpc"
 	v1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/sync/v1"
@@ -30,8 +30,6 @@ const (
 	backOffLimit         = 3
 	backOffBase          = 4
 	constantBackOffDelay = 60
-
-	tlsVersion = tls.VersionTLS12
 )
 
 // type aliases for interfaces required by this component - needed for mock generation with gomock

--- a/core/pkg/sync/grpc/grpc_sync_test.go
+++ b/core/pkg/sync/grpc/grpc_sync_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/golang/mock/gomock"
-	credendialsmock "github.com/open-feature/flagd/core/pkg/sync/grpc/credentials/mock"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/credentials"
 	"io"
 	"log"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/golang/mock/gomock"
+	credendialsmock "github.com/open-feature/flagd/core/pkg/sync/grpc/credentials/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
 
 	"golang.org/x/sync/errgroup"
 
@@ -739,7 +740,7 @@ type bufferedServer struct {
 	fetchAllFlagsError    error
 }
 
-func (b *bufferedServer) SyncFlags(req *v1.SyncFlagsRequest, stream syncv1grpc.FlagSyncService_SyncFlagsServer) error {
+func (b *bufferedServer) SyncFlags(_ *v1.SyncFlagsRequest, stream syncv1grpc.FlagSyncService_SyncFlagsServer) error {
 	for _, response := range b.mockResponses {
 		err := stream.Send(&v1.SyncFlagsResponse{
 			FlagConfiguration: response.flags,
@@ -754,6 +755,6 @@ func (b *bufferedServer) SyncFlags(req *v1.SyncFlagsRequest, stream syncv1grpc.F
 	return nil
 }
 
-func (b *bufferedServer) FetchAllFlags(ctx context.Context, req *v1.FetchAllFlagsRequest) (*v1.FetchAllFlagsResponse, error) {
+func (b *bufferedServer) FetchAllFlags(_ context.Context, _ *v1.FetchAllFlagsRequest) (*v1.FetchAllFlagsResponse, error) {
 	return b.fetchAllFlagsResponse, b.fetchAllFlagsError
 }

--- a/core/pkg/sync/http/http_sync.go
+++ b/core/pkg/sync/http/http_sync.go
@@ -46,7 +46,7 @@ func (hs *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error
 	return nil
 }
 
-func (hs *Sync) Init(ctx context.Context) error {
+func (hs *Sync) Init(_ context.Context) error {
 	// noop
 	return nil
 }

--- a/core/pkg/sync/kubernetes/kubernetes_sync.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync.go
@@ -81,7 +81,7 @@ func (k *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error 
 	return nil
 }
 
-func (k *Sync) Init(ctx context.Context) error {
+func (k *Sync) Init(_ context.Context) error {
 	var err error
 
 	k.namespace, k.crdName, err = parseURI(k.URI)

--- a/core/pkg/sync/kubernetes/kubernetes_sync_test.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync_test.go
@@ -882,7 +882,7 @@ type MockClient struct {
 	getResponse v1alpha1.FeatureFlagConfiguration
 }
 
-func (m MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (m MockClient) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 	// return error if error is set
 	if m.clientErr != nil {
 		return m.clientErr


### PR DESCRIPTION
## This PR

Fix lint check & adds lint fixes for existing lint failures (reason for 16 file changes)

See this example [1], linting was failing silently as we rely on a `foreach` loop. 

Solution credits - https://stackoverflow.com/a/22214424/3197055  

[1] - https://github.com/open-feature/flagd/actions/runs/4471193065/jobs/7855746534#step:5:640