### PR TITLE
chore: refactor configuration handling for startup

### DIFF
--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/open-feature/flagd/core/pkg/service"
 	"net/http"
 	"regexp"
 	msync "sync"
 	"time"
+
+	"github.com/open-feature/flagd/core/pkg/service"
 
 	"go.opentelemetry.io/otel/exporters/prometheus"
 

--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -85,12 +85,6 @@ func FromConfig(logger *logger.Logger, config Config) (*Runtime, error) {
 	}
 
 	connectService := &flageval.ConnectService{
-		ConnectServiceConfiguration: &flageval.ConnectServiceConfiguration{
-			ServerKeyPath:    config.ServiceKeyPath,
-			ServerCertPath:   config.ServiceCertPath,
-			ServerSocketPath: config.ServiceSocketPath,
-			CORS:             config.CORS,
-		},
 		Logger: logger.WithFields(
 			zap.String("component", "service"),
 		),
@@ -120,6 +114,10 @@ func FromConfig(logger *logger.Logger, config Config) (*Runtime, error) {
 			Port:        config.ServicePort,
 			MetricsPort: config.MetricsPort,
 			ServiceName: svcName,
+			KeyPath:     config.ServiceKeyPath,
+			CertPath:    config.ServiceCertPath,
+			SocketPath:  config.ServiceSocketPath,
+			CORS:        config.CORS,
 		},
 		SyncImpl: iSyncs,
 	}, nil

--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -55,7 +55,7 @@ type SourceConfig struct {
 	Selector    string `json:"selector,omitempty"`
 }
 
-// Config is the configuration structure from derived from startup arguments.
+// Config is the configuration structure derived from startup arguments.
 type Config struct {
 	ServicePort       uint16
 	MetricsPort       uint16
@@ -124,6 +124,7 @@ func FromConfig(logger *logger.Logger, config Config) (*Runtime, error) {
 	}, nil
 }
 
+// syncProvidersFromConfig is a helper to build ISync implementations from SourceConfig
 func syncProvidersFromConfig(logger *logger.Logger, sources []SourceConfig) ([]sync.ISync, error) {
 	syncImpls := []sync.ISync{}
 

--- a/core/pkg/runtime/from_config_test.go
+++ b/core/pkg/runtime/from_config_test.go
@@ -1,9 +1,10 @@
 package runtime
 
 import (
-	"github.com/open-feature/flagd/core/pkg/logger"
 	"reflect"
 	"testing"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
 )
 
 func TestParseSource(t *testing.T) {

--- a/core/pkg/runtime/from_config_test.go
+++ b/core/pkg/runtime/from_config_test.go
@@ -1,23 +1,20 @@
-package runtime_test
+package runtime
 
 import (
 	"reflect"
 	"testing"
-
-	"github.com/open-feature/flagd/core/pkg/runtime"
-	"github.com/open-feature/flagd/core/pkg/sync"
 )
 
-func TestSyncProviderArgParse(t *testing.T) {
+func TestParseSource(t *testing.T) {
 	test := map[string]struct {
 		in        string
 		expectErr bool
-		out       []sync.SourceConfig
+		out       []SourceConfig
 	}{
 		"simple": {
 			in:        "[{\"uri\":\"config/samples/example_flags.json\",\"provider\":\"file\"}]",
 			expectErr: false,
-			out: []sync.SourceConfig{
+			out: []SourceConfig{
 				{
 					URI:      "config/samples/example_flags.json",
 					Provider: "file",
@@ -32,7 +29,7 @@ func TestSyncProviderArgParse(t *testing.T) {
 					{"uri":"default/my-crd","provider":"kubernetes"}
 				]`,
 			expectErr: false,
-			out: []sync.SourceConfig{
+			out: []SourceConfig{
 				{
 					URI:      "config/samples/example_flags.json",
 					Provider: "file",
@@ -61,7 +58,7 @@ func TestSyncProviderArgParse(t *testing.T) {
 					{"uri":"core.openfeature.dev/namespace/my-crd","provider":"kubernetes"}
 				]`,
 			expectErr: false,
-			out: []sync.SourceConfig{
+			out: []SourceConfig{
 				{
 					URI:      "config/samples/example_flags.json",
 					Provider: "file",
@@ -90,18 +87,18 @@ func TestSyncProviderArgParse(t *testing.T) {
 		"empty": {
 			in:        `[]`,
 			expectErr: false,
-			out:       []sync.SourceConfig{},
+			out:       []SourceConfig{},
 		},
 		"parse-failure": {
 			in:        ``,
 			expectErr: true,
-			out:       []sync.SourceConfig{},
+			out:       []SourceConfig{},
 		},
 	}
 
 	for name, tt := range test {
 		t.Run(name, func(t *testing.T) {
-			out, err := runtime.SyncProviderArgParse(tt.in)
+			out, err := ParseSources(tt.in)
 			if tt.expectErr {
 				if err == nil {
 					t.Error("expected error, got none")
@@ -116,18 +113,18 @@ func TestSyncProviderArgParse(t *testing.T) {
 	}
 }
 
-func TestSyncProvidersFromURIs(t *testing.T) {
+func TestParseSyncProviderURIs(t *testing.T) {
 	test := map[string]struct {
 		in        []string
 		expectErr bool
-		out       []sync.SourceConfig
+		out       []SourceConfig
 	}{
 		"simple": {
 			in: []string{
 				"file:my-file.json",
 			},
 			expectErr: false,
-			out: []sync.SourceConfig{
+			out: []SourceConfig{
 				{
 					URI:      "my-file.json",
 					Provider: "file",
@@ -142,7 +139,7 @@ func TestSyncProvidersFromURIs(t *testing.T) {
 				"core.openfeature.dev/default/my-crd",
 			},
 			expectErr: false,
-			out: []sync.SourceConfig{
+			out: []SourceConfig{
 				{
 					URI:      "my-file.json",
 					Provider: "file",
@@ -164,18 +161,18 @@ func TestSyncProvidersFromURIs(t *testing.T) {
 		"empty": {
 			in:        []string{},
 			expectErr: false,
-			out:       []sync.SourceConfig{},
+			out:       []SourceConfig{},
 		},
 		"parse-failure": {
 			in:        []string{"care.openfeature.dev/will/fail"},
 			expectErr: true,
-			out:       []sync.SourceConfig{},
+			out:       []SourceConfig{},
 		},
 	}
 
 	for name, tt := range test {
 		t.Run(name, func(t *testing.T) {
-			out, err := runtime.SyncProvidersFromURIs(tt.in)
+			out, err := ParseSyncProviderURIs(tt.in)
 			if tt.expectErr {
 				if err == nil {
 					t.Error("expected error, got none")

--- a/core/pkg/sync/isync.go
+++ b/core/pkg/sync/isync.go
@@ -57,13 +57,3 @@ type DataSync struct {
 	Source   string
 	Type
 }
-
-type SourceConfig struct {
-	URI      string `json:"uri"`
-	Provider string `json:"provider"`
-
-	BearerToken string `json:"bearerToken,omitempty"`
-	CertPath    string `json:"certPath,omitempty"`
-	ProviderID  string `json:"providerID,omitempty"`
-	Selector    string `json:"selector,omitempty"`
-}

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/runtime"
-	"github.com/open-feature/flagd/core/pkg/sync"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -120,14 +119,14 @@ var startCmd = &cobra.Command{
 				"Docs: https://github.com/open-feature/flagd/blob/main/docs/configuration/configuration.md")
 		}
 
-		syncProviders, err := runtime.SyncProvidersFromURIs(viper.GetStringSlice(uriFlagName))
+		syncProviders, err := runtime.ParseSyncProviderURIs(viper.GetStringSlice(uriFlagName))
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		syncProvidersFromConfig := []sync.SourceConfig{}
+		syncProvidersFromConfig := []runtime.SourceConfig{}
 		if cfgFile == "" && viper.GetString(sourcesFlagName) != "" {
-			syncProvidersFromConfig, err = runtime.SyncProviderArgParse(viper.GetString(sourcesFlagName))
+			syncProvidersFromConfig, err = runtime.ParseSources(viper.GetString(sourcesFlagName))
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
## This PR

No logic changes - Pure refactoring[1] to untangle startup argument-based configurations from runtime.

Consider the simple sequence diagram below, 

```mermaid
sequenceDiagram
    participant start
    participant from_config
    participant runtime
    start-->>from_config: ParseSyncProviderURIs()
    start-->>from_config: ParseSources()
    start-->>from_config: FromConfig()
    Note left of from_config: This parse & build the runtime.
    from_config-->>start: Runtime
    Note left of from_config: Runtime structure is self-contained & <br/> does not rely on the startup configuration
    start-->>runtime: rt.Start()
    loop Run
        runtime->>runtime: flagd runtime
    end
```

The core idea was to isolate startup configuration & get rid of the unwanted `Config` [2] structure parsing to the `Runtime` layer. 

This change 

- Helps to isolate startup arguments & runtime (low coupling)
- Improves testability by removing unused/unwanted pointer receivers  
- Improves readability as we have a clear logic flow 


[1]  Note - Had to change this faulty log line :  https://github.com/open-feature/flagd/blob/c98db4f34c8b3abd478432b823ffbd2b8fe2d301/core/pkg/runtime/from_config.go#L149-L151
[2] - https://github.com/open-feature/flagd/blob/main/core/pkg/runtime/runtime.go#L30
