### PR TITLE
fix: nil pointer fix + export constructors

### DIFF
--- a/core/pkg/sync-store/sync_store.go
+++ b/core/pkg/sync-store/sync_store.go
@@ -264,7 +264,7 @@ func (sb *SyncBuilder) SyncFromURI(uri string, logger *logger.Logger) (isync.ISy
 	switch uriB := []byte(uri); {
 	// filepath may be used for debugging, not recommended in deployment
 	case regFile.Match(uriB):
-		return runtime.NewFile(isync.SourceConfig{
+		return runtime.NewFile(runtime.SourceConfig{
 			URI: regFile.ReplaceAllString(uri, ""),
 		}, logger.WithFields(
 			zap.String("component", "sync"),


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes nil pointer deference bug with grpc sync
- exports constructors, this code was duplicated in the sync store

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->
```
go run flagd/main.go start --debug --sources '[{"uri":"grpc://localhost:8013","provider":"grpc","selector":"file:./config/samples/example_flags.json"}]'
```
resulted in 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1047af4e8]

goroutine 1 [running]:
github.com/open-feature/flagd/core/pkg/sync/grpc.(*Sync).Init(0x140002671f0, {0x10582c6b0, 0x14000687450})
```
credential builder was not being set in the constructor
### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

