### PR TITLE
ci: improve homebrew release process

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: google-github-actions/release-please-action@ee9822ec2c397e8a364d634464339ac43a06e042 # v3
         id: release
         with:
+          release-type: "go"
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
@@ -35,7 +36,7 @@ jobs:
         uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6
         id: items-to-publish
         env:
-          CHANGED_ITEMS: '${{ steps.release.outputs.paths_released }}'
+          CHANGED_ITEMS: "${{ steps.release.outputs.paths_released }}"
         with:
           # Release please outputs a string representation of an array under the key paths_released
           # This script parses the output, and filters each of the changed items (provided as paths to the root of the package, e.g. flagd or core)
@@ -55,18 +56,18 @@ jobs:
       flagd_tag_name: ${{ steps.release.outputs.flagd--tag_name }}
       flagd-proxy_version: ${{ steps.release.outputs.flagd-proxy--version }}
       flagd-proxy_tag_name: ${{ steps.release.outputs.flagd-proxy--tag_name }}
-      
+
   container-release:
     name: Build and push containers to GHCR
     needs: release-please
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.items_to_publish != '' && toJson(fromJson(needs.release-please.outputs.items_to_publish)) != '[]' }}
     strategy:
-      matrix: 
+      matrix:
         path: ${{ fromJSON(needs.release-please.outputs.items_to_publish) }}
 
     env:
-      TAG: ${{ needs.release-please.outputs[format('{0}_tag_name', matrix.path)] }} 
+      TAG: ${{ needs.release-please.outputs[format('{0}_tag_name', matrix.path)] }}
       VERSION: v${{ needs.release-please.outputs[format('{0}_version', matrix.path)] }}
     steps:
       - name: Checkout
@@ -80,18 +81,18 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-  
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ matrix.path }}
-  
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
           platforms: all
-  
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
@@ -112,7 +113,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.path }}:latest
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.path }}:${{ env.VERSION }}
-          labels: ${{ steps.meta.outputs.labels }} 
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ env.VERSION }}
             COMMIT=${{ github.sha }}
@@ -145,18 +146,18 @@ jobs:
           tag_name: ${{ env.TAG }}
           files: |
             ${{ env.PUBLIC_KEY_FILE }}
-            ${{ steps.image-sbom-file-gen.outputs.IMG_SBOM_FILE }} 
+            ${{ steps.image-sbom-file-gen.outputs.IMG_SBOM_FILE }}
   release-go-binaries:
     name: Create and publish binaries to GitHub
     needs: release-please
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.items_to_publish != '' && toJson(fromJson(needs.release-please.outputs.items_to_publish)) != '[]' }}
     strategy:
-      matrix: 
+      matrix:
         path: ${{ fromJSON(needs.release-please.outputs.items_to_publish) }}
 
     env:
-      TAG: ${{ needs.release-please.outputs[format('{0}_tag_name', matrix.path)] }} 
+      TAG: ${{ needs.release-please.outputs[format('{0}_tag_name', matrix.path)] }}
       VERSION: v${{ needs.release-please.outputs[format('{0}_version', matrix.path)] }}
       VERSION_NO_PREFIX: ${{ needs.release-please.outputs[format('{0}_version', matrix.path)] }}
     steps:
@@ -214,19 +215,20 @@ jobs:
             ./sbom.xml
             ./*.tar.gz
   homebrew:
-   name: Bump homebrew-core formula
-   needs: release-please
-   runs-on: ubuntu-latest
-   # Only run on non-forked flagd releases
-   if: ${{ github.repository_owner == 'open-feature' && needs.release-please.outputs.flagd_tag_name }}
-   steps:
-     - uses: mislav/bump-homebrew-formula-action@v2
-       with:
-         formula-name: flagd
-         tag-name: ${{ needs.release-please.outputs.flagd_tag_name }}
-         download-url: https://github.com/${{ github.repository }}.git
-         commit-message: |
-           {{formulaName}} {{version}}
-           Created by https://github.com/mislav/bump-homebrew-formula-action
-       env:
-         COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+    name: Bump homebrew-core formula
+    needs: release-please
+    runs-on: ubuntu-latest
+    # Only run on non-forked flagd releases
+    if: ${{ github.repository_owner == 'open-feature' && needs.release-please.outputs.flagd_tag_name }}
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v2
+        with:
+          formula-name: flagd
+          tag-name: ${{ needs.release-please.outputs.flagd_tag_name }}
+          download-url: https://github.com/${{ github.repository }}.git
+          commit-message: |
+            {{formulaName}} ${{ needs.release-please.outputs.flagd_version }}
+
+            Created by https://github.com/mislav/bump-homebrew-formula-action
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## This PR

- adds a base `release-type` as required by [Release Please](https://github.com/google-github-actions/release-please-action/blob/main/action.yml#L20-L22)
- update homebrew commit message to not include the flagd prefix

### Notes

Homebrew uses the first line of the commit message as the PR title and the rest of the message as the PR body. Without a body, Homebrew will flag the PR as invalid.

Addresses: https://github.com/Homebrew/homebrew-core/pull/127098#issuecomment-1490624290