### PR TITLE
chore: add instructions for windows and fix failing unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     ```
 
     Or use docker:
-   (for Windows use WSL both for the file path and the docker commands. This flagd on docker command WILL NOT WORK on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
+    _Note - In Windows, use WSL system for both the file location and Docker runtime. Mixed file systems does not
+    work and this is a limitation of Docker (https://github.com/docker/for-win/issues/8479)_
 
     ```sh
     docker run \
@@ -74,7 +75,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
       --uri file:./example_flags.flagd.json
     ```
 
-    Or use docker (!! this does not work on Windows without using WSL !!):
+    Or use docker ( _Note - In Windows, this require WSL system for both the file location and Docker runtime_):
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
 
     Or use docker:
     _Note - In Windows, use WSL system for both the file location and Docker runtime. Mixed file systems does not
-    work and this is a [limitation of Docker] (https://github.com/docker/for-win/issues/8479)_
+    work and this is a [limitation of Docker](https://github.com/docker/for-win/issues/8479)_
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     ```
 
     Or use docker:
-   (this flagd on docker command will not work on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
+   (this flagd on docker command WILL NOT WORK on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
       -d '{"flagKey":"myStringFlag","context":{}}' -H "Content-Type: application/json"
     ```
 
+    For Windows use bash or use the following:
+
+    ```sh
+    set json={"flagKey":"myStringFlag","context":{}}
+    curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveString"
+    ```
+
     Result:
 
     ```json

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     ```
 
     Or use docker:
-   (this flagd on docker command WILL NOT WORK on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
+   (for Windows use WSL both for the file path and the docker commands. This flagd on docker command WILL NOT WORK on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
 
     ```sh
     docker run \
@@ -74,7 +74,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
       --uri file:./example_flags.flagd.json
     ```
 
-    Or use docker (!!this does not work on Windows!!):
+    Or use docker (!! this does not work on Windows without using WSL !!):
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     curl -X POST "http://localhost:8013/schema.v1.Service/ResolveString" \
       -d '{"flagKey":"myStringFlag","context":{}}' -H "Content-Type: application/json"
     ```
+
    For Windows we recommend using a [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) terminal.
    Otherwise, use the following with `cmd`:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
       --uri file:./example_flags.flagd.json
     ```
 
-    Or use docker ( _Note - In Windows, this require WSL system for both the file location and Docker runtime_):
+    Or use docker ( _Note - In Windows, this requires WSL system for both the file location and Docker runtime_):
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     ```
 
     Or use docker:
+   (this flagd on docker command will not work on Windows due to the mixed filesystems [#8479](https://github.com/docker/for-win/issues/8479)!! See also [this medium article](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) )
 
     ```sh
     docker run \
@@ -73,7 +74,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
       --uri file:./example_flags.flagd.json
     ```
 
-    Or use docker:
+    Or use docker (!!this does not work on Windows!!):
 
     ```sh
     docker run \

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
     curl -X POST "http://localhost:8013/schema.v1.Service/ResolveString" \
       -d '{"flagKey":"myStringFlag","context":{}}' -H "Content-Type: application/json"
     ```
-
-    For Windows use bash or use the following:
+   For Windows we recommend using a [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) terminal.
+   Otherwise, use the following with `cmd`:
 
     ```sh
     set json={"flagKey":"myStringFlag","context":{}}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Experiment with flagd in your browser using [the Killercoda tutorial](https://ki
 
     Or use docker:
     _Note - In Windows, use WSL system for both the file location and Docker runtime. Mixed file systems does not
-    work and this is a limitation of Docker (https://github.com/docker/for-win/issues/8479)_
+    work and this is a [limitation of Docker] (https://github.com/docker/for-win/issues/8479)_
 
     ```sh
     docker run \

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	msync "sync"
-
-	//msync "sync"
 	"testing"
 	"time"
 

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -22,7 +22,6 @@ const (
 )
 
 func TestSimpleReSync(t *testing.T) {
-
 	fetchDirName := t.TempDir()
 	source := filepath.Join(fetchDirName, fetchFileName)
 	expectedDataSync := sync.DataSync{

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	msync "sync"
+
+	//msync "sync"
 	"testing"
 	"time"
 
@@ -16,120 +19,113 @@ import (
 )
 
 const (
-	fetchDirName      = "test"
 	fetchFileName     = "to_fetch.json"
 	fetchFileContents = "fetch me"
 )
 
 func TestSimpleReSync(t *testing.T) {
-	tests := map[string]struct {
-		fileContents     string
-		expectedDataSync sync.DataSync
-	}{
-		"simple-read": {
-			fileContents: "hello",
-			expectedDataSync: sync.DataSync{
-				FlagData: "hello",
-				Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
-				Type:     sync.ALL,
-			},
-		},
-	}
 
+	fetchDirName := t.TempDir()
+	source := filepath.Join(fetchDirName, fetchFileName)
+	expectedDataSync := sync.DataSync{
+		FlagData: "hello",
+		Source:   source,
+		Type:     sync.ALL,
+	}
 	handler := Sync{
-		URI:    fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+		URI:    source,
 		Logger: logger.NewLogger(nil, false),
 	}
 
-	for test, tt := range tests {
-		t.Run(test, func(t *testing.T) {
-			defer t.Cleanup(cleanupFilePath)
-			setupDir(t)
-			createFile(t)
-			writeToFile(t, tt.fileContents)
+	createFile(t, fetchDirName)
+	writeToFile(t, fetchDirName, "hello")
+	ctx := context.Background()
+	dataSyncChan := make(chan sync.DataSync, 1)
 
-			ctx := context.Background()
-			dataSyncChan := make(chan sync.DataSync, 1)
+	go func() {
+		err := handler.ReSync(ctx, dataSyncChan)
+		if err != nil {
+			log.Fatalf("Error start sync: %s", err.Error())
+			return
+		}
+	}()
 
-			go func() {
-				err := handler.ReSync(ctx, dataSyncChan)
-				if err != nil {
-					log.Fatalf("Error start sync: %s", err.Error())
-					return
-				}
-			}()
-
-			select {
-			case s := <-dataSyncChan:
-				if !reflect.DeepEqual(tt.expectedDataSync, s) {
-					t.Errorf("resync failed, incorrect datasync value, got %v want %v", s, tt.expectedDataSync)
-				}
-			case <-time.After(5 * time.Second):
-				t.Error("timed out waiting for datasync")
-			}
-		})
+	select {
+	case s := <-dataSyncChan:
+		if !reflect.DeepEqual(expectedDataSync, s) {
+			t.Errorf("resync failed, incorrect datasync value, got %v want %v", s, expectedDataSync)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("timed out waiting for datasync")
 	}
 }
 
 func TestSimpleSync(t *testing.T) {
+	readDirName := t.TempDir()
+	updateDirName := t.TempDir()
+	deleteDirName := t.TempDir()
 	tests := map[string]struct {
 		manipulationFuncs []func(t *testing.T)
 		expectedDataSync  []sync.DataSync
+		fetchDirName      string
 	}{
 		"simple-read": {
+			fetchDirName: readDirName,
 			manipulationFuncs: []func(t *testing.T){
 				func(t *testing.T) {
-					writeToFile(t, fetchFileContents)
+					writeToFile(t, readDirName, fetchFileContents)
 				},
 			},
 			expectedDataSync: []sync.DataSync{
 				{
 					FlagData: fetchFileContents,
-					Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+					Source:   fmt.Sprintf("%s/%s", readDirName, fetchFileName),
 					Type:     sync.ALL,
 				},
 			},
 		},
 		"update-event": {
+			fetchDirName: updateDirName,
 			manipulationFuncs: []func(t *testing.T){
 				func(t *testing.T) {
-					writeToFile(t, fetchFileContents)
+					writeToFile(t, updateDirName, fetchFileContents)
 				},
 				func(t *testing.T) {
-					writeToFile(t, "new content")
+					writeToFile(t, updateDirName, "new content")
 				},
 			},
 			expectedDataSync: []sync.DataSync{
 				{
 					FlagData: fetchFileContents,
-					Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+					Source:   fmt.Sprintf("%s/%s", updateDirName, fetchFileName),
 					Type:     sync.ALL,
 				},
 				{
 					FlagData: "new content",
-					Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+					Source:   fmt.Sprintf("%s/%s", updateDirName, fetchFileName),
 					Type:     sync.ALL,
 				},
 			},
 		},
 		"delete-event": {
+			fetchDirName: deleteDirName,
 			manipulationFuncs: []func(t *testing.T){
 				func(t *testing.T) {
-					writeToFile(t, fetchFileContents)
+					writeToFile(t, deleteDirName, fetchFileContents)
 				},
 				func(t *testing.T) {
-					deleteFile(t, fetchDirName, fetchFileName)
+					deleteFile(t, deleteDirName, fetchFileName)
 				},
 			},
 			expectedDataSync: []sync.DataSync{
 				{
 					FlagData: fetchFileContents,
-					Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+					Source:   fmt.Sprintf("%s/%s", deleteDirName, fetchFileName),
 					Type:     sync.ALL,
 				},
 				{
 					FlagData: defaultState,
-					Source:   fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+					Source:   fmt.Sprintf("%s/%s", deleteDirName, fetchFileName),
 					Type:     sync.DELETE,
 				},
 			},
@@ -138,16 +134,14 @@ func TestSimpleSync(t *testing.T) {
 
 	for test, tt := range tests {
 		t.Run(test, func(t *testing.T) {
-			defer t.Cleanup(cleanupFilePath)
-			setupDir(t)
-			createFile(t)
+			createFile(t, tt.fetchDirName)
 
 			ctx := context.Background()
 
 			dataSyncChan := make(chan sync.DataSync, len(tt.expectedDataSync))
 
 			syncHandler := Sync{
-				URI:    fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+				URI:    fmt.Sprintf("%s/%s", tt.fetchDirName, fetchFileName),
 				Logger: logger.NewLogger(nil, false),
 				Mux:    &msync.RWMutex{},
 			}
@@ -199,13 +193,17 @@ func TestSimpleSync(t *testing.T) {
 }
 
 func TestFilePathSync_Fetch(t *testing.T) {
+	successDirName := t.TempDir()
+	falureDirName := t.TempDir()
 	tests := map[string]struct {
 		fpSync         Sync
 		handleResponse func(t *testing.T, fetched string, err error)
+		fetchDirName   string
 	}{
 		"success": {
+			fetchDirName: successDirName,
 			fpSync: Sync{
-				URI:    fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
+				URI:    fmt.Sprintf("%s/%s", successDirName, fetchFileName),
 				Logger: logger.NewLogger(nil, false),
 			},
 			handleResponse: func(t *testing.T, fetched string, err error) {
@@ -219,8 +217,9 @@ func TestFilePathSync_Fetch(t *testing.T) {
 			},
 		},
 		"not found": {
+			fetchDirName: falureDirName,
 			fpSync: Sync{
-				URI:    fmt.Sprintf("%s/%s", fetchDirName, "not_found"),
+				URI:    fmt.Sprintf("%s/%s", falureDirName, "not_found"),
 				Logger: logger.NewLogger(nil, false),
 			},
 			handleResponse: func(t *testing.T, fetched string, err error) {
@@ -233,10 +232,8 @@ func TestFilePathSync_Fetch(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			setupDir(t)
-			createFile(t)
-			writeToFile(t, fetchFileContents)
-			defer t.Cleanup(cleanupFilePath)
+			createFile(t, tt.fetchDirName)
+			writeToFile(t, tt.fetchDirName, fetchFileContents)
 
 			data, err := tt.fpSync.fetch(context.Background())
 
@@ -246,16 +243,15 @@ func TestFilePathSync_Fetch(t *testing.T) {
 }
 
 func TestIsReadySyncFlag(t *testing.T) {
+	fetchDirName := t.TempDir()
 	fpSync := Sync{
 		URI:    fmt.Sprintf("%s/%s", fetchDirName, fetchFileName),
 		Logger: logger.NewLogger(nil, false),
 		Mux:    &msync.RWMutex{},
 	}
 
-	setupDir(t)
-	createFile(t)
-	writeToFile(t, fetchFileContents)
-	defer t.Cleanup(cleanupFilePath)
+	createFile(t, fetchDirName)
+	writeToFile(t, fetchDirName, fetchFileContents)
 	if fpSync.IsReady() != false {
 		t.Errorf("expected not to be ready")
 	}
@@ -283,31 +279,25 @@ func TestIsReadySyncFlag(t *testing.T) {
 	}
 }
 
-func cleanupFilePath() {
-	if err := os.RemoveAll(fetchDirName); err != nil {
-		log.Fatalf("rmdir: %v", err)
-	}
-}
-
 func deleteFile(t *testing.T, dirName string, fileName string) {
 	if err := os.Remove(fmt.Sprintf("%s/%s", dirName, fileName)); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func setupDir(t *testing.T) {
-	if err := os.Mkdir(fetchDirName, os.ModePerm); err != nil {
+func createFile(t *testing.T, fetchDirName string) {
+	f, err := os.Create(fmt.Sprintf("%s/%s", fetchDirName, fetchFileName))
+	defer func(file *os.File) {
+		if err := file.Close(); err != nil {
+			log.Fatalf("close file: %v", err)
+		}
+	}(f)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func createFile(t *testing.T) {
-	if _, err := os.Create(fmt.Sprintf("%s/%s", fetchDirName, fetchFileName)); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func writeToFile(t *testing.T, fileContents string) {
+func writeToFile(t *testing.T, fetchDirName, fileContents string) {
 	file, err := os.OpenFile(fmt.Sprintf("%s/%s", fetchDirName, fetchFileName), os.O_RDWR, 0o644)
 	if err != nil {
 		t.Fatal(err)

--- a/docs/usage/evaluation_examples.md
+++ b/docs/usage/evaluation_examples.md
@@ -33,6 +33,13 @@ Command:
 curl -X POST "localhost:8013/schema.v1.Service/ResolveBoolean" -d '{"flagKey":"myBoolFlag","context":{}}' -H "Content-Type: application/json"
 ```
 
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"myBoolFlag","context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveBoolean"
+```
+
 Result:
 
 ```sh
@@ -47,6 +54,13 @@ Command:
 curl -X POST "localhost:8013/schema.v1.Service/ResolveString" -d '{"flagKey":"myStringFlag","context":{}}' -H "Content-Type: application/json"
 ```
 
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"myStringFlag","context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveString"
+```
+
 Result:
 
 ```sh
@@ -59,6 +73,13 @@ Command:
 
 ```sh
 curl -X POST "localhost:8013/schema.v1.Service/ResolveInt" -d '{"flagKey":"myIntFlag","context":{}}' -H "Content-Type: application/json"
+```
+
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"myIntFlag","context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveInt"
 ```
 
 Result:
@@ -77,6 +98,13 @@ Command:
 curl -X POST "localhost:8013/schema.v1.Service/ResolveFloat" -d '{"flagKey":"myFloatFlag","context":{}}' -H "Content-Type: application/json"
 ```
 
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"myFloatFlag","context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveFloat"
+```
+
 Result:
 
 ```sh
@@ -91,6 +119,13 @@ Command:
 curl -X POST "localhost:8013/schema.v1.Service/ResolveObject" -d '{"flagKey":"myObjectFlag","context":{}}' -H "Content-Type: application/json"
 ```
 
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"myObjectFlag","context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveObject"
+```
+
 Result:
 
 ```sh
@@ -103,6 +138,13 @@ Command:
 
 ```sh
 curl -X POST "localhost:8013/schema.v1.Service/ResolveBoolean" -d '{"flagKey":"isColorYellow","context":{"color":"yellow"}}' -H "Content-Type: application/json"
+```
+
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"flagKey":"isColorYellow","context":{"color":"yellow"}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveBoolean"
 ```
 
 Result:
@@ -150,6 +192,13 @@ Command:
 
 ```sh
 curl -X POST "localhost:8013/schema.v1.Service/ResolveAll" -d '{"context":{}}' -H "Content-Type: application/json"
+```
+
+For Windows users, open a command prompt and use:
+
+```sh
+set json={"context":{}}
+curl -i -X POST -H "Content-Type: application/json" -d %json:"=\"% "localhost:8013/schema.v1.Service/ResolveAll"
 ```
 
 Result:


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes unit tests that failed on windows machines
- clarifies usage of flagd on a windows machine

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/flagd/issues/630

### Notes
<!-- any additional notes for this PR -->
The learning from this pr were:

1.  Always prefer using the go test suite tempdir instead of relying on os library to allocate and delete test folders, this simplifies code and avoids os-specific issues
2.  Make sure to always close file pointers, since leaving dangling ones tends to cause access errors in Windows aka error file already open. 
3.  When running via docker one must make sure that the file is in the same filesystem where the docker container runs than the watcher will work. AKA on Windows it is good as long as everything comes from WSL filesystem

