### PR TITLE
chore: adding licenses to release archives and provide zip archive for windows

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -199,14 +199,29 @@ jobs:
         run: |
           env GOOS=linux GOARCH=386 go build -o ./${{ matrix.path }}_linux_i386 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Linux_i386.tar.gz ./${{ matrix.path }}_linux_i386 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
+      # Windows artifacts use .zip archive
       - name: build windows x86_64
         run: |
           env GOOS=windows GOARCH=amd64 go build -o ./${{ matrix.path }}_windows_x86_64 ./${{ matrix.path }}/main.go
-          tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_x86_64.tar.gz ./${{ matrix.path }}_windows_x86_64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
+          zip -r ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_x86_64.zip ./${{ matrix.path }}_windows_x86_64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build windows i386
         run: |
           env GOOS=windows GOARCH=386 go build -o ./${{ matrix.path }}_windows_i386 ./${{ matrix.path }}/main.go
-          tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_i386.tar.gz ./${{ matrix.path }}_windows_i386 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
+          zip -r ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_i386.zip ./${{ matrix.path }}_windows_i386 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
+      # Bundle licenses
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+      - name: Build license extraction locations
+        id: license-files
+        run: |
+          echo "LICENSE_FOLDER=${{ format('{0}-third-party-license', matrix.path) }}" >> $GITHUB_OUTPUT
+          echo "LICENSE_ERROR_FILE=${{ format('{0}-license-errors.txt', matrix.path) }}" >> $GITHUB_OUTPUT
+      - name: Run go-licenses for module ${{ matrix.path }}
+        run: go-licenses save ./${{ matrix.path }} --save_path=./${{ steps.license-files.outputs.LICENSE_FOLDER }} --force --logtostderr=false 2> ./${{ steps.license-files.outputs.LICENSE_ERROR_FILE }}
+        continue-on-error: true # tool set stderr which can be ignored and referred through error artefact
+      - name: Bundle license extracts
+        run: tar czf ./${{ steps.license-files.outputs.LICENSE_FOLDER }}.tar.gz ./${{ steps.license-files.outputs.LICENSE_FOLDER }}
+      # Bundle release artifacts
       - name: Bundle release assets
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
@@ -214,6 +229,8 @@ jobs:
           files: |
             ./sbom.xml
             ./*.tar.gz
+            ./${{ steps.license-files.outputs.LICENSE_FOLDER }}.tar.gz
+            ./${{ steps.license-files.outputs.LICENSE_ERROR_FILE }}
   homebrew:
     name: Bump homebrew-core formula
     needs: release-please


### PR DESCRIPTION
## This PR

Fixes https://github.com/open-feature/flagd/issues/581 & https://github.com/open-feature/flagd/issues/639

**Third-party license artifacts https://github.com/open-feature/flagd/issues/581**

This PR improved release builds to add `<module>-third-party-license.tar.gz` to release artifacts. This artifact contains third-party licenses extracted using https://github.com/google/go-licenses.

This is an attempt to credit our dependencies and be license compliant (ex:- retaining copyright notices) where possible. 

Note that, the go-license tool emits error if it fails to identify licenses (ex:- for non-go codes/internal deps). This breaks the build (as it writes to stderr) and the workaround was to use `continue-on-error: true`. Unfortunately, GH Actions do not provide any better alternative and refer [1] for ongoing discussions. Errors are accumulated to artifact `module-license-errors.txt` for anyone's interest. 

**Artefact archive format for Windows https://github.com/open-feature/flagd/issues/639**

PR further set `.zip` archiving for Windows (i386 & x86-64)

### How to test

An example build was tested and a sample release is available here [2]. Please see `license.tar.gz` & `licenseErrors.txt` for third party license content

[1] - https://github.com/actions/runner/issues/2347
[2] - https://github.com/Kavindu-Dodan/flag-test-ground/releases/tag/v0.1.7
