### PR TITLE
fix: fix connect error code handling for disabled flags

### DIFF
--- a/core/pkg/service/flag-evaluation/flag_evaluator.go
+++ b/core/pkg/service/flag-evaluation/flag_evaluator.go
@@ -322,11 +322,9 @@ func errFormat(err error) error {
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	case model.TypeMismatchErrorCode:
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
-	case model.FlagDisabledErrorCode:
-		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	case model.ParseErrorCode:
 		return connect.NewError(connect.CodeDataLoss, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
-	case model.GeneralErrorCode:
+	case model.FlagDisabledErrorCode, model.GeneralErrorCode:
 		return connect.NewError(connect.CodeUnknown, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	}
 

--- a/core/pkg/service/flag-evaluation/flag_evaluator.go
+++ b/core/pkg/service/flag-evaluation/flag_evaluator.go
@@ -318,13 +318,13 @@ func formatContextKeys(context *structpb.Struct) []string {
 
 func errFormat(err error) error {
 	switch err.Error() {
-	case model.FlagNotFoundErrorCode:
+	case model.FlagNotFoundErrorCode, model.FlagDisabledErrorCode:
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	case model.TypeMismatchErrorCode:
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	case model.ParseErrorCode:
 		return connect.NewError(connect.CodeDataLoss, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
-	case model.FlagDisabledErrorCode, model.GeneralErrorCode:
+	case model.GeneralErrorCode:
 		return connect.NewError(connect.CodeUnknown, fmt.Errorf("%s, %s", ErrorPrefix, err.Error()))
 	}
 

--- a/core/pkg/service/flag-evaluation/flag_evaluator_test.go
+++ b/core/pkg/service/flag-evaluation/flag_evaluator_test.go
@@ -904,9 +904,9 @@ func getMetricReader() (*telemetry.MetricsRecorder, metric.Reader) {
 	return telemetry.NewOTelRecorder(exp, rs, "testSvc"), exp
 }
 
-// TestFlag_Evaluation_ErrorCodes test validate error mapping from known errors to connect.
-// Code and avoid accidental changes. This is essential as SDK implementations rely on connect.
-// Code to differentiate GRPC errors vs Flag errors. For any change, we must change respective SDK changes
+// TestFlag_Evaluation_ErrorCodes test validate error mapping from known errors to connect.Code and avoid accidental
+// changes. This is essential as SDK implementations rely on connect. Code to differentiate GRPC errors vs Flag errors.
+// For any change in error codes, we must change respective SDK.
 func TestFlag_Evaluation_ErrorCodes(t *testing.T) {
 	tests := []struct {
 		err  error

--- a/core/pkg/service/flag-evaluation/flag_evaluator_test.go
+++ b/core/pkg/service/flag-evaluation/flag_evaluator_test.go
@@ -926,7 +926,7 @@ func TestFlag_Evaluation_ErrorCodes(t *testing.T) {
 		},
 		{
 			err:  errors.New(model.FlagDisabledErrorCode),
-			code: connect.CodeUnknown,
+			code: connect.CodeNotFound,
 		},
 		{
 			err:  errors.New(model.GeneralErrorCode),


### PR DESCRIPTION
## This PR

fixes #668 

Fixes incorrect error code mapping, which resulted in error message `error code: PROVIDER_NOT_READY: connection not made`

With fix, the error code is set to unknown (as there is no appropriate error code for this error) , and results in message `openfeature: GENERAL: unknown: FLAG_DISABLED`