### PR TITLE
fix: remove disabled flags from bulk evaluation

### DIFF
--- a/core/pkg/eval/json_evaluator.go
+++ b/core/pkg/eval/json_evaluator.go
@@ -122,6 +122,11 @@ func (je *JSONEvaluator) ResolveAllValues(ctx context.Context, reqID string, con
 	var err error
 	allFlags := je.store.GetAll()
 	for flagKey, flag := range allFlags {
+		if flag.State == Disabled {
+			// ignore evaluation of disabled flag
+			continue
+		}
+
 		defaultValue := flag.Variants[flag.DefaultVariant]
 		switch defaultValue.(type) {
 		case bool:

--- a/core/pkg/eval/json_evaluator_test.go
+++ b/core/pkg/eval/json_evaluator_test.go
@@ -346,18 +346,22 @@ func TestResolveAllValues(t *testing.T) {
 				v, _, reason, _ := evaluator.ResolveBooleanValue(context.TODO(), reqID, val.FlagKey, apStruct)
 				assert.Equal(t, v, vT)
 				assert.Equal(t, val.Reason, reason)
+				assert.Equalf(t, val.Error, nil, "expected no errors, but got %v for flag key %s", val.Error, val.FlagKey)
 			case string:
 				v, _, reason, _ := evaluator.ResolveStringValue(context.TODO(), reqID, val.FlagKey, apStruct)
 				assert.Equal(t, v, vT)
 				assert.Equal(t, val.Reason, reason)
+				assert.Equalf(t, val.Error, nil, "expected no errors, but got %v for flag key %s", val.Error, val.FlagKey)
 			case float64:
 				v, _, reason, _ := evaluator.ResolveFloatValue(context.TODO(), reqID, val.FlagKey, apStruct)
 				assert.Equal(t, v, vT)
 				assert.Equal(t, val.Reason, reason)
+				assert.Equalf(t, val.Error, nil, "expected no errors, but got %v for flag key %s", val.Error, val.FlagKey)
 			case interface{}:
 				v, _, reason, _ := evaluator.ResolveObjectValue(context.TODO(), reqID, val.FlagKey, apStruct)
 				assert.Equal(t, v, vT)
 				assert.Equal(t, val.Reason, reason)
+				assert.Equalf(t, val.Error, nil, "expected no errors, but got %v for flag key %s", val.Error, val.FlagKey)
 			}
 		}
 	}

--- a/core/pkg/eval/json_evaluator_test.go
+++ b/core/pkg/eval/json_evaluator_test.go
@@ -341,6 +341,11 @@ func TestResolveAllValues(t *testing.T) {
 		}
 		vals := evaluator.ResolveAllValues(context.TODO(), reqID, apStruct)
 		for _, val := range vals {
+			// disabled flag must be ignored from bulk evaluation
+			if val.FlagKey == DisabledFlag {
+				t.Errorf("disabled flag '%s' is present in evaluation results", DisabledFlag)
+			}
+
 			switch vT := val.Value.(type) {
 			case bool:
 				v, _, reason, _ := evaluator.ResolveBooleanValue(context.TODO(), reqID, val.FlagKey, apStruct)


### PR DESCRIPTION
## This PR

Fixes #652 & enhance tests to validate error sates 

Note - had to sync go deps and thus the go mod/sum changes 