### PR TITLE
chore: remove duplicate tar.gz bundling

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -229,7 +229,6 @@ jobs:
           files: |
             ./sbom.xml
             ./*.tar.gz
-            ./${{ steps.license-files.outputs.LICENSE_FOLDER }}.tar.gz
             ./${{ steps.license-files.outputs.LICENSE_ERROR_FILE }}
   homebrew:
     name: Bump homebrew-core formula


### PR DESCRIPTION
## This PR

tar.gz bundling is already handled with widlcard usage `*.tar.gz`. This caused pipeline failures 