### PR TITLE
test(flagd): replace os.Setenv by t.Setenv in test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - whitespace
     - wrapcheck
     - gofumpt
+    - tenv
 linters-settings:
   funlen:
     statements: 50

--- a/flagd/cmd/start_test.go
+++ b/flagd/cmd/start_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"log"
-	"os"
 	"testing"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -46,7 +45,7 @@ func Test_getPort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("FLAGD_PORT", tt.envVarValue)
+			t.Setenv("FLAGD_PORT", tt.envVarValue)
 			if got := getPortValueOrDefault(tt.args.flagName, tt.args.value, tt.args.defaultValue, logger); got != tt.want {
 				t.Errorf("getPort() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- replaces `os.Setenv` by `t.Setenv` in unit test (reference: https://pkg.go.dev/testing#T.Setenv)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

N/A

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

