### PR TITLE
feat!: rename metrics and service

### DIFF
--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -33,7 +33,7 @@ const (
 	syncProviderGrpc       = "grpc"
 	syncProviderKubernetes = "kubernetes"
 	syncProviderHTTP       = "http"
-	svcName                = "openfeature/flagd"
+	svcName                = "flagd"
 )
 
 var (

--- a/core/pkg/service/sync/sync_metrics.go
+++ b/core/pkg/service/sync/sync_metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	serviceName = "openfeature/flagd-proxy"
+	serviceName = "flagd-proxy"
 )
 
 func (s *Server) captureMetrics() error {

--- a/core/pkg/telemetry/metrics.go
+++ b/core/pkg/telemetry/metrics.go
@@ -15,13 +15,16 @@ import (
 )
 
 const (
-	requestDurationName      = "http_request_duration_seconds"
-	responseSizeName         = "http_response_size_bytes"
-	FlagdProviderName        = "flagd"
-	FeatureFlagReasonKeyName = "feature_flag.reason"
-	ExceptionTypeKeyName     = "exception.type"
-	FeatureFlagReasonKey     = attribute.Key(FeatureFlagReasonKeyName)
-	ExceptionTypeKey         = attribute.Key(ExceptionTypeKeyName)
+	ProviderName = "flagd"
+
+	FeatureFlagReasonKey = attribute.Key("feature_flag.reason")
+	ExceptionTypeKey     = attribute.Key("ExceptionTypeKeyName")
+
+	httpRequestDurationMetric = "http.server.duration"
+	httpResponseSizeMetric    = "http.server.response.size"
+	httpActiveRequestsMetric  = "http.server.active_requests"
+	impressionMetric          = "feature_flag." + ProviderName + ".impression"
+	reasonMetric              = "feature_flag." + ProviderName + ".evaluation.reason"
 )
 
 type MetricsRecorder struct {
@@ -72,7 +75,7 @@ func (r MetricsRecorder) Impressions(ctx context.Context, reason, variant, key s
 
 func (r MetricsRecorder) Reasons(ctx context.Context, key string, reason string, err error) {
 	attrs := []attribute.KeyValue{
-		semconv.FeatureFlagProviderName(FlagdProviderName),
+		semconv.FeatureFlagProviderName(ProviderName),
 		FeatureFlagReason(reason),
 	}
 	if err == nil {
@@ -116,9 +119,9 @@ func NewOTelRecorder(exporter msdk.Reader, resource *resource.Resource, serviceN
 	provider := msdk.NewMeterProvider(
 		msdk.WithReader(exporter),
 		// for the request duration metric we use the default bucket size which are tailored for response time in seconds
-		msdk.WithView(getDurationView(requestDurationName, serviceName, prometheus.DefBuckets)),
+		msdk.WithView(getDurationView(httpRequestDurationMetric, serviceName, prometheus.DefBuckets)),
 		// for response size we want 8 exponential bucket starting from 100 Bytes
-		msdk.WithView(getDurationView(responseSizeName, serviceName, prometheus.ExponentialBuckets(100, 10, 8))),
+		msdk.WithView(getDurationView(httpResponseSizeMetric, serviceName, prometheus.ExponentialBuckets(100, 10, 8))),
 		// set entity producing telemetry
 		msdk.WithResource(resource),
 	)
@@ -127,25 +130,29 @@ func NewOTelRecorder(exporter msdk.Reader, resource *resource.Resource, serviceN
 
 	// we can ignore errors from OpenTelemetry since they could occur if we select the wrong aggregator
 	hduration, _ := meter.Float64Histogram(
-		requestDurationName,
+		httpRequestDurationMetric,
 		metric.WithDescription("The latency of the HTTP requests"),
+		metric.WithUnit("s"),
 	)
 	hsize, _ := meter.Float64Histogram(
-		responseSizeName,
+		httpResponseSizeMetric,
 		metric.WithDescription("The size of the HTTP responses"),
 		metric.WithUnit("By"),
 	)
 	reqCounter, _ := meter.Int64UpDownCounter(
-		"http_requests_inflight",
+		httpActiveRequestsMetric,
 		metric.WithDescription("The number of inflight requests being handled at the same time"),
+		metric.WithUnit("{request}"),
 	)
 	impressions, _ := meter.Int64Counter(
-		"impressions",
+		impressionMetric,
 		metric.WithDescription("The number of evaluations for a given flag"),
+		metric.WithUnit("{impression}"),
 	)
 	reasons, _ := meter.Int64Counter(
-		"reasons",
+		reasonMetric,
 		metric.WithDescription("The number of evaluations for a given reason"),
+		metric.WithUnit("{reason}"),
 	)
 	return &MetricsRecorder{
 		httpRequestDurHistogram:   hduration,


### PR DESCRIPTION
## This PR

Fixes https://github.com/open-feature/flagd/issues/712 

Refer the following table for metrics renames and their units,


 |  Old | New  | Unit |
|---|---|---|
| http_request_duration_seconds  |  http.server.duration | s |
| http_response_size_bytes | http.server.response.size | By |
| http_requests_inflight |http.server.active_requests | {request} |
| impressions | feature_flag.flagd.impression| {impression} | 
| reasons | feature_flag.flagd.evaluation.reason| {reason} |

### Validation

This change was validated against an OTel setup. Consider following screen captures,

![Screenshot 2023-07-04 at 1 16 02 PM](https://github.com/open-feature/flagd/assets/8186721/5aba3103-e3fc-42a7-a396-c78999d22b05)

![Screenshot 2023-07-04 at 1 15 41 PM](https://github.com/open-feature/flagd/assets/8186721/0ea196f8-fcb4-4e8c-86eb-c6774de3e2f3)

![Screenshot 2023-07-04 at 1 14 53 PM](https://github.com/open-feature/flagd/assets/8186721/c285d78d-525a-4e40-bfe2-895a85d96cd6)

![Screenshot 2023-07-04 at 1 14 40 PM](https://github.com/open-feature/flagd/assets/8186721/e826ed8c-6056-4fd4-b206-d76592d8d484)

![Screenshot 2023-07-04 at 1 14 18 PM](https://github.com/open-feature/flagd/assets/8186721/30c959af-197b-405c-b303-c4dd59807311)



