### PR TITLE
ci: include windows binaries on the release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -233,6 +233,7 @@ jobs:
           files: |
             ./sbom.xml
             ./*.tar.gz
+            ./*.zip
             ./${{ steps.license-files.outputs.LICENSE_ERROR_FILE }}
   homebrew:
     name: Bump homebrew-core formula


### PR DESCRIPTION
## This PR

- adds Windows binaries to the release

### Related Issues

Fixes #775

### Notes

This issue was introduced when the binary was compressed using zip instead of a tarball.

https://github.com/open-feature/flagd/commit/5060a0e5476038534cc9d2b151cbe48fba78a56d
