### PR TITLE
docs: remove architecture diagram

### DIFF
--- a/web-docs/concepts/architecture.md
+++ b/web-docs/concepts/architecture.md
@@ -1,13 +1,5 @@
 # flagd Architecture
 
-```mermaid
-flowchart LR
-    source-A  -->|config-A| store -->|merge|source-A-config-A\nsource-B-config-B
-    source-B  -->|config-B| store
-```
-
-## Component overview
-
 Flagd consists of four main components - Service, Evaluator engine, Runtime and Sync.
 
 The service component exposes the evaluator engine for client libraries.


### PR DESCRIPTION

## This PR
- Removes the redundant mermaid diagram (which doesn't render anyway)

### Related Issues

- Fixes #801

