### PR TITLE
chore: pin golangci-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
       - id: gofumpt
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.46.2
+    rev: v1.50.1
     hooks:
       - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ uninstall:
 	rm /etc/systemd/system/flagd.service
 	rm -f $(DESTDIR)$(PREFIX)/bin/flagd
 lint:
-	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+# pinned to @v1.53.3 until we migrate to go 1.20 (newer versions use incompatible transitive deps)
+	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --deadline=5m --timeout=5m $(module)/... || exit;)
 install-mockgen:
 	go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
golangci requires go 1.20 now :grimacing: . 

We can upgrade to 1.20, but for now the change in this tool is causing lint failures since we use `@latest` when we install it.