### PR TITLE
ci: ensure unit tests are run in PR checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ build: workspace-init # default to flagd
 	make build-flagd
 build-flagd:
 	go build -ldflags "-X main.version=dev -X main.commit=$$(git rev-parse --short HEAD) -X main.date=$$(date +%FT%TZ)" -o ./bin/flagd ./flagd
+.PHONY: test
 test: # default to core
 	make test-core
 test-core:


### PR DESCRIPTION
Closes #853 

This PR fixes the behavior described in the referenced issue by makeing the `test` target in the makefile a `.PHONY`.

The issue was occuring because in the same directory as the Makefile, there was a directory with the same name as the `test` target, which caused the target to not run - For more details, see [this thread](https://stackoverflow.com/questions/3931741/why-does-make-think-the-target-is-up-to-date) on StackOverflow