### PR TITLE
feat: add grpc health, deprecate old health

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -163,7 +163,7 @@ jobs:
       VERSION_NO_PREFIX: ${{ needs.release-please.outputs[format('{0}_version', matrix.path)] }}
       COMMIT: ${{ github.sha }}
       DATE: ${{ needs.release-please.outputs.date }}
-      BUILD_ARGS: '-a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"'
+      BUILD_ARGS: '-a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"'
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -163,7 +163,7 @@ jobs:
       VERSION_NO_PREFIX: ${{ needs.release-please.outputs[format('{0}_version', matrix.path)] }}
       COMMIT: ${{ github.sha }}
       DATE: ${{ needs.release-please.outputs.date }}
-      BUILD_ARGS: '-a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"'
+      BUILD_ARGS: '-a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"'
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ZD_TEST_NAMESPACE ?= flagd-zd-test
 ZD_CLIENT_IMG ?= zd-client:latest
 FLAGD_PROXY_IMG ?= flagd-proxy:latest
 FLAGD_PROXY_IMG_ZD ?= flagd-proxy:zd
+# the same "status.proto" is supplied by 2 modules, which causes an error we can safely ignore
+export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
 
 workspace-init: workspace-clean
 	go work init
@@ -35,7 +37,7 @@ docker-push-flagd:
 build: workspace-init # default to flagd
 	make build-flagd
 build-flagd:
-	go build -ldflags "-X main.version=dev -X main.commit=$$(git rev-parse --short HEAD) -X main.date=$$(date +%FT%TZ)" -o ./bin/flagd ./flagd
+	go build -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=dev -X main.commit=$$(git rev-parse --short HEAD) -X main.date=$$(date +%FT%TZ)" -o ./bin/flagd ./flagd
 .PHONY: test
 test: # default to core
 	make test-core

--- a/config/deployments/flagd/deployment.yaml
+++ b/config/deployments/flagd/deployment.yaml
@@ -29,13 +29,13 @@ spec:
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8014
+              port: 8013
             initialDelaySeconds: 5
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8014
+              port: 8013
             initialDelaySeconds: 5
             periodSeconds: 60
           ports:

--- a/core/pkg/service/flag-evaluation/connect_service.go
+++ b/core/pkg/service/flag-evaluation/connect_service.go
@@ -220,10 +220,12 @@ func (s *ConnectService) startMetricsServer(svcConf service.Configuration) error
 	s.metricsServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
-			s.logger.Warn(fmt.Sprintf("call to deprecated /healthz endpoint on port %d, use port %d instead", svcConf.MetricsPort, svcConf.Port))
+			s.logger.Warn(
+				fmt.Sprintf("/healthz endpoint on port %d is deprecated, use port %d instead", svcConf.MetricsPort, svcConf.Port))
 			w.WriteHeader(http.StatusOK)
 		case "/readyz":
-			s.logger.Warn(fmt.Sprintf("call to deprecated /readyz endpoint on port %d, use port %d instead", svcConf.MetricsPort, svcConf.Port))
+			s.logger.Warn(
+				fmt.Sprintf("/readyz endpoint on port %d is deprecated, use port %d instead", svcConf.MetricsPort, svcConf.Port))
 			if s.readinessEnabled && svcConf.ReadinessProbe() {
 				w.WriteHeader(http.StatusOK)
 			} else {

--- a/core/pkg/service/flag-evaluation/connect_service.go
+++ b/core/pkg/service/flag-evaluation/connect_service.go
@@ -129,8 +129,7 @@ func (s *ConnectService) setupServer(svcConf service.Configuration) (net.Listene
 		protojson.UnmarshalOptions{DiscardUnknown: true},
 	)
 
-	path, handler := schemaConnectV1.NewServiceHandler(fes, append(svcConf.Options, marshalOpts)...)
-	mux.Handle(path, handler)
+	mux.Handle(schemaConnectV1.NewServiceHandler(fes, append(svcConf.Options, marshalOpts)...))
 	mux.Handle(grpchealth.NewHandler(grpchealth.NewStaticChecker(
 		schemaConnectV1.ServiceName,
 	)))

--- a/docs/other_resources/high_level_architecture.md
+++ b/docs/other_resources/high_level_architecture.md
@@ -35,13 +35,18 @@ process gets pushed to event subscribers.
 
 ## Readiness & Liveness probes
 
+### HTTP
+
 Flagd exposes HTTP liveness and readiness probes.
 These probes can be used for K8s deployments.
-With default
-start-up configurations, these probes are exposed at the following URLs,
+With default start-up configurations, these probes are exposed on the service port (default: 8013) at the following URLs,
 
-- Liveness: <http://localhost:8014/healthz>
-- Readiness: <http://localhost:8014/readyz>
+- Liveness: <http://localhost:8013/healthz>
+- Readiness: <http://localhost:8013/readyz>
+
+### gRPC
+
+Flagd exposes a [standard gRPC health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) on the service port (default: 8013).
 
 ### Definition of Liveness
 

--- a/docs/other_resources/high_level_architecture.md
+++ b/docs/other_resources/high_level_architecture.md
@@ -46,7 +46,7 @@ With default start-up configurations, these probes are exposed on the service po
 
 ### gRPC
 
-Flagd exposes a [standard gRPC health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) on the service port (default: 8013).
+Flagd exposes a [standard gRPC liveness check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) on the service port (default: 8013).
 
 ### Definition of Liveness
 

--- a/flagd-proxy/build.Dockerfile
+++ b/flagd-proxy/build.Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,source=./core,target=./core \
     --mount=type=bind,source=./flagd,target=./flagd \
     --mount=type=bind,source=./flagd-proxy,target=./flagd-proxy \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-proxy flagd-proxy/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-proxy flagd-proxy/main.go
 
 # # Use distroless as minimal base image to package the manager binary
 # # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/flagd/build.Dockerfile
+++ b/flagd/build.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=./core,target=./core \
     --mount=type=bind,source=./flagd,target=./flagd \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build flagd/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build flagd/main.go
 
 # # Use distroless as minimal base image to package the manager binary
 # # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/flagd/build.Dockerfile
+++ b/flagd/build.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=./core,target=./core \
     --mount=type=bind,source=./flagd,target=./flagd \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build flagd/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build flagd/main.go
 
 # # Use distroless as minimal base image to package the manager binary
 # # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/flagd/go.mod
+++ b/flagd/go.mod
@@ -18,6 +18,8 @@ require (
 	buf.build/gen/go/open-feature/flagd/bufbuild/connect-go v1.9.0-20230720212818-3675556880a1.1 // indirect
 	buf.build/gen/go/open-feature/flagd/grpc/go v1.3.0-20230710190440-2333a9579c1a.1 // indirect
 	buf.build/gen/go/open-feature/flagd/protocolbuffers/go v1.31.0-20230720212818-3675556880a1.1 // indirect
+	connectrpc.com/connect v1.11.0 // indirect
+	connectrpc.com/grpchealth v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bufbuild/connect-go v1.10.0 // indirect
 	github.com/bufbuild/connect-opentelemetry-go v0.4.0 // indirect

--- a/flagd/go.sum
+++ b/flagd/go.sum
@@ -404,6 +404,10 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
 cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
+connectrpc.com/connect v1.11.0 h1:Av2KQXxSaX4vjqhf5Cl01SX4dqYADQ38eBtr84JSUBk=
+connectrpc.com/connect v1.11.0/go.mod h1:3AGaO6RRGMx5IKFfqbe3hvK1NqLosFNP2BxDYTPmNPo=
+connectrpc.com/grpchealth v1.2.0 h1:aHP33Bki+F2jPNI1mFVSFG7v0qJrgmfbg7X7nOdSj0M=
+connectrpc.com/grpchealth v1.2.0/go.mod h1:fZos12C4p/ZaZC6OwBGZUM+i/fhnRhv75ax/6V/zIeM=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/flagd/profile.Dockerfile
+++ b/flagd/profile.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=./core,target=./core \
     --mount=type=bind,source=./flagd,target=./flagd \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build ./flagd/main.go ./flagd/profiler.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build ./flagd/main.go ./flagd/profiler.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/flagd/profile.Dockerfile
+++ b/flagd/profile.Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=./core,target=./core \
     --mount=type=bind,source=./flagd,target=./flagd \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build ./flagd/main.go ./flagd/profiler.go
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" -o /bin/flagd-build ./flagd/main.go ./flagd/profiler.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/web-docs/concepts/architecture.md
+++ b/web-docs/concepts/architecture.md
@@ -33,13 +33,18 @@ process gets pushed to event subscribers.
 
 ## Readiness & Liveness probes
 
+### HTTP
+
 Flagd exposes HTTP liveness and readiness probes.
 These probes can be used for K8s deployments.
-With default
-start-up configurations, these probes are exposed at the following URLs,
+With default start-up configurations, these probes are exposed on the service port (default: 8013) at the following URLs,
 
-- Liveness: <http://localhost:8014/healthz>
-- Readiness: <http://localhost:8014/readyz>
+- Liveness: <http://localhost:8013/healthz>
+- Readiness: <http://localhost:8013/readyz>
+
+### gRPC
+
+Flagd exposes a [standard gRPC liveness check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) on the service port (default: 8013).
 
 ### Definition of Liveness
 


### PR DESCRIPTION
* adds a standard gRPC health check
* moves HTTP health checks off the metrics port, to the app port (we previously hadn't documented the health-checks are controlled by the metrics port config)
* deprecates old health checks on metrics port (logs warning)

fixes: https://github.com/open-feature/flagd/issues/831