### PR TITLE
chore: deprecate fractionalEvaluation for fractional

### DIFF
--- a/core/pkg/eval/fractional_evaluation.go
+++ b/core/pkg/eval/fractional_evaluation.go
@@ -9,6 +9,8 @@ import (
 	"github.com/twmb/murmur3"
 )
 
+const FractionEvaluationName = "fractional"
+
 type FractionalEvaluator struct {
 	Logger *logger.Logger
 }

--- a/core/pkg/eval/json_evaluator.go
+++ b/core/pkg/eval/json_evaluator.go
@@ -331,7 +331,7 @@ func (je *JSONEvaluator) evaluateVariant(reqID string, flagKey string, context m
 		}
 
 		var result bytes.Buffer
-		// evaluate json-logic rules to determine the variant
+		// evaluate JsonLogic rules to determine the variant
 		err = jsonlogic.Apply(bytes.NewReader(targetingBytes), bytes.NewReader(b), &result)
 		if err != nil {
 			je.Logger.ErrorWithID(reqID, fmt.Sprintf("error applying rules: %s", err))

--- a/core/pkg/eval/legacy_fractional_evaluation.go
+++ b/core/pkg/eval/legacy_fractional_evaluation.go
@@ -1,0 +1,138 @@
+// This evaluation type is deprecated and will be removed before v1
+// Do not enhance it or us it for reference.
+
+package eval
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"github.com/zeebo/xxh3"
+)
+
+const LegacyFractionEvaluationName = "fractionalEvaluation"
+const LegacyFractionEvaluationLink = "https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation"
+
+type LegacyFractionalEvaluator struct {
+	Logger *logger.Logger
+}
+
+type legacyFractionalEvaluationDistribution struct {
+	variant    string
+	percentage int
+}
+
+func NewLegacyFractionalEvaluator(logger *logger.Logger) *LegacyFractionalEvaluator {
+	return &LegacyFractionalEvaluator{Logger: logger}
+}
+
+func (fe *LegacyFractionalEvaluator) LegacyFractionalEvaluation(values, data interface{}) interface{} {
+	fe.Logger.Warn(
+		fmt.Sprintf("%s is deprecated, please use %s, see: %s",
+			LegacyFractionEvaluationName,
+			FractionEvaluationName,
+			LegacyFractionEvaluationLink))
+
+	valueToDistribute, feDistributions, err := parseLegacyFractionalEvaluationData(values, data)
+	if err != nil {
+		fe.Logger.Error(fmt.Sprintf("parse fractional evaluation data: %v", err))
+		return nil
+	}
+
+	return distributeLegacyValue(valueToDistribute, feDistributions)
+}
+
+func parseLegacyFractionalEvaluationData(values, data interface{}) (string, []legacyFractionalEvaluationDistribution, error) {
+	valuesArray, ok := values.([]interface{})
+	if !ok {
+		return "", nil, errors.New("fractional evaluation data is not an array")
+	}
+	if len(valuesArray) < 2 {
+		return "", nil, errors.New("fractional evaluation data has length under 2")
+	}
+
+	bucketBy, ok := valuesArray[0].(string)
+	if !ok {
+		return "", nil, errors.New("first element of fractional evaluation data isn't of type string")
+	}
+
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return "", nil, errors.New("data isn't of type map[string]interface{}")
+	}
+
+	v, ok := dataMap[bucketBy]
+	if !ok {
+		return "", nil, nil
+	}
+
+	valueToDistribute, ok := v.(string)
+	if !ok {
+		return "", nil, fmt.Errorf("var: %s isn't of type string", bucketBy)
+	}
+
+	feDistributions, err := parseLegacyFractionalEvaluationDistributions(valuesArray)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return valueToDistribute, feDistributions, nil
+}
+
+func parseLegacyFractionalEvaluationDistributions(values []interface{}) ([]legacyFractionalEvaluationDistribution, error) {
+	sumOfPercentages := 0
+	var feDistributions []legacyFractionalEvaluationDistribution
+	for i := 1; i < len(values); i++ {
+		distributionArray, ok := values[i].([]interface{})
+		if !ok {
+			return nil, errors.New("distribution elements aren't of type []interface{}")
+		}
+
+		if len(distributionArray) != 2 {
+			return nil, errors.New("distribution element isn't length 2")
+		}
+
+		variant, ok := distributionArray[0].(string)
+		if !ok {
+			return nil, errors.New("first element of distribution element isn't string")
+		}
+
+		percentage, ok := distributionArray[1].(float64)
+		if !ok {
+			return nil, errors.New("second element of distribution element isn't float")
+		}
+
+		sumOfPercentages += int(percentage)
+
+		feDistributions = append(feDistributions, legacyFractionalEvaluationDistribution{
+			variant:    variant,
+			percentage: int(percentage),
+		})
+	}
+
+	if sumOfPercentages != 100 {
+		return nil, fmt.Errorf("percentages must sum to 100, got: %d", sumOfPercentages)
+	}
+
+	return feDistributions, nil
+}
+
+func distributeLegacyValue(value string, feDistribution []legacyFractionalEvaluationDistribution) string {
+	hashValue := xxh3.HashString(value)
+
+	hashRatio := float64(hashValue) / math.Pow(2, 64) // divide the hash value by the largest possible value, integer 2^64
+
+	bucket := int(hashRatio * 100) // integer in range [0, 99]
+
+	rangeEnd := 0
+	for _, dist := range feDistribution {
+		rangeEnd += dist.percentage
+		if bucket < rangeEnd {
+			return dist.variant
+		}
+	}
+
+	return ""
+}

--- a/core/pkg/eval/legacy_fractional_evaluation.go
+++ b/core/pkg/eval/legacy_fractional_evaluation.go
@@ -12,8 +12,10 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
-const LegacyFractionEvaluationName = "fractionalEvaluation"
-const LegacyFractionEvaluationLink = "https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation"
+const (
+	LegacyFractionEvaluationName = "fractionalEvaluation"
+	LegacyFractionEvaluationLink = "https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation"
+)
 
 type LegacyFractionalEvaluator struct {
 	Logger *logger.Logger
@@ -44,7 +46,9 @@ func (fe *LegacyFractionalEvaluator) LegacyFractionalEvaluation(values, data int
 	return distributeLegacyValue(valueToDistribute, feDistributions)
 }
 
-func parseLegacyFractionalEvaluationData(values, data interface{}) (string, []legacyFractionalEvaluationDistribution, error) {
+func parseLegacyFractionalEvaluationData(values, data interface{}) (string,
+	[]legacyFractionalEvaluationDistribution, error,
+) {
 	valuesArray, ok := values.([]interface{})
 	if !ok {
 		return "", nil, errors.New("fractional evaluation data is not an array")
@@ -81,7 +85,9 @@ func parseLegacyFractionalEvaluationData(values, data interface{}) (string, []le
 	return valueToDistribute, feDistributions, nil
 }
 
-func parseLegacyFractionalEvaluationDistributions(values []interface{}) ([]legacyFractionalEvaluationDistribution, error) {
+func parseLegacyFractionalEvaluationDistributions(values []interface{}) (
+	[]legacyFractionalEvaluationDistribution, error,
+) {
 	sumOfPercentages := 0
 	var feDistributions []legacyFractionalEvaluationDistribution
 	for i := 1; i < len(values); i++ {

--- a/core/pkg/eval/legacy_fractional_evaluation.go
+++ b/core/pkg/eval/legacy_fractional_evaluation.go
@@ -1,5 +1,5 @@
-// This evaluation type is deprecated and will be removed before v1
-// Do not enhance it or us it for reference.
+// This evaluation type is deprecated and will be removed before v1.
+// Do not enhance it or use it for reference.
 
 package eval
 

--- a/core/pkg/eval/legacy_fractional_evaluation.go
+++ b/core/pkg/eval/legacy_fractional_evaluation.go
@@ -17,6 +17,7 @@ const (
 	LegacyFractionEvaluationLink = "https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation"
 )
 
+// Deprecated: LegacyFractionalEvaluator is deprecated. This will be removed prior to v1 release.
 type LegacyFractionalEvaluator struct {
 	Logger *logger.Logger
 }

--- a/core/pkg/eval/semver_evaluation.go
+++ b/core/pkg/eval/semver_evaluation.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const SemVerEvaluationName = "sem_ver"
+
 type SemVerOperator string
 
 const (

--- a/core/pkg/eval/semver_evaluation_test.go
+++ b/core/pkg/eval/semver_evaluation_test.go
@@ -701,7 +701,7 @@ func TestJSONEvaluator_semVerEvaluation(t *testing.T) {
 				log,
 				store.NewFlags(),
 				WithEvaluator(
-					"sem_ver",
+					SemVerEvaluationName,
 					NewSemVerComparisonEvaluator(log).SemVerEvaluation,
 				),
 			)

--- a/core/pkg/eval/string_comparison_evaluation.go
+++ b/core/pkg/eval/string_comparison_evaluation.go
@@ -8,6 +8,9 @@ import (
 	"github.com/open-feature/flagd/core/pkg/logger"
 )
 
+const StartsWithEvaluationName = "starts_with"
+const EndsWithEvaluationName = "ends_with"
+
 type StringComparisonEvaluator struct {
 	Logger *logger.Logger
 }

--- a/core/pkg/eval/string_comparison_evaluation.go
+++ b/core/pkg/eval/string_comparison_evaluation.go
@@ -8,8 +8,10 @@ import (
 	"github.com/open-feature/flagd/core/pkg/logger"
 )
 
-const StartsWithEvaluationName = "starts_with"
-const EndsWithEvaluationName = "ends_with"
+const (
+	StartsWithEvaluationName = "starts_with"
+	EndsWithEvaluationName   = "ends_with"
+)
 
 type StringComparisonEvaluator struct {
 	Logger *logger.Logger

--- a/core/pkg/eval/string_comparison_evaluation_test.go
+++ b/core/pkg/eval/string_comparison_evaluation_test.go
@@ -185,7 +185,7 @@ func TestJSONEvaluator_startsWithEvaluation(t *testing.T) {
 				log,
 				store.NewFlags(),
 				WithEvaluator(
-					"starts_with",
+					StartsWithEvaluationName,
 					NewStringComparisonEvaluator(log).StartsWithEvaluation,
 				),
 			)
@@ -387,7 +387,7 @@ func TestJSONEvaluator_endsWithEvaluation(t *testing.T) {
 				log,
 				store.NewFlags(),
 				WithEvaluator(
-					"ends_with",
+					EndsWithEvaluationName,
 					NewStringComparisonEvaluator(log).EndsWithEvaluation,
 				),
 			)

--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -151,20 +151,25 @@ func setupJSONEvaluator(logger *logger.Logger, s *store.Flags) *eval.JSONEvaluat
 		logger,
 		s,
 		eval.WithEvaluator(
-			"fractionalEvaluation",
+			eval.FractionEvaluationName,
 			eval.NewFractionalEvaluator(logger).FractionalEvaluation,
 		),
 		eval.WithEvaluator(
-			"starts_with",
+			eval.StartsWithEvaluationName,
 			eval.NewStringComparisonEvaluator(logger).StartsWithEvaluation,
 		),
 		eval.WithEvaluator(
-			"ends_with",
+			eval.EndsWithEvaluationName,
 			eval.NewStringComparisonEvaluator(logger).EndsWithEvaluation,
 		),
 		eval.WithEvaluator(
-			"sem_ver",
+			eval.SemVerEvaluationName,
 			eval.NewSemVerComparisonEvaluator(logger).SemVerEvaluation,
+		),
+		// deprecated: will be removed before v1!
+		eval.WithEvaluator(
+			eval.LegacyFractionEvaluationName,
+			eval.NewLegacyFractionalEvaluator(logger).LegacyFractionalEvaluation,
 		),
 	)
 	return evaluator

--- a/docs/configuration/fractional_evaluation.md
+++ b/docs/configuration/fractional_evaluation.md
@@ -120,7 +120,7 @@ The only way to get a different value is to change the email or update the `frac
 
 If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
 The new `fractional` evaluator supports nested properties and json-logic expressions.
-To migrate, simple use a json-logic variable declaration for the bucketing property, instead of a string:
+To migrate, simply use a json-logic variable declaration for the bucketing property, instead of a string:
 
 old:
 

--- a/docs/configuration/fractional_evaluation.md
+++ b/docs/configuration/fractional_evaluation.md
@@ -12,7 +12,7 @@ Importantly, the evaluations are "sticky" meaning that the same `email` address 
 
 ## Fractional Evaluation: Technical Description
 
-The `fractionalEvaluation` operation is a custom JsonLogic operation which deterministically selects a variant based on
+The `fractional` operation is a custom JsonLogic operation which deterministically selects a variant based on
 the defined distribution of each variant (as a percentage).
 This works by hashing ([murmur3](https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp))
 the given data point, converting it into an int in the range [0, 99].
@@ -22,7 +22,7 @@ As hashing is deterministic we can be sure to get the same result every time for
 
 ## Fractional evaluation configuration
 
-The `fractionalEvaluation` can be added as part of a targeting definition.
+The `fractional` operation can be added as part of a targeting definition.
 The value is an array and the first element is the name of the property to use from the evaluation context.
 This value should typically be something that remains consistent for the duration of a users session (e.g. email or session ID).
 The other elements in the array are nested arrays with the first element representing a variant and the second being the percentage that this option is selected.
@@ -30,9 +30,9 @@ There is no limit to the number of elements but the configured percentages must 
 
 ```js
 // Factional evaluation property name used in a targeting rule
-"fractionalEvaluation": [
+"fractional": [
   // Evaluation context property used to determine the split
-  "email",
+  { "var": "email" },
   // Split definitions contain an array with a variant and percentage
   // Percentages must add up to 100
   [
@@ -66,8 +66,8 @@ Flags defined as such:
       "defaultVariant": "red",
       "state": "ENABLED",
       "targeting": {
-        "fractionalEvaluation": [
-          "email",
+        "fractional": [
+          { "var": "email" },
           [
             "red",
             50
@@ -114,4 +114,28 @@ Result:
 ```
 
 Notice that rerunning either curl command will always return the same variant and value.
-The only way to get a different value is to change the email or update the `fractionalEvaluation` configuration.
+The only way to get a different value is to change the email or update the `fractional` configuration.
+
+### Migrating from legacy fractionalEvaluation
+
+If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
+The new `fractional` evaluator supports nested properties and json-logic expressions.
+To migrate, simple use a json-logic variable declaration for the bucketing property, instead of a string:
+
+old:
+
+```json
+"fractionalEvaluation": [
+    "email",
+    [ "red", 25 ], [ "blue", 25 ], [ "green", 25 ], [ "yellow", 25 ]
+]
+```
+
+new:
+
+```json
+"fractional": [
+    { "var": "email" },
+    [ "red", 25 ], [ "blue", 25 ], [ "green", 25 ], [ "yellow", 25 ]
+]
+```

--- a/docs/configuration/fractional_evaluation.md
+++ b/docs/configuration/fractional_evaluation.md
@@ -122,8 +122,8 @@ The only way to get a different value is to change the email or update the `frac
 ### Migrating from legacy fractionalEvaluation
 
 If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
-The new `fractional` evaluator supports nested properties and json-logic expressions.
-To migrate, simply use a json-logic variable declaration for the bucketing property, instead of a string:
+The new `fractional` evaluator supports nested properties and JsonLogic expressions.
+To migrate, simply use a JsonLogic variable declaration for the bucketing property, instead of a string:
 
 old:
 

--- a/docs/configuration/fractional_evaluation.md
+++ b/docs/configuration/fractional_evaluation.md
@@ -4,11 +4,14 @@ OpenFeature allows clients to pass contextual information which can then be used
 
 In some scenarios, it is desirable to use that contextual information to segment the user population further and thus return dynamic values.
 
-Look at the [headerColor](https://github.com/open-feature/flagd/blob/main/samples/example_flags.flagd.json#L88-#L133) flag. The `defaultVariant` is `red`, but it contains a [targeting rule](reusable_targeting_rules.md), meaning a fractional evaluation occurs for flag evaluation with a `context` object containing `email` and where that `email` value contains `@faas.com`.
+See the [headerColor](https://github.com/open-feature/flagd/blob/main/samples/example_flags.flagd.json#L88-#L133) flag.
+The `defaultVariant` is `red`, but it contains a [targeting rule](reusable_targeting_rules.md), meaning a fractional evaluation occurs for flag evaluation with a `context` object containing `email` and where that `email` value contains `@faas.com`.
 
-In this case, `25%` of the email addresses will receive `red`, `25%` will receive `blue`, and so on.
+In this case, `25%` of the evaluations will receive `red`, `25%` will receive `blue`, and so on.
 
-Importantly, the evaluations are "sticky" meaning that the same `email` address will always belong to the same "bucket" and thus always receive the same color.
+Assignment is deterministic (sticky) based on the expression supplied as the first parameter (`{ "var": "email" }`, in this case).
+The value retrieved by this expression is referred to as the "bucketing value".
+The bucketing value expression can be omitted, in which case a concatenation of the `targetingKey` and the `flagKey` will be used.
 
 ## Fractional Evaluation: Technical Description
 

--- a/web-docs/concepts/index.md
+++ b/web-docs/concepts/index.md
@@ -186,7 +186,7 @@ See this page for more information on [flagd fractional evaluation logic](https:
 
 If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
 The new `fractional` evaluator supports nested properties and json-logic expressions.
-To migrate, simple use a json-logic variable declaration for the bucketing property, instead of a string:
+To migrate, simply use a json-logic variable declaration for the bucketing property, instead of a string:
 
 old:
 

--- a/web-docs/concepts/index.md
+++ b/web-docs/concepts/index.md
@@ -186,8 +186,8 @@ See this page for more information on [flagd fractional evaluation logic](https:
 ### Migrating from legacy fractionalEvaluation
 
 If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
-The new `fractional` evaluator supports nested properties and json-logic expressions.
-To migrate, simply use a json-logic variable declaration for the bucketing property, instead of a string:
+The new `fractional` evaluator supports nested properties and JsonLogic expressions.
+To migrate, simply use a JsonLogic variable declaration for the bucketing property, instead of a string:
 
 old:
 

--- a/web-docs/concepts/index.md
+++ b/web-docs/concepts/index.md
@@ -175,10 +175,11 @@ In this case, `25%` of the email addresses will receive `red`, `25%` will receiv
 ### Fractional evaluations are sticky
 
 Fractional evaluations are "sticky" (deterministic) meaning that the same email address will always belong to the same "bucket" and thus always receive the same color.
-This is true even if you run multiple flagd APIs completely independently.
+This is true even if you run multiple flagd instances completely independently.
 
-Note that the first argument to the `fractional` operator specifies the *bucketing value*.
+Note that the first argument to the `fractional` operator is an expression specifying the *bucketing value*.
 This value is used as input to the bucketing algorithm to ensure a deterministic result.
+This argument can be omitted, in which case a concatenation of the `targetingKey` and the `flagKey` will be used as the bucketing value.
 
 See this page for more information on [flagd fractional evaluation logic](https://github.com/open-feature/flagd/blob/main/docs/configuration/fractional_evaluation.md).
 

--- a/web-docs/concepts/index.md
+++ b/web-docs/concepts/index.md
@@ -160,7 +160,8 @@ In this case, `25%` of the email addresses will receive `red`, `25%` will receiv
                     }
                 },
                 {
-                    "fractionalEvaluation": [ "email",
+                    "fractional": [
+                        { "var": "email" },
                         [ "red", 25 ], [ "blue", 25 ], [ "green", 25 ], [ "yellow", 25 ]
                     ]
                 }, null
@@ -173,11 +174,37 @@ In this case, `25%` of the email addresses will receive `red`, `25%` will receiv
 
 ### Fractional evaluations are sticky
 
-Fractional evaluations are "sticky" and deterministic meaning that the same email address will always belong to the same "bucket" and thus always receive the same color.
-
+Fractional evaluations are "sticky" (deterministic) meaning that the same email address will always belong to the same "bucket" and thus always receive the same color.
 This is true even if you run multiple flagd APIs completely independently.
 
+Note that the first argument to the `fractional` operator specifies the *bucketing value*.
+This value is used as input to the bucketing algorithm to ensure a deterministic result.
+
 See this page for more information on [flagd fractional evaluation logic](https://github.com/open-feature/flagd/blob/main/docs/configuration/fractional_evaluation.md).
+
+### Migrating from legacy fractionalEvaluation
+
+If you are using a legacy fractional evaluation (`fractionalEvaluation`), it's recommended you migrate to `fractional`.
+The new `fractional` evaluator supports nested properties and json-logic expressions.
+To migrate, simple use a json-logic variable declaration for the bucketing property, instead of a string:
+
+old:
+
+```json
+"fractionalEvaluation": [
+    "email",
+    [ "red", 25 ], [ "blue", 25 ], [ "green", 25 ], [ "yellow", 25 ]
+]
+```
+
+new:
+
+```json
+"fractional": [
+    { "var": "email" },
+    [ "red", 25 ], [ "blue", 25 ], [ "green", 25 ], [ "yellow", 25 ]
+]
+```
 
 ## Other target specifiers
 


### PR DESCRIPTION
* deprecates fractionalEvaluation in favor of fractional
* adds evaluation names to their implementations to bind them more closely

```
2023-08-28T19:22:53.098-0400    warn    eval/legacy_fractional_evaluation.go:32 fractionalEvaluation is deprecated, please use fractional, see: https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation
```

cc @craigpastro 

fixes: https://github.com/open-feature/flagd/issues/871