### PR TITLE
fix: use 32bit murmur calculation (64 is not stable)

### DIFF
--- a/core/pkg/eval/fractional_evaluation.go
+++ b/core/pkg/eval/fractional_evaluation.go
@@ -108,12 +108,11 @@ func parseFractionalEvaluationDistributions(values []any) ([]fractionalEvaluatio
 	return feDistributions, nil
 }
 
+// distributeValue calculate hash for given hash key and find the bucket distributions belongs to
 func distributeValue(value string, feDistribution []fractionalEvaluationDistribution) string {
-	hashValue := murmur3.StringSum64(value)
-
-	hashRatio := float64(hashValue) / math.MaxUint64
-
-	bucket := int(hashRatio * 100) // integer in range [0, 99]
+	hashValue := int32(murmur3.StringSum32(value))
+	hashRatio := math.Abs(float64(hashValue)) / math.MaxInt32
+	bucket := int(hashRatio * 100) // in range [0, 100]
 
 	rangeEnd := 0
 	for _, dist := range feDistribution {

--- a/core/pkg/eval/fractional_evaluation_test.go
+++ b/core/pkg/eval/fractional_evaluation_test.go
@@ -79,8 +79,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"email": "monica@faas.com",
 			},
-			expectedVariant: "green",
-			expectedValue:   "#00FF00",
+			expectedVariant: "blue",
+			expectedValue:   "#0000FF",
 			expectedReason:  model.TargetingMatchReason,
 		},
 		"joey@faas.com": {
@@ -89,8 +89,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"email": "joey@faas.com",
 			},
-			expectedVariant: "blue",
-			expectedValue:   "#0000FF",
+			expectedVariant: "red",
+			expectedValue:   "#FF0000",
 			expectedReason:  model.TargetingMatchReason,
 		},
 		"ross@faas.com": {
@@ -99,8 +99,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"email": "ross@faas.com",
 			},
-			expectedVariant: "red",
-			expectedValue:   "#FF0000",
+			expectedVariant: "green",
+			expectedValue:   "#00FF00",
 			expectedReason:  model.TargetingMatchReason,
 		},
 		"ross@faas.com with different flag key": {
@@ -152,8 +152,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"email": "ross@faas.com",
 			},
-			expectedVariant: "blue",
-			expectedValue:   "#0000FF",
+			expectedVariant: "red",
+			expectedValue:   "#FF0000",
 			expectedReason:  model.TargetingMatchReason,
 		},
 		"non even split": {
@@ -201,8 +201,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"email": "test4@faas.com",
 			},
-			expectedVariant: "green",
-			expectedValue:   "#00FF00",
+			expectedVariant: "red",
+			expectedValue:   "#FF0000",
 			expectedReason:  model.TargetingMatchReason,
 		},
 		"fallback to default variant if no email provided": {
@@ -346,8 +346,8 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"targetingKey": "foo@foo.com",
 			},
-			expectedVariant: "green",
-			expectedValue:   "#00FF00",
+			expectedVariant: "blue",
+			expectedValue:   "#0000FF",
 			expectedReason:  model.TargetingMatchReason,
 		},
 	}

--- a/docs/other_resources/in-process-providers/evaluators/fractional_evaluation.md
+++ b/docs/other_resources/in-process-providers/evaluators/fractional_evaluation.md
@@ -168,8 +168,8 @@ func FractionalEvaluation(values, data interface{}) interface{} {
         return nil
     }
 
-    // 4. Calculate the hash of the target property and map it to a number between [0, 99]
-	hashValue := int32(murmur3.StringSum32(value))
+    // 4. Calculate the hash of the target property and map it to a number between [0, 99] 
+    hashValue := int32(murmur3.StringSum32(value))
     hashRatio := math.Abs(float64(hashValue)) / math.MaxInt32
     bucket := int(hashRatio * 100)
 

--- a/docs/other_resources/in-process-providers/evaluators/fractional_evaluation.md
+++ b/docs/other_resources/in-process-providers/evaluators/fractional_evaluation.md
@@ -169,12 +169,8 @@ func FractionalEvaluation(values, data interface{}) interface{} {
     }
 
     // 4. Calculate the hash of the target property and map it to a number between [0, 99]
-    hashValue := murmur3.HashString(value)
-
-    // divide the hash value by the largest possible value, integer 2^64
-    hashRatio := float64(hashValue) / math.Pow(2, 64)
-
-    // integer in range [0, 99]
+	hashValue := int32(murmur3.StringSum32(value))
+    hashRatio := math.Abs(float64(hashValue)) / math.MaxInt32
     bucket := int(hashRatio * 100)
 
     // 5. Iterate through the variant and increment the threshold by the percentage of each variant.


### PR DESCRIPTION
## This PR

Fixes murmur3 hash calculation to be cross language compatible.

See PR discussion here for more details - https://github.com/open-feature/java-sdk-contrib/pull/434

Depends on flagd-testbed PR - https://github.com/open-feature/flagd-testbed/pull/65 