### PR TITLE
feat: added management port configuration (#867)

### DIFF
--- a/core/pkg/runtime/from_config.go
+++ b/core/pkg/runtime/from_config.go
@@ -60,7 +60,7 @@ type SourceConfig struct {
 // Config is the configuration structure derived from startup arguments.
 type Config struct {
 	MetricExporter    string
-	MetricsPort       uint16
+	ManagementPort    uint16
 	OtelCollectorURI  string
 	ServiceCertPath   string
 	ServiceKeyPath    string

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -19,7 +19,7 @@ const (
 	evaluatorFlagName      = "evaluator"
 	logFormatFlagName      = "log-format"
 	metricsExporter        = "metrics-exporter"
-	metricsPortFlagName    = "metrics-port"
+	managementPortFlagName = "management-port"
 	otelCollectorURI       = "otel-collector-uri"
 	portFlagName           = "port"
 	providerArgsFlagName   = "sync-provider-args"
@@ -30,8 +30,9 @@ const (
 	syncProviderFlagName   = "sync-provider"
 	uriFlagName            = "uri"
 
-	defaultServicePort = 8013
-	defaultMetricsPort = 8014
+	defaultServicePort    = 8013
+	defaultMetricsPort    = 8014
+	defaultManagementPort = 8015
 )
 
 func init() {
@@ -40,7 +41,7 @@ func init() {
 	// allows environment variables to use _ instead of -
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_")) // sync-provider-args becomes SYNC_PROVIDER_ARGS
 	viper.SetEnvPrefix("FLAGD")                            // port becomes FLAGD_PORT
-	flags.Int32P(metricsPortFlagName, "m", defaultMetricsPort, "Port to serve metrics on")
+	flags.Int32P(managementPortFlagName, "M", defaultManagementPort, "Port for management operations")
 	flags.Int32P(portFlagName, "p", defaultServicePort, "Port to listen on")
 	flags.StringP(socketPathFlagName, "d", "", "Flagd socket path. "+
 		"With grpc the service will become available on this address. "+
@@ -81,7 +82,7 @@ func init() {
 	_ = viper.BindPFlag(evaluatorFlagName, flags.Lookup(evaluatorFlagName))
 	_ = viper.BindPFlag(logFormatFlagName, flags.Lookup(logFormatFlagName))
 	_ = viper.BindPFlag(metricsExporter, flags.Lookup(metricsExporter))
-	_ = viper.BindPFlag(metricsPortFlagName, flags.Lookup(metricsPortFlagName))
+	_ = viper.BindPFlag(managementPortFlagName, flags.Lookup(managementPortFlagName))
 	_ = viper.BindPFlag(otelCollectorURI, flags.Lookup(otelCollectorURI))
 	_ = viper.BindPFlag(portFlagName, flags.Lookup(portFlagName))
 	_ = viper.BindPFlag(providerArgsFlagName, flags.Lookup(providerArgsFlagName))
@@ -154,10 +155,10 @@ var startCmd = &cobra.Command{
 		rt, err := runtime.FromConfig(logger, Version, runtime.Config{
 			CORS:           viper.GetStringSlice(corsFlagName),
 			MetricExporter: viper.GetString(metricsExporter),
-			MetricsPort: getPortValueOrDefault(
-				metricsPortFlagName,
-				viper.GetUint16(metricsPortFlagName),
-				defaultMetricsPort,
+			ManagementPort: getPortValueOrDefault(
+				managementPortFlagName,
+				viper.GetUint16(managementPortFlagName),
+				defaultMetricsPort, // If managementPort is unspecified, it defaults use metricsPort
 				rtLogger,
 			),
 			OtelCollectorURI: viper.GetString(otelCollectorURI),


### PR DESCRIPTION
Fixes [#867](https://github.com/open-feature/flagd/issues/867)

-  If 'managementPort' is not specified, it will use 'metricsPort' as the default.
- Removed the reference to 'MetricsPort' and added 'ManagementPort' in the 'core/pkg/runtime/from_config.go' file to align with the updated configuration structure.
- Seeking assistance to incorporate a deprecation warning.
