### PR TITLE
fix: erroneous warning about prop overwrite

### DIFF
--- a/core/pkg/eval/json_evaluator.go
+++ b/core/pkg/eval/json_evaluator.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -362,13 +363,15 @@ func (je *JSONEvaluator) setFlagdProperties(
 		context = map[string]any{}
 	}
 
-	if _, ok := context[flagdPropertiesKey]; ok {
+	newContext := maps.Clone(context)
+
+	if _, ok := newContext[flagdPropertiesKey]; ok {
 		je.Logger.Warn("overwriting $flagd properties in the context")
 	}
 
-	context[flagdPropertiesKey] = properties
+	newContext[flagdPropertiesKey] = properties
 
-	return context
+	return newContext
 }
 
 func getFlagdProperties(context map[string]any) (flagdProperties, bool) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

When adding flagdProperties to the context in preparation for evaluation return a new context so that it doesn't affect any references to the current context.

Without this change:
```
$ make run
make run-flagd
cd flagd; go run main.go start -f file:../config/samples/example_flags.flagd.json

                 ______   __       ________   _______    ______      
                /_____/\ /_/\     /_______/\ /______/\  /_____/\     
                \::::_\/_\:\ \    \::: _  \ \\::::__\/__\:::_ \ \    
                 \:\/___/\\:\ \    \::(_)  \ \\:\ /____/\\:\ \ \ \   
                  \:::._\/ \:\ \____\:: __  \ \\:\\_  _\/ \:\ \ \ \  
                   \:\ \    \:\/___/\\:.\ \  \ \\:\_\ \ \  \:\/.:| | 
                    \_\/     \_____\/ \__\/\__\/ \_____\/   \____/_/ 

2023-09-18T19:16:39.581-0700    info    cmd/start.go:117        flagd version: dev (HEAD), built at: unknown    {"component": "start"}
2023-09-18T19:16:39.581-0700    info    file/filepath_sync.go:37        Starting filepath sync notifier {"component": "sync", "sync": "filepath"}
2023-09-18T19:16:39.582-0700    info    flag-evaluation/connect_service.go:203  metrics and probes listening at 8014    {"component": "service"}
2023-09-18T19:16:39.582-0700    info    file/filepath_sync.go:66        watching filepath: ../config/samples/example_flags.flagd.json       {"component": "sync", "sync": "filepath"}
2023-09-18T19:16:39.582-0700    info    flag-evaluation/connect_service.go:183  Flag Evaluation listening at [::]:8013  {"component": "service"}
2023-09-18T19:16:41.258-0700    warn    eval/json_evaluator.go:368      overwriting $flagd properties in the context    {"component": "evaluator", "evaluator": "json"}
2023-09-18T19:16:41.259-0700    warn    eval/json_evaluator.go:368      overwriting $flagd properties in the context    {"component": "evaluator", "evaluator": "json"}
2023-09-18T19:16:41.259-0700    warn    eval/legacy_fractional_evaluation.go:35 fractionalEvaluation is deprecated, please use fractional, see: https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation
2023-09-18T19:16:41.259-0700    warn    eval/json_evaluator.go:368      overwriting $flagd properties in the context    {"component": "evaluator", "evaluator": "json"}
```

With this change:
```
$ make run
make run-flagd
cd flagd; go run main.go start -f file:../config/samples/example_flags.flagd.json

                 ______   __       ________   _______    ______      
                /_____/\ /_/\     /_______/\ /______/\  /_____/\     
                \::::_\/_\:\ \    \::: _  \ \\::::__\/__\:::_ \ \    
                 \:\/___/\\:\ \    \::(_)  \ \\:\ /____/\\:\ \ \ \   
                  \:::._\/ \:\ \____\:: __  \ \\:\\_  _\/ \:\ \ \ \  
                   \:\ \    \:\/___/\\:.\ \  \ \\:\_\ \ \  \:\/.:| | 
                    \_\/     \_____\/ \__\/\__\/ \_____\/   \____/_/ 

2023-09-18T19:20:29.011-0700    info    cmd/start.go:117        flagd version: dev (HEAD), built at: unknown    {"component": "start"}
2023-09-18T19:20:29.012-0700    info    file/filepath_sync.go:37        Starting filepath sync notifier {"component": "sync", "sync": "filepath"}
2023-09-18T19:20:29.013-0700    info    flag-evaluation/connect_service.go:203  metrics and probes listening at 8014    {"component": "service"}
2023-09-18T19:20:29.013-0700    info    flag-evaluation/connect_service.go:183  Flag Evaluation listening at [::]:8013  {"component": "service"}
2023-09-18T19:20:29.014-0700    info    file/filepath_sync.go:66        watching filepath: ../config/samples/example_flags.flagd.json       {"component": "sync", "sync": "filepath"}
2023-09-18T19:20:32.784-0700    warn    eval/legacy_fractional_evaluation.go:35 fractionalEvaluation is deprecated, please use fractional, see: https://flagd.dev/concepts/#migrating-from-legacy-fractionalevaluation
```

Both logs were triggered by the request in the bug report:
```
$ curl -X POST "http://localhost:8013/schema.v1.Service/ResolveAll" \
  -d '{"context":{}}' -H "Content-Type: application/json"
```

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #923.

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

