### PR TITLE
chore: deployment

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,10 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - tables
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 nav:
   - 'Getting started': 'index.md'

--- a/web-docs/deployment.md
+++ b/web-docs/deployment.md
@@ -1,0 +1,66 @@
+# Docker
+
+<!-- x-release-please-start-version -->
+:octicons-terminal-24: Install from the command line:
+
+```shell
+docker pull ghcr.io/open-feature/flagd:v0.6.6
+```
+
+:octicons-code-square-24: Use as base image in Dockerfile:
+
+```
+FROM ghcr.io/open-feature/flagd:v0.6.6
+```
+<!-- x-release-please-end -->
+
+## Kubernetes
+
+flagd was designed with cloud-native paradigms in mind.
+You can run it as a sidecar, or as a central service in your cluster.
+If you're interested in a full-featured solution for using flagd in Kubernetes, consider the [OpenFeature operator](https://github.com/open-feature/open-feature-operator).
+
+<!-- for now, we are just linking out to the OFO README, but eventually we should consider fully documenting OFO here. -->
+
+---
+
+# Binary
+
+<!-- x-release-please-start-version -->
+:fontawesome-brands-linux::fontawesome-brands-windows::fontawesome-brands-apple: Binaries are available in x86/ARM.
+
+[Latest release](https://github.com/open-feature/flagd/releases/tag/flagd%2Fv0.6.6)
+<!-- x-release-please-end -->
+
+## systemd
+
+A systemd wrapper is available [here](https://github.com/open-feature/flagd/blob/main/systemd/flagd.service).
+
+---
+
+# In-Process
+
+## :fontawesome-brands-golang: Go in-process provider
+
+[flagd-in-process/pkg](https://pkg.go.dev/github.com/open-feature/go-sdk-contrib/providers/flagd-in-process/pkg)
+
+```shell
+go get github.com/open-feature/go-sdk-contrib/providers/flagd-in-process/pkg@v0.1.1
+```
+
+## :fontawesome-brands-java: Java in-process provider
+
+### Maven
+
+```xml
+<dependency>
+  <groupId>dev.openfeature.contrib.providers</groupId>
+  <artifactId>flagd</artifactId>
+</dependency>
+```
+
+### Gradle
+
+```
+implementation 'dev.openfeature.contrib.providers:flagd'
+```


### PR DESCRIPTION
* adds fonticon support
* adds "deployment" page
  * I've chosen to specifically add the "in-process" providers here because that's a deployment we've specifically mentioned.. we could add the RPC ones as well in the some other section... not sure about that.
  
  
![image](https://github.com/open-feature/flagd/assets/25272906/e73363c1-3e84-4ebd-8787-52ee0e92c8cd)
