### PR TITLE
feature: add timestamp to json evaluator

### DIFF
--- a/core/pkg/eval/json_evaluator.go
+++ b/core/pkg/eval/json_evaluator.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/diegoholiveira/jsonlogic/v3"
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -38,7 +39,8 @@ const (
 var regBrace *regexp.Regexp
 
 type flagdProperties struct {
-	FlagKey string `json:"flagKey"`
+	FlagKey   string    `json:"flagKey"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 func init() {
@@ -321,7 +323,8 @@ func (je *JSONEvaluator) evaluateVariant(reqID string, flagKey string, context m
 		}
 
 		context = je.setFlagdProperties(context, flagdProperties{
-			FlagKey: flagKey,
+			FlagKey:   flagKey,
+			Timestamp: time.Now(),
 		})
 
 		b, err := json.Marshal(context)


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds "timestamp" to the json evaluation context.


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Related to #851. I am not sure we want to say that it closes the issue though.
