### PR TITLE
chore: adds meta descriptions to improve indexing/SEO/etc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,7 @@
+---
+description: flagd architecture
+---
+
 # Architecture
 
 flagd architectures fall into two broad categories: those where the evaluation engine is deployed in a standalone process to which the client application connects ([RPC](#rpc-evaluation)), and those where the evaluation engine is embedded into the client application ([in-process](#in-process-evaluation)).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,3 +1,7 @@
+---
+description: flagd faq
+---
+
 # Frequently Asked Questions
 
 > Why do I need this? Can't I just use environment variables?

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,3 +1,7 @@
+---
+description: installing flagd
+---
+
 # Installation
 
 ## Docker

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,3 +1,7 @@
+---
+description: flagd quick start
+---
+
 # Quick Start
 
 Learn the basics of flagd from the comfort of your terminal.

--- a/docs/reference/custom-operations/fractional-operation.md
+++ b/docs/reference/custom-operations/fractional-operation.md
@@ -1,3 +1,7 @@
+---
+description: flagd fractional custom operation
+---
+
 # Fractional Operation
 
 OpenFeature allows clients to pass contextual information which can then be used during a flag evaluation. For example, a client could pass the email address of the user.

--- a/docs/reference/custom-operations/semver-operation.md
+++ b/docs/reference/custom-operations/semver-operation.md
@@ -1,3 +1,7 @@
+---
+description: flagd semver custom operation
+---
+
 # Semantic Version Operation
 
 OpenFeature allows clients to pass contextual information which can then be used during a flag evaluation. For example, a client could pass the email address of the user.

--- a/docs/reference/custom-operations/string-comparison-operation.md
+++ b/docs/reference/custom-operations/string-comparison-operation.md
@@ -1,3 +1,7 @@
+---
+description: flagd string custom operations
+---
+
 # Starts-With / Ends-With Operation
 
 OpenFeature allows clients to pass contextual information which can then be used during a flag evaluation. For example, a client could pass the email address of the user.

--- a/docs/reference/flag-definitions.md
+++ b/docs/reference/flag-definitions.md
@@ -1,3 +1,7 @@
+---
+description: flagd flag definition
+---
+
 # Flag Definitions
 
 ## Flags

--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -1,3 +1,7 @@
+---
+description: monitoring and telemetry flagd and flagd providers
+---
+
 # Monitoring
 
 ## Readiness & Liveness probes

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -1,3 +1,7 @@
+---
+description: naming conventions for flagd and associated artifacts
+---
+
 # Naming
 
 _flagd_ was conceived as a simple program with a POSIX-style CLI that's designed to run as a service or [daemon](https://en.wikipedia.org/wiki/Daemon_(computing)).

--- a/docs/reference/specifications/in-process-providers.md
+++ b/docs/reference/specifications/in-process-providers.md
@@ -1,3 +1,7 @@
+---
+description: flagd in-process proivider specification
+---
+
 # Creating an in-process flagd provider
 
 An in-process flagd provider is designed to be embedded into the application, and therefore no communication outside the process of the application for feature flag evaluation is needed.

--- a/docs/reference/specifications/rpc-providers.md
+++ b/docs/reference/specifications/rpc-providers.md
@@ -1,3 +1,7 @@
+---
+description: flagd RPC proivider specification
+---
+
 # Creating an RPC flagd provider
 
 By default, **flagd** is a remote service that is accessed via **grpc** by a client application to retrieve feature flags.

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -1,3 +1,7 @@
+---
+description: sync configuration overview for flagd and flagd providers
+---
+
 # Sync configuration
 
 See [syncs](../concepts/syncs.md) for a conceptual overview.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,7 @@
+---
+description: troubleshooting flagd
+---
+
 # Troubleshooting flagd
 
 ## Debugging Evaluations


### PR DESCRIPTION
I was looking into what we could do to improve our indexing and social object graph. I don't think there's much except adding meta-descriptions. These aren't as important as they used to be, but they can still improve indexing and increase likelihood of sharing on social media, etc.

Adding a markdown metadata section with `description` in mkdocs results in it being used in the description meta tag for the page, so I've done that for some pages that are likely to be searched.