### PR TITLE
fix: remove deprecated command options

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,8 +25,6 @@ jobs:
       - uses: google-github-actions/release-please-action@a6d1fd9854c8c40688a72f7e4b072a1e965860a0 # v4
         id: release
         with:
-          release-type: "go"
-          command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
 


### PR DESCRIPTION
## This PR

Remove deprecated command options.

see - https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4 