### PR TITLE
docs: fix a typo in `docs/featureflagsource.md`

### DIFF
--- a/docs/reference/openfeature-operator/crds/featureflagsource.md
+++ b/docs/reference/openfeature-operator/crds/featureflagsource.md
@@ -96,7 +96,7 @@ metadata:
     name: flag-source-sample
 spec:
     managementPort: 8080
-    Port: 80
+    port: 80
     evaluator: json
     image: my-custom-sidecar-image
     defaultSyncProvider: filepath


### PR DESCRIPTION
## This PR

Fix a typo in `docs/featureflagsource.md`
