### PR TITLE
fix: make sure sync builder is initialized to avoid nil pointer access

### DIFF
--- a/core/pkg/subscriptions/manager.go
+++ b/core/pkg/subscriptions/manager.go
@@ -54,7 +54,7 @@ func NewManager(ctx context.Context, logger *logger.Logger) *Coordinator {
 		multiplexers: map[string]*multiplexer{},
 		logger:       logger,
 		mu:           &sync.RWMutex{},
-		syncBuilder:  &syncbuilder.SyncBuilder{},
+		syncBuilder:  syncbuilder.NewSyncBuilder(),
 	}
 	go mgr.cleanup()
 	return &mgr


### PR DESCRIPTION
This is a follow up to the latest refactoring PR #1044 to avoid a nil pointer access when attempting to read from a kubernetes sync source