### PR TITLE
fix: CGO_ENABLED=0 for statically-linked builds

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -183,32 +183,32 @@ jobs:
           cd ${{ matrix.path }} && cyclonedx-gomod app > ../sbom.xml
       - name: build darwin arm64
         run: |
-          env GOOS=darwin GOARCH=arm64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_darwin_arm64 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_darwin_arm64 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Darwin_arm64.tar.gz ./${{ matrix.path }}_darwin_arm64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build darwin x86_64
         run: |
-          env GOOS=darwin GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_darwin_x86_64 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_darwin_x86_64 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Darwin_x86_64.tar.gz ./${{ matrix.path }}_darwin_x86_64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build linux arm64
         run: |
-          env GOOS=linux GOARCH=arm64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_arm64 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_arm64 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Linux_arm64.tar.gz ./${{ matrix.path }}_linux_arm64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build linux x86_64
         run: |
-          env GOOS=linux GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_x86_64 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_x86_64 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Linux_x86_64.tar.gz ./${{ matrix.path }}_linux_x86_64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build linux i386
         run: |
-          env GOOS=linux GOARCH=386 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_i386 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_linux_i386 ./${{ matrix.path }}/main.go
           tar -cvzf ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Linux_i386.tar.gz ./${{ matrix.path }}_linux_i386 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       # Windows artifacts use .zip archive
       - name: build windows x86_64
         run: |
-          env GOOS=windows GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_windows_x86_64 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_windows_x86_64 ./${{ matrix.path }}/main.go
           zip -r ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_x86_64.zip ./${{ matrix.path }}_windows_x86_64 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       - name: build windows i386
         run: |
-          env GOOS=windows GOARCH=386 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_windows_i386 ./${{ matrix.path }}/main.go
+          env CGO_ENABLED=0 GOOS=windows GOARCH=386 go build ${{ env.BUILD_ARGS }} -o ./${{ matrix.path }}_windows_i386 ./${{ matrix.path }}/main.go
           zip -r ${{ matrix.path }}_${{ env.VERSION_NO_PREFIX }}_Windows_i386.zip ./${{ matrix.path }}_windows_i386 ./LICENSE ./CHANGELOG.md ./README.md ./sbom.xml
       # Bundle licenses
       - name: Install go-licenses


### PR DESCRIPTION
Removes the dependency on native c-libs for more portability.

This is already done in the docker builds, updates were only needed for bins. Tested this locally by mounting it into an old Ubuntu and it resolved the issue.

Fixes: https://github.com/open-feature/flagd/issues/878