### PR TITLE
fix: add custom marshalling options

### DIFF
--- a/core/pkg/service/flag-evaluation/connect_service.go
+++ b/core/pkg/service/flag-evaluation/connect_service.go
@@ -168,7 +168,7 @@ func (s *ConnectService) setupServer(svcConf service.Configuration) (net.Listene
 		s.metrics,
 	)
 
-	_, newHandler := evaluationV1.NewServiceHandler(newFes, svcConf.Options...)
+	_, newHandler := evaluationV1.NewServiceHandler(newFes, append(svcConf.Options, marshalOpts)...)
 
 	bs := bufSwitchHandler{
 		old: oldHandler,


### PR DESCRIPTION
## This PR

- add custom marshalling options

### Related Issues

Fixes #1116

### Notes

I manually tested to confirm the fix is working. However, it's currently not automatically tested because the issue only affects HTTP-based requests, and the E2E tests use gRPC. I'll create a follow-up task to expand the E2E test suite to include HTTP tests.
