### PR TITLE
fix: use correct link in sources flag helper text in start cmd

### DIFF
--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -21,7 +21,7 @@ flagd start [flags]
   -c, --server-cert-path string     Server side tls certificate path
   -k, --server-key-path string      Server side tls key path
   -d, --socket-path string          Flagd socket path. With grpc the service will become available on this address. With http(s) the grpc-gateway proxy will use this address internally.
-  -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://github.com/open-feature/flagd/blob/main/docs/configuration/configuration.md#sync-provider-customisation
+  -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://flagd.dev/reference/sync-configuration/#source-configuration
   -f, --uri .yaml/.yml/.json        Set a sync provider uri to read data from, this can be a filepath, URL (HTTP and gRPC) or FeatureFlag custom resource. When flag keys are duplicated across multiple providers the merge priority follows the index of the flag arguments, as such flags from the uri at index 0 take the lowest precedence, with duplicated keys being overwritten by those from the uri at index 1. Please note that if you are using filepath, flagd only supports files with .yaml/.yml/.json extension.
 ```
 

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -54,7 +54,7 @@ func init() {
 	flags.StringP(
 		sourcesFlagName, "s", "", "JSON representation of an array of SourceConfig objects. This object contains "+
 			"2 required fields, uri (string) and provider (string). Documentation for this object: "+
-			"https://github.com/open-feature/flagd/blob/main/docs/configuration/configuration.md#sync-provider-customisation",
+			"https://flagd.dev/reference/sync-configuration/#source-configuration",
 	)
 	flags.StringP(logFormatFlagName, "z", "console", "Set the logging format, e.g. console or json")
 	flags.StringP(metricsExporter, "t", "", "Set the metrics exporter. Default(if unset) is Prometheus."+


### PR DESCRIPTION
## This PR

- fix broken link

### Related Issues

Fixes #1122 