### PR TITLE
feat(core): support any auth scheme in HTTP-sync auth header

### DIFF
--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -148,6 +148,7 @@ func (sb *SyncBuilder) newHTTP(config sync.SourceConfig, logger *logger.Logger) 
 			zap.String("sync", "remote"),
 		),
 		BearerToken: config.BearerToken,
+		AuthHeader:  config.AuthHeader,
 		Interval:    interval,
 		Cron:        cron.New(),
 	}

--- a/core/pkg/sync/builder/syncbuilder_test.go
+++ b/core/pkg/sync/builder/syncbuilder_test.go
@@ -199,6 +199,11 @@ func Test_SyncsFromFromConfig(t *testing.T) {
 						BearerToken: "token",
 					},
 					{
+						URI:        "https://host:port",
+						Provider:   syncProviderHTTP,
+						AuthHeader: "scheme credentials/token",
+					},
+					{
 						URI:      "/tmp/flags.json",
 						Provider: syncProviderFile,
 					},
@@ -210,6 +215,7 @@ func Test_SyncsFromFromConfig(t *testing.T) {
 			},
 			wantSyncs: []sync.ISync{
 				&grpc.Sync{},
+				&http.Sync{},
 				&http.Sync{},
 				&file.Sync{},
 				&kubernetes.Sync{},

--- a/core/pkg/sync/builder/utils.go
+++ b/core/pkg/sync/builder/utils.go
@@ -22,6 +22,11 @@ func ParseSources(sourcesFlag string) ([]sync.SourceConfig, error) {
 		if sp.Provider == "" {
 			return syncProvidersParsed, errors.New("sync provider argument parse: provider is a required field")
 		}
+		if sp.AuthHeader != "" && sp.BearerToken != "" {
+			return syncProvidersParsed, errors.New(
+				"sync provider argument parse: both authHeader and bearerToken are defined, only one is allowed at a time",
+			)
+		}
 	}
 	return syncProvidersParsed, nil
 }

--- a/core/pkg/sync/builder/utils_test.go
+++ b/core/pkg/sync/builder/utils_test.go
@@ -55,6 +55,8 @@ func TestParseSource(t *testing.T) {
 			in: `[{"uri":"config/samples/example_flags.json","provider":"file"},
             		{"uri":"http://my-flag-source.json","provider":"http","bearerToken":"bearer-dji34ld2l"},
             		{"uri":"https://secure-remote","provider":"http","bearerToken":"bearer-dji34ld2l"},
+								{"uri":"https://secure-remote","provider":"http","authHeader":"Bearer bearer-dji34ld2l"},
+								{"uri":"https://secure-remote","provider":"http","authHeader":"Basic dXNlcjpwYXNz"},
             		{"uri":"http://site.com","provider":"http","interval":77 },
 					{"uri":"default/my-flag-config","provider":"kubernetes"},
             		{"uri":"grpc-source:8080","provider":"grpc"},
@@ -77,6 +79,16 @@ func TestParseSource(t *testing.T) {
 					BearerToken: "bearer-dji34ld2l",
 				},
 				{
+					URI:        "https://secure-remote",
+					Provider:   syncProviderHTTP,
+					AuthHeader: "Bearer bearer-dji34ld2l",
+				},
+				{
+					URI:        "https://secure-remote",
+					Provider:   syncProviderHTTP,
+					AuthHeader: "Basic dXNlcjpwYXNz",
+				},
+				{
 					URI:      "http://site.com",
 					Provider: syncProviderHTTP,
 					Interval: 77,
@@ -96,6 +108,22 @@ func TestParseSource(t *testing.T) {
 					CertPath:   "/certs/ca.cert",
 					ProviderID: "flagd-weatherapp-sidecar",
 					Selector:   "source=database,app=weatherapp",
+				},
+			},
+		},
+		"multiple-auth-options": {
+			in: `[
+				{"uri":"https://secure-remote","provider":"http","authHeader":"Bearer bearer-dji34ld2l","bearerToken":"bearer-dji34ld2l"}
+			]`,
+			expectErr: true,
+			out: []sync.SourceConfig{
+				{
+					URI:         "https://secure-remote",
+					Provider:    syncProviderHTTP,
+					AuthHeader:  "Bearer bearer-dji34ld2l",
+					BearerToken: "bearer-dji34ld2l",
+					TLS:         false,
+					Interval:    0,
 				},
 			},
 		},

--- a/core/pkg/sync/builder/utils_test.go
+++ b/core/pkg/sync/builder/utils_test.go
@@ -52,16 +52,17 @@ func TestParseSource(t *testing.T) {
 			},
 		},
 		"multiple-syncs-with-options": {
-			in: `[{"uri":"config/samples/example_flags.json","provider":"file"},
-            		{"uri":"http://my-flag-source.json","provider":"http","bearerToken":"bearer-dji34ld2l"},
-            		{"uri":"https://secure-remote","provider":"http","bearerToken":"bearer-dji34ld2l"},
-								{"uri":"https://secure-remote","provider":"http","authHeader":"Bearer bearer-dji34ld2l"},
-								{"uri":"https://secure-remote","provider":"http","authHeader":"Basic dXNlcjpwYXNz"},
-            		{"uri":"http://site.com","provider":"http","interval":77 },
-					{"uri":"default/my-flag-config","provider":"kubernetes"},
-            		{"uri":"grpc-source:8080","provider":"grpc"},
-            		{"uri":"my-flag-source:8080","provider":"grpc", "tls":true, "certPath": "/certs/ca.cert", "providerID": "flagd-weatherapp-sidecar", "selector": "source=database,app=weatherapp"}]
-				`,
+			in: `[
+				{"uri":"config/samples/example_flags.json","provider":"file"},
+				{"uri":"http://my-flag-source.json","provider":"http","bearerToken":"bearer-dji34ld2l"},
+				{"uri":"https://secure-remote","provider":"http","bearerToken":"bearer-dji34ld2l"},
+				{"uri":"https://secure-remote","provider":"http","authHeader":"Bearer bearer-dji34ld2l"},
+				{"uri":"https://secure-remote","provider":"http","authHeader":"Basic dXNlcjpwYXNz"},
+				{"uri":"http://site.com","provider":"http","interval":77 },
+				{"uri":"default/my-flag-config","provider":"kubernetes"},
+				{"uri":"grpc-source:8080","provider":"grpc"},
+				{"uri":"my-flag-source:8080","provider":"grpc", "tls":true, "certPath": "/certs/ca.cert", "providerID": "flagd-weatherapp-sidecar", "selector": "source=database,app=weatherapp"}
+			]`,
 			expectErr: false,
 			out: []sync.SourceConfig{
 				{

--- a/core/pkg/sync/http/http_sync.go
+++ b/core/pkg/sync/http/http_sync.go
@@ -49,7 +49,7 @@ func (hs *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error
 
 func (hs *Sync) Init(_ context.Context) error {
 	if hs.BearerToken != "" {
-		hs.Logger.Info("Deprecation Alert: bearerToken option is deprecated, please use authHeader instead")
+		hs.Logger.Warn("Deprecation Alert: bearerToken option is deprecated, please use authHeader instead")
 	}
 	return nil
 }

--- a/core/pkg/sync/http/http_sync.go
+++ b/core/pkg/sync/http/http_sync.go
@@ -21,6 +21,7 @@ type Sync struct {
 	LastBodySHA string
 	Logger      *logger.Logger
 	BearerToken string
+	AuthHeader  string
 	Interval    uint32
 	ready       bool
 }
@@ -47,7 +48,9 @@ func (hs *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error
 }
 
 func (hs *Sync) Init(_ context.Context) error {
-	// noop
+	if hs.BearerToken != "" {
+		hs.Logger.Info("Deprecation Alert: bearerToken option is deprecated, please use authHeader instead")
+	}
 	return nil
 }
 
@@ -120,7 +123,9 @@ func (hs *Sync) fetchBodyFromURL(ctx context.Context, url string) ([]byte, error
 
 	req.Header.Add("Accept", "application/json")
 
-	if hs.BearerToken != "" {
+	if hs.AuthHeader != "" {
+		req.Header.Set("Authorization", hs.AuthHeader)
+	} else if hs.BearerToken != "" {
 		bearer := fmt.Sprintf("Bearer %s", hs.BearerToken)
 		req.Header.Set("Authorization", bearer)
 	}

--- a/core/pkg/sync/http/http_sync_test.go
+++ b/core/pkg/sync/http/http_sync_test.go
@@ -189,6 +189,29 @@ func TestHTTPSync_Fetch(t *testing.T) {
 	}
 }
 
+func TestSync_Init(t *testing.T) {
+	tests := []struct {
+		name        string
+		bearerToken string
+	}{
+		{"with bearerToken", "bearer-1234"},
+		{"without bearerToken", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			httpSync := Sync{
+				BearerToken: tt.bearerToken,
+				Logger:      logger.NewLogger(nil, false),
+			}
+
+			if err := httpSync.Init(context.Background()); err != nil {
+				t.Errorf("Init() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestHTTPSync_Resync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/core/pkg/sync/isync.go
+++ b/core/pkg/sync/isync.go
@@ -66,6 +66,7 @@ type SourceConfig struct {
 	Provider string `json:"provider"`
 
 	BearerToken string `json:"bearerToken,omitempty"`
+	AuthHeader  string `json:"authHeader,omitempty"`
 	CertPath    string `json:"certPath,omitempty"`
 	TLS         bool   `json:"tls,omitempty"`
 	ProviderID  string `json:"providerID,omitempty"`

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -27,26 +27,21 @@ The flagd accepts a string argument, which should be a JSON representation of an
 
 Alternatively, these configurations can be passed to flagd via config file, specified using the `--config` flag.
 
-| Field       | Type               | Note                                                                                                                                                                          |
-| ----------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| uri         | required `string`  | Flag configuration source of the sync                                                                                                                                         |
-| provider    | required `string`  | Provider type - `file`, `kubernetes`, `http`, or `grpc`                                                                                                                       |
-| authHeader  | optional `string`  | Used for http sync; set this to include the complete `Authorization` header value for any authentication scheme (e.g., "Bearer token_here", "Basic base64_credentials", etc.) |
-| bearerToken | optional `string`  | (Deprecated) Used for http sync; token gets appended to `Authorization` header with [bearer schema](https://www.rfc-editor.org/rfc/rfc6750#section-2.1)                       |
-| interval    | optional `uint32`  | Used for http sync; requests will be made at this interval. Defaults to 5 seconds.                                                                                            |
-| tls         | optional `boolean` | Enable/Disable secure TLS connectivity. Currently used only by gRPC sync. Default (ex: if unset) is false, which will use an insecure connection                              |
-| providerID  | optional `string`  | Value binds to grpc connection's providerID field. gRPC server implementations may use this to identify connecting flagd instance                                             |
-| selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                                                       |
-| certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                      |
+| Field       | Type               | Note                                                                                                                                                                                                             |
+| ----------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uri         | required `string`  | Flag configuration source of the sync                                                                                                                                                                            |
+| provider    | required `string`  | Provider type - `file`, `kubernetes`, `http`, or `grpc`                                                                                                                                                          |
+| authHeader  | optional `string`  | Used for http sync; set this to include the complete `Authorization` header value for any authentication scheme (e.g., "Bearer token_here", "Basic base64_credentials", etc.). Cannot be used with `bearerToken` |
+| bearerToken | optional `string`  | (Deprecated) Used for http sync; token gets appended to `Authorization` header with [bearer schema](https://www.rfc-editor.org/rfc/rfc6750#section-2.1). Cannot be used with `authHeader`                        |
+| interval    | optional `uint32`  | Used for http sync; requests will be made at this interval. Defaults to 5 seconds.                                                                                                                               |
+| tls         | optional `boolean` | Enable/Disable secure TLS connectivity. Currently used only by gRPC sync. Default (ex: if unset) is false, which will use an insecure connection                                                                 |
+| providerID  | optional `string`  | Value binds to grpc connection's providerID field. gRPC server implementations may use this to identify connecting flagd instance                                                                                |
+| selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                                                                                          |
+| certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                                                         |
 
-### Important Notes
-
-- **Mutual Exclusivity**: `authHeader` and `bearerToken` cannot be used simultaneously. Setting both fields in the configuration
-  results in an error, preventing the application from starting.
-
-- **URI Formatting**: The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
-  from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect
-  URIs will result in a flagd start-up failure with errors from the respective sync provider implementation.
+The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
+from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect
+URIs will result in a flagd start-up failure with errors from the respective sync provider implementation.
 
 Given below are example sync providers, startup command and equivalent config file definition:
 

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -27,20 +27,26 @@ The flagd accepts a string argument, which should be a JSON representation of an
 
 Alternatively, these configurations can be passed to flagd via config file, specified using the `--config` flag.
 
-| Field       | Type               | Note                                                                                                                                             |
-| ----------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| uri         | required `string`  | Flag configuration source of the sync                                                                                                            |
-| provider    | required `string`  | Provider type - `file`, `kubernetes`, `http` or `grpc`                                                                                           |
-| bearerToken | optional `string`  | Used for http sync; token gets appended to `Authorization` header with [bearer schema](https://www.rfc-editor.org/rfc/rfc6750#section-2.1)       |
-| interval    | optional `uint32`  | Used for http sync; requests will be made at this interval. Defaults to 5 seconds.                                                               |
-| tls         | optional `boolean` | Enable/Disable secure TLS connectivity. Currently used only by gRPC sync. Default(ex:- if unset) is false, which will use an insecure connection |
-| providerID  | optional `string`  | Value binds to grpc connection's providerID field. gRPC server implementations may use this to identify connecting flagd instance                |
-| selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                          |
-| certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                         |
+| Field       | Type               | Note                                                                                                                                                                          |
+| ----------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| uri         | required `string`  | Flag configuration source of the sync                                                                                                                                         |
+| provider    | required `string`  | Provider type - `file`, `kubernetes`, `http`, or `grpc`                                                                                                                       |
+| authHeader  | optional `string`  | Used for http sync; set this to include the complete `Authorization` header value for any authentication scheme (e.g., "Bearer token_here", "Basic base64_credentials", etc.) |
+| bearerToken | optional `string`  | (Deprecated) Used for http sync; token gets appended to `Authorization` header with [bearer schema](https://www.rfc-editor.org/rfc/rfc6750#section-2.1)                       |
+| interval    | optional `uint32`  | Used for http sync; requests will be made at this interval. Defaults to 5 seconds.                                                                                            |
+| tls         | optional `boolean` | Enable/Disable secure TLS connectivity. Currently used only by gRPC sync. Default (ex: if unset) is false, which will use an insecure connection                              |
+| providerID  | optional `string`  | Value binds to grpc connection's providerID field. gRPC server implementations may use this to identify connecting flagd instance                                             |
+| selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                                                       |
+| certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                      |
 
-The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
-from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect
-URIs will result in a flagd start-up failure with errors from the respective sync provider implementation.
+### Important Notes:
+
+- **Mutual Exclusivity**: `authHeader` and `bearerToken` cannot be used simultaneously. Setting both fields in the configuration
+  results in an error, preventing the application from starting.
+
+- **URI Formatting**: The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
+  from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect
+  URIs will result in a flagd start-up failure with errors from the respective sync provider implementation.
 
 Given below are example sync providers, startup command and equivalent config file definition:
 
@@ -56,9 +62,11 @@ Sync providers:
 Startup command:
 
 ```sh
-./bin/flagd start 
+./bin/flagd start
 --sources='[{"uri":"config/samples/example_flags.json","provider":"file"},
             {"uri":"http://my-flag-source.json","provider":"http","bearerToken":"bearer-dji34ld2l"},
+            {"uri":"https://secure-remote/bearer-auth","provider":"http","authHeader":"Bearer bearer-dji34ld2l"},
+            {"uri":"https://secure-remote/basic-auth","provider":"http","authHeader":"Basic dXNlcjpwYXNz"},
             {"uri":"default/my-flag-config","provider":"kubernetes"},
             {"uri":"grpc-source:8080","provider":"grpc"},
             {"uri":"my-flag-source:8080","provider":"grpc", "certPath": "/certs/ca.cert", "tls": true, "providerID": "flagd-weatherapp-sidecar", "selector": "source=database,app=weatherapp"}]'
@@ -82,5 +90,5 @@ sources:
     certPath: /certs/ca.cert
     tls: true
     providerID: flagd-weatherapp-sidecar
-    selector: 'source=database,app=weatherapp'
+    selector: "source=database,app=weatherapp"
 ```

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -39,7 +39,7 @@ Alternatively, these configurations can be passed to flagd via config file, spec
 | selector    | optional `string`  | Value binds to grpc connection's selector field. gRPC server implementations may use this to filter flag configurations                                                       |
 | certPath    | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                      |
 
-### Important Notes:
+### Important Notes
 
 - **Mutual Exclusivity**: `authHeader` and `bearerToken` cannot be used simultaneously. Setting both fields in the configuration
   results in an error, preventing the application from starting.


### PR DESCRIPTION
## This PR

- adds support for any auth scheme in HTTP-sync auth header

### Related Issues

Closes #1150
