### PR TITLE
chore: fix renovate go version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
-
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "constraints": {
+    "go": "1.20"
+  },
   "extends": [
     "config:base",
     "helpers:pinGitHubActionDigests"


### PR DESCRIPTION
## This PR

Set go version of renovate to 1.20 [1] and avoid updates causing build failures 


[1] - https://docs.renovatebot.com/golang/#go-binary-version