### PR TITLE
chore: revert release-plz version

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e # v4
+      - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "go": "1.20"
   },
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "go": "1.20"
   },
   "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests"
+    "config:base"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
- reverts release please action to v3 (see [bug](https://github.com/google-github-actions/release-please-action/issues/912)).
- removes GH action SHA pinning