### PR TITLE
feat: serve sync.proto on port 8015

### DIFF
--- a/config/samples/example_flags.flagd.json
+++ b/config/samples/example_flags.flagd.json
@@ -2,7 +2,7 @@
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
     "myBoolFlag": {
-      "state": "ENABLED",
+      "state": "DISABLED",
       "variants": {
         "on": true,
         "off": false

--- a/config/samples/example_flags.flagd.json
+++ b/config/samples/example_flags.flagd.json
@@ -2,7 +2,7 @@
   "$schema": "https://flagd.dev/schema/v0/flags.json",
   "flags": {
     "myBoolFlag": {
-      "state": "DISABLED",
+      "state": "ENABLED",
       "variants": {
         "on": true,
         "off": false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ In-process deployments embed the flagd evaluation engine directly into the clien
 The in-process provider is connected via the sync protocol to an implementing [gRPC service](./concepts/syncs.md#grpc-sync) that provides the flag definitions.
 You can use flagd as a [gRPC sync service](./reference/grpc-sync-service.md).
 In this mode, the flag sync stream will expose aggregated flag configurations currently configured through [syncs](./concepts/syncs.md).
-This pattern requires an in-process implementation of the flagd evaluation engine but has the benefit of no I/O overhead, since no inter-process communication is required.
+This pattern requires an in-process implementation of the flagd evaluation engine but has the benefit of no I/O overhead for flag evaluations, since no inter-process communication is required.
 
 ```mermaid
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,9 @@ erDiagram
 
 In-process deployments embed the flagd evaluation engine directly into the client application through the use of an [in-process provider](./installation.md#in-process).
 The in-process provider is connected via the sync protocol to an implementing [gRPC service](./concepts/syncs.md#grpc-sync) that provides the flag definitions.
-This pattern requires an in-process implementation of the flagd evaluation engine, but has the benefit of no I/O overhead, since no inter-process communication is required.
+You can use flagd itself as a [gRPC service](./reference/grpc-sync-service.md).
+In this mode, the flag sync stream will expose aggregated flag configurations currently configured through [syncs](./concepts/syncs.md).
+This pattern requires an in-process implementation of the flagd evaluation engine but has the benefit of no I/O overhead, since no inter-process communication is required.
 
 ```mermaid
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ erDiagram
 
 In-process deployments embed the flagd evaluation engine directly into the client application through the use of an [in-process provider](./installation.md#in-process).
 The in-process provider is connected via the sync protocol to an implementing [gRPC service](./concepts/syncs.md#grpc-sync) that provides the flag definitions.
-You can use flagd itself as a [gRPC service](./reference/grpc-sync-service.md).
+You can use flagd as a [gRPC sync service](./reference/grpc-sync-service.md).
 In this mode, the flag sync stream will expose aggregated flag configurations currently configured through [syncs](./concepts/syncs.md).
 This pattern requires an in-process implementation of the flagd evaluation engine but has the benefit of no I/O overhead, since no inter-process communication is required.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ With flagd you can:
 * perform pseudorandom assignments for experimentation
 * perform progressive roll-outs of new features
 * aggregate flag definitions from multiple sources
+* expose aggregated flags as a gRPC stream to be used by in-process providers
 
 It doesn't include a UI, management console or a persistence layer.
 It's configurable entirely via a [POSIX-style CLI](./reference/flagd-cli/flagd.md).

--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -22,6 +22,8 @@ flagd start [flags]
   -k, --server-key-path string      Server side tls key path
   -d, --socket-path string          Flagd socket path. With grpc the service will become available on this address. With http(s) the grpc-gateway proxy will use this address internally.
   -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://flagd.dev/reference/sync-configuration/#source-configuration
+  -e, --syncEnabled                 Set true to enable gRPC sync service from flagd. This is disabled by default
+  -g, --syncPort int32              gRPC Sync port (default 8015)
   -f, --uri .yaml/.yml/.json        Set a sync provider uri to read data from, this can be a filepath, URL (HTTP and gRPC) or FeatureFlag custom resource. When flag keys are duplicated across multiple providers the merge priority follows the index of the flag arguments, as such flags from the uri at index 0 take the lowest precedence, with duplicated keys being overwritten by those from the uri at index 1. Please note that if you are using filepath, flagd only supports files with .yaml/.yml/.json extension.
 ```
 

--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -22,7 +22,6 @@ flagd start [flags]
   -k, --server-key-path string      Server side tls key path
   -d, --socket-path string          Flagd socket path. With grpc the service will become available on this address. With http(s) the grpc-gateway proxy will use this address internally.
   -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://flagd.dev/reference/sync-configuration/#source-configuration
-  -e, --sync-enabled                Enables the gRPC sync service from flagd. This is disabled by default
   -g, --sync-port int32             gRPC Sync port (default 8015)
   -f, --uri .yaml/.yml/.json        Set a sync provider uri to read data from, this can be a filepath, URL (HTTP and gRPC) or FeatureFlag custom resource. When flag keys are duplicated across multiple providers the merge priority follows the index of the flag arguments, as such flags from the uri at index 0 take the lowest precedence, with duplicated keys being overwritten by those from the uri at index 1. Please note that if you are using filepath, flagd only supports files with .yaml/.yml/.json extension.
 ```

--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -22,7 +22,7 @@ flagd start [flags]
   -k, --server-key-path string      Server side tls key path
   -d, --socket-path string          Flagd socket path. With grpc the service will become available on this address. With http(s) the grpc-gateway proxy will use this address internally.
   -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://flagd.dev/reference/sync-configuration/#source-configuration
-  -e, --sync-enabled                Set true to enable gRPC sync service from flagd. This is disabled by default
+  -e, --sync-enabled                Enables the gRPC sync service from flagd. This is disabled by default
   -g, --sync-port int32             gRPC Sync port (default 8015)
   -f, --uri .yaml/.yml/.json        Set a sync provider uri to read data from, this can be a filepath, URL (HTTP and gRPC) or FeatureFlag custom resource. When flag keys are duplicated across multiple providers the merge priority follows the index of the flag arguments, as such flags from the uri at index 0 take the lowest precedence, with duplicated keys being overwritten by those from the uri at index 1. Please note that if you are using filepath, flagd only supports files with .yaml/.yml/.json extension.
 ```

--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -22,8 +22,8 @@ flagd start [flags]
   -k, --server-key-path string      Server side tls key path
   -d, --socket-path string          Flagd socket path. With grpc the service will become available on this address. With http(s) the grpc-gateway proxy will use this address internally.
   -s, --sources string              JSON representation of an array of SourceConfig objects. This object contains 2 required fields, uri (string) and provider (string). Documentation for this object: https://flagd.dev/reference/sync-configuration/#source-configuration
-  -e, --syncEnabled                 Set true to enable gRPC sync service from flagd. This is disabled by default
-  -g, --syncPort int32              gRPC Sync port (default 8015)
+  -e, --sync-enabled                Set true to enable gRPC sync service from flagd. This is disabled by default
+  -g, --sync-port int32             gRPC Sync port (default 8015)
   -f, --uri .yaml/.yml/.json        Set a sync provider uri to read data from, this can be a filepath, URL (HTTP and gRPC) or FeatureFlag custom resource. When flag keys are duplicated across multiple providers the merge priority follows the index of the flag arguments, as such flags from the uri at index 0 take the lowest precedence, with duplicated keys being overwritten by those from the uri at index 1. Please note that if you are using filepath, flagd only supports files with .yaml/.yml/.json extension.
 ```
 

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -5,7 +5,6 @@ description: flagd as a gRPC sync service
 # Overview
 
 flagd can expose a gRPC sync service, allowing in-process providers to obtain their flag definitions.
-This mode is **disabled** by default, and you can enable it by using startup flag `--sync-enabled` (or `-e` shorthand flag).
 The gRPC sync stream contains flag definitions currently configured at flagd as [sync-configurations](./sync-configuration.md).
 
 ```mermaid

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -22,7 +22,7 @@ erDiagram
 
 You may change the default port of the service using startup flag `--sync-port` (or `-g` shothand flag).
 
-By default, the gRPC stream expose all the flag configurations merged following merge strategy of flagd.
+By default, the gRPC stream exposes all the flag configurations, with conflicting flag keys merged following flag's standard merge strategy.
 You can read more about the merge strategy in our dedicated [concepts guide on syncs](../concepts/syncs.md).
 
 If you specify a `selector` in the gRPC sync request, the gRPC service will attempt match the provided selector valur to a source and stream specific flags.

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -25,7 +25,7 @@ You may change the default port of the service using startup flag `--sync-port` 
 By default, the gRPC stream exposes all the flag configurations, with conflicting flag keys merged following flag's standard merge strategy.
 You can read more about the merge strategy in our dedicated [concepts guide on syncs](../concepts/syncs.md).
 
-If you specify a `selector` in the gRPC sync request, the gRPC service will attempt match the provided selector valur to a source and stream specific flags.
+If you specify a `selector` in the gRPC sync request, the gRPC service will attempt match the provided selector value to a source, and stream just the flags identified in that source.
 For example, if `selector` is set to `myFlags.json`, service will stream flags observed from `myFlags.json` file.
 And the request will fail if there is no flag source matching the requested `selector`.
 flagd provider implementations expose the ability to define the `selector` value.

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -4,7 +4,7 @@ description: flagd as a gRPC sync service
 
 # Overview
 
-flagd can expose a gRPC sync service, allowing in-process providers to obtain their flag configurations.
+flagd can expose a gRPC sync service, allowing in-process providers to obtain their flag definitions.
 This mode is **disabled** by default, and you can enable it by using startup flag `--sync-enabled` (or `-e` shorthand flag).
 The gRPC sync stream contains flag configurations currently configured at flagd as [sync-configurations](./sync-configuration.md).
 

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -27,8 +27,10 @@ You can read more about the merge strategy in our dedicated [concepts guide on s
 
 If you specify a `selector` in the gRPC sync request, the gRPC service will attempt match the provided selector value to a source, and stream just the flags identified in that source.
 For example, if `selector` is set to `myFlags.json`, service will stream flags observed from `myFlags.json` file.
+Note that, to observe flags from `myFlags.json` file, you may use startup option `uri` like `--uri myFlags.json` or `source` option `--sources='[{"uri":"myFlags.json", provider":"file"}]`.
 And the request will fail if there is no flag source matching the requested `selector`.
-flagd provider implementations expose the ability to define the `selector` value.
+
+flagd provider implementations expose the ability to define the `selector` value. Please consider below example for Java,
 
 ```java
 final FlagdProvider flagdProvider =

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -6,7 +6,7 @@ description: flagd as a gRPC sync service
 
 flagd can expose a gRPC sync service, allowing in-process providers to obtain their flag definitions.
 This mode is **disabled** by default, and you can enable it by using startup flag `--sync-enabled` (or `-e` shorthand flag).
-The gRPC sync stream contains flag configurations currently configured at flagd as [sync-configurations](./sync-configuration.md).
+The gRPC sync stream contains flag definitions currently configured at flagd as [sync-configurations](./sync-configuration.md).
 
 ```mermaid
 ---

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -1,0 +1,41 @@
+---
+description: flagd as a gRPC sync service
+---
+
+# Overview
+
+flagd can expose a gRPC sync service, allowing in-process providers to obtain their flag configurations.
+This mode is **disabled** by default, and you can enable it by using startup flag `--sync-enabled` (or `-e` shorthand flag).
+The gRPC sync stream contains flag configurations currently configured at flagd as [sync-configurations](./sync-configuration.md).
+
+```mermaid
+---
+title: gRPC sync
+---
+erDiagram
+    flagd ||--o{ "sync (file)" : watches
+    flagd ||--o{ "sync (http)" : polls
+    flagd ||--o{ "sync (grpc)" : "sync.proto (gRPC/stream)"
+    flagd ||--o{ "sync (kubernetes)" : watches
+    "In-Process provider" ||--|| flagd : "gRPC sync stream (default port 8015)"
+```
+
+You may change the default port of the service using startup flag `--sync-port` (or `-g` shothand flag).
+
+By default, the gRPC stream expose all the flag configurations merged following merge strategy of flagd.
+You can read more about the merge strategy in our dedicated [concepts guide on syncs](../concepts/syncs.md).
+
+If you specify a `selector` in the gRPC sync request, the gRPC service will attempt match the provided selector valur to a source and stream specific flags.
+For example, if `selector` is set to `myFlags.json`, service will stream flags observed from `myFlags.json` file.
+And the request will fail if there is no flag source matching the requested `selector`.
+flagd provider implementations expose the ability to define the `selector` value.
+
+```java
+final FlagdProvider flagdProvider =
+        new FlagdProvider(FlagdOptions.builder()
+                .resolverType(Config.Evaluator.IN_PROCESS)
+                .host("localhost")
+                .port(8015)
+                .selector("myFlags.json")
+                .build());
+```

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -26,7 +26,6 @@ const (
 	serverKeyPathFlagName  = "server-key-path"
 	socketPathFlagName     = "socket-path"
 	sourcesFlagName        = "sources"
-	syncEnabledFlagName    = "sync-enabled"
 	syncPortFlagName       = "sync-port"
 	uriFlagName            = "uri"
 )
@@ -67,9 +66,6 @@ func init() {
 	flags.StringP(otelCollectorURI, "o", "", "Set the grpc URI of the OpenTelemetry collector "+
 		"for flagd runtime. If unset, the collector setup will be ignored and traces will not be exported.")
 
-	flags.BoolP(syncEnabledFlagName, "e", false, "Enables the gRPC sync service from flagd. "+
-		"This is disabled by default")
-
 	_ = viper.BindPFlag(corsFlagName, flags.Lookup(corsFlagName))
 	_ = viper.BindPFlag(logFormatFlagName, flags.Lookup(logFormatFlagName))
 	_ = viper.BindPFlag(metricsExporter, flags.Lookup(metricsExporter))
@@ -82,7 +78,6 @@ func init() {
 	_ = viper.BindPFlag(sourcesFlagName, flags.Lookup(sourcesFlagName))
 	_ = viper.BindPFlag(uriFlagName, flags.Lookup(uriFlagName))
 	_ = viper.BindPFlag(syncPortFlagName, flags.Lookup(syncPortFlagName))
-	_ = viper.BindPFlag(syncEnabledFlagName, flags.Lookup(syncEnabledFlagName))
 }
 
 // startCmd represents the start command
@@ -138,7 +133,6 @@ var startCmd = &cobra.Command{
 			ServicePort:       viper.GetUint16(portFlagName),
 			ServiceSocketPath: viper.GetString(socketPathFlagName),
 			SyncServicePort:   viper.GetUint16(syncPortFlagName),
-			WithSyncService:   viper.GetBool(syncEnabledFlagName),
 			SyncProviders:     syncProviders,
 		})
 		if err != nil {

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -67,7 +67,7 @@ func init() {
 	flags.StringP(otelCollectorURI, "o", "", "Set the grpc URI of the OpenTelemetry collector "+
 		"for flagd runtime. If unset, the collector setup will be ignored and traces will not be exported.")
 
-	flags.BoolP(syncEnabledFlagName, "e", false, "Set true to enable gRPC sync service from flagd. "+
+	flags.BoolP(syncEnabledFlagName, "e", false, "Enables the gRPC sync service from flagd. "+
 		"This is disabled by default")
 
 	_ = viper.BindPFlag(corsFlagName, flags.Lookup(corsFlagName))

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -26,8 +26,8 @@ const (
 	serverKeyPathFlagName  = "server-key-path"
 	socketPathFlagName     = "socket-path"
 	sourcesFlagName        = "sources"
-	syncEnabledFlagName    = "syncEnabled"
-	syncPortFlagName       = "syncPort"
+	syncEnabledFlagName    = "sync-enabled"
+	syncPortFlagName       = "sync-port"
 	uriFlagName            = "uri"
 )
 

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -12,7 +12,7 @@ import (
 	syncbuilder "github.com/open-feature/flagd/core/pkg/sync/builder"
 	"github.com/open-feature/flagd/core/pkg/telemetry"
 	flageval "github.com/open-feature/flagd/flagd/pkg/service/flag-evaluation"
-	flag_sync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
+	flagsync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
 	"go.uber.org/zap"
 )
 
@@ -84,9 +84,9 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 		recorder)
 
 	// flag sync service
-	var flagSyncService flag_sync.ISyncService = &flag_sync.NoopSyncService{}
+	var flagSyncService flagsync.ISyncService = &flagsync.NoopSyncService{}
 	if config.WithSyncService {
-		flagSyncService, err = flag_sync.NewSyncService(flag_sync.SvcConfigurations{
+		flagSyncService, err = flagsync.NewSyncService(flagsync.SvcConfigurations{
 			Logger:  logger.WithFields(zap.String("component", "FlagSyncService")),
 			Port:    config.SyncServicePort,
 			Sources: sources,

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -59,7 +59,7 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 
 	// build flag store, collect flag sources & fill sources details
 	s := store.NewFlags()
-	var sources []string
+	sources := []string{}
 
 	for _, provider := range config.SyncProviders {
 		s.FlagSources = append(s.FlagSources, provider.URI)
@@ -80,10 +80,15 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 		recorder)
 
 	// todo - port as parameter and disable sync service by default
-	flagSyncService := flag_sync.NewSyncService(sources, flag_sync.SvcConfigurations{
-		Port:   8015,
-		Logger: logger.WithFields(zap.String("component", "FlagSyncService")),
+	flagSyncService, err := flag_sync.NewSyncService(flag_sync.SvcConfigurations{
+		Logger:  logger.WithFields(zap.String("component", "FlagSyncService")),
+		Port:    8015,
+		Sources: sources,
+		Store:   s,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating sync service: %w", err)
+	}
 
 	// build sync providers
 	syncLogger := logger.WithFields(zap.String("component", "sync"))

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -30,7 +30,6 @@ type Config struct {
 	ServicePort       uint16
 	ServiceSocketPath string
 	SyncServicePort   uint16
-	WithSyncService   bool
 
 	SyncProviders []sync.SourceConfig
 	CORS          []string
@@ -84,17 +83,14 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 		recorder)
 
 	// flag sync service
-	var flagSyncService flagsync.ISyncService = &flagsync.NoopSyncService{}
-	if config.WithSyncService {
-		flagSyncService, err = flagsync.NewSyncService(flagsync.SvcConfigurations{
-			Logger:  logger.WithFields(zap.String("component", "FlagSyncService")),
-			Port:    config.SyncServicePort,
-			Sources: sources,
-			Store:   s,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error creating sync service: %w", err)
-		}
+	flagSyncService, err := flagsync.NewSyncService(flagsync.SvcConfigurations{
+		Logger:  logger.WithFields(zap.String("component", "FlagSyncService")),
+		Port:    config.SyncServicePort,
+		Sources: sources,
+		Store:   s,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating sync service: %w", err)
 	}
 
 	// build sync providers

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -89,7 +89,6 @@ func (r *Runtime) Start() error {
 	defer func() {
 		r.Logger.Info("Shutting down server...")
 		r.Service.Shutdown()
-		r.FlagSync.Shutdown()
 		r.Logger.Info("Server successfully shutdown.")
 	}()
 
@@ -106,15 +105,14 @@ func (r *Runtime) Start() error {
 		// startup delay - allow all sync sources to finish the initial sync
 		<-time.After(5 * time.Second)
 
-		err := r.FlagSync.Start()
+		err := r.FlagSync.Start(gCtx)
 		if err != nil {
-			return fmt.Errorf("error from server: %w", err)
+			return fmt.Errorf("error from sync server: %w", err)
 		}
 
 		return nil
 	})
 
-	<-gCtx.Done()
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("errgroup closed with error: %w", err)
 	}

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	msync "sync"
 	"syscall"
-	"time"
 
 	"github.com/open-feature/flagd/core/pkg/evaluator"
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -102,9 +101,6 @@ func (r *Runtime) Start() error {
 	})
 
 	g.Go(func() error {
-		// startup delay - allow all sync sources to finish the initial sync
-		<-time.After(5 * time.Second)
-
 		err := r.FlagSync.Start(gCtx)
 		if err != nil {
 			return fmt.Errorf("error from sync server: %w", err)
@@ -147,10 +143,7 @@ func (r *Runtime) updateAndEmit(payload sync.DataSync) bool {
 		},
 	})
 
-	// Emit flag syncs only when re-syncs are not needed
-	if !resyncRequired {
-		r.FlagSync.Emit()
-	}
+	r.FlagSync.Emit(resyncRequired, payload.Source)
 
 	return resyncRequired
 }

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -13,12 +13,14 @@ import (
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/service"
 	"github.com/open-feature/flagd/core/pkg/sync"
+	flag_sync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
 	"golang.org/x/sync/errgroup"
 )
 
 type Runtime struct {
 	Evaluator     evaluator.IEvaluator
 	Logger        *logger.Logger
+	FlagSync      flag_sync.SyncService
 	Service       service.IFlagEvaluationService
 	ServiceConfig service.Configuration
 	SyncImpl      []sync.ISync
@@ -49,18 +51,16 @@ func (r *Runtime) Start() error {
 				// resync events are triggered when a delete occurs during flag merges in the store
 				// resync events may trigger further resync events, however for a flag to be deleted from the store
 				// its source must match, preventing the opportunity for resync events to snowball
-				if resyncRequired := r.updateWithNotify(data); resyncRequired {
+				if resyncRequired := r.updateAndEmit(data); resyncRequired {
 					for _, s := range r.SyncImpl {
 						p := s
-						go func() {
-							g.Go(func() error {
-								err := p.ReSync(gCtx, dataSync)
-								if err != nil {
-									return fmt.Errorf("error resyncing sources: %w", err)
-								}
-								return nil
-							})
-						}()
+						g.Go(func() error {
+							err := p.ReSync(gCtx, dataSync)
+							if err != nil {
+								return fmt.Errorf("error resyncing sources: %w", err)
+							}
+							return nil
+						})
 					}
 				}
 			case <-gCtx.Done():
@@ -99,6 +99,11 @@ func (r *Runtime) Start() error {
 		}
 		return nil
 	})
+
+	g.Go(func() error {
+		return r.FlagSync.Serve()
+	})
+
 	<-gCtx.Done()
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("errgroup closed with error: %w", err)
@@ -116,8 +121,8 @@ func (r *Runtime) isReady() bool {
 	return true
 }
 
-// updateWithNotify helps to update state and notify listeners
-func (r *Runtime) updateWithNotify(payload sync.DataSync) bool {
+// updateAndEmit helps to update state, notify changes and trigger sync updates
+func (r *Runtime) updateAndEmit(payload sync.DataSync) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -14,14 +14,14 @@ import (
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/service"
 	"github.com/open-feature/flagd/core/pkg/sync"
-	flag_sync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
+	flagsync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
 	"golang.org/x/sync/errgroup"
 )
 
 type Runtime struct {
 	Evaluator     evaluator.IEvaluator
 	Logger        *logger.Logger
-	FlagSync      flag_sync.ISyncService
+	FlagSync      flagsync.ISyncService
 	Service       service.IFlagEvaluationService
 	ServiceConfig service.Configuration
 	SyncImpl      []sync.ISync

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	msync "sync"
 	"syscall"
+	"time"
 
 	"github.com/open-feature/flagd/core/pkg/evaluator"
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -20,7 +21,7 @@ import (
 type Runtime struct {
 	Evaluator     evaluator.IEvaluator
 	Logger        *logger.Logger
-	FlagSync      *flag_sync.Service
+	FlagSync      flag_sync.ISyncService
 	Service       service.IFlagEvaluationService
 	ServiceConfig service.Configuration
 	SyncImpl      []sync.ISync
@@ -102,6 +103,9 @@ func (r *Runtime) Start() error {
 	})
 
 	g.Go(func() error {
+		// startup delay - allow all sync sources to finish the initial sync
+		<-time.After(5 * time.Second)
+
 		err := r.FlagSync.Serve()
 		if err != nil {
 			return fmt.Errorf("error from server: %w", err)

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -106,7 +106,7 @@ func (r *Runtime) Start() error {
 		// startup delay - allow all sync sources to finish the initial sync
 		<-time.After(5 * time.Second)
 
-		err := r.FlagSync.Serve()
+		err := r.FlagSync.Start()
 		if err != nil {
 			return fmt.Errorf("error from server: %w", err)
 		}

--- a/flagd/pkg/service/flag-sync/handler.go
+++ b/flagd/pkg/service/flag-sync/handler.go
@@ -12,7 +12,7 @@ import (
 
 // syncHandler implements the sync contract
 type syncHandler struct {
-	mux *syncMultiplexer
+	mux *Multiplexer
 	log *logger.Logger
 }
 
@@ -22,7 +22,7 @@ func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.F
 
 	ctx := server.Context()
 
-	err := s.mux.register(ctx, selector, muxPayload)
+	err := s.mux.Register(ctx, selector, muxPayload)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.F
 				return fmt.Errorf("error sending stream response: %w", err)
 			}
 		case <-ctx.Done():
-			s.mux.unregister(ctx, selector)
+			s.mux.Unregister(ctx, selector)
 			s.log.Debug("context done, exiting stream request")
 			return nil
 		}
@@ -46,7 +46,7 @@ func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.F
 func (s syncHandler) FetchAllFlags(_ context.Context, req *syncv1.FetchAllFlagsRequest) (
 	*syncv1.FetchAllFlagsResponse, error,
 ) {
-	flags, err := s.mux.getALlFlags(req.GetSelector())
+	flags, err := s.mux.GetALlFlags(req.GetSelector())
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (s syncHandler) GetMetadata(_ context.Context, _ *syncv1.GetMetadataRequest
 	*syncv1.GetMetadataResponse, error,
 ) {
 	metadata, err := structpb.NewStruct(map[string]interface{}{
-		"sources": s.mux.sourcesAsMetadata(),
+		"sources": s.mux.SourcesAsMetadata(),
 	})
 	if err != nil {
 		s.log.Warn(fmt.Sprintf("error from struct creation: %v", err))

--- a/flagd/pkg/service/flag-sync/handler.go
+++ b/flagd/pkg/service/flag-sync/handler.go
@@ -1,26 +1,74 @@
-package flag_sync
+package sync
 
 import (
-	syncv1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
-	"connectrpc.com/connect"
 	"context"
+	"fmt"
+
+	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
+	"buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// Request handler
+// syncHandler implements the sync contract
 type syncHandler struct {
+	mux *syncMultiplexer
+	log *logger.Logger
 }
 
-func (s syncHandler) SyncFlags(ctx context.Context, c *connect.Request[syncv1.SyncFlagsRequest], c2 *connect.ServerStream[syncv1.SyncFlagsResponse]) error {
-	//TODO implement me
-	panic("implement me")
+func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.FlagSyncService_SyncFlagsServer) error {
+	muxPayload := make(chan payload, 1)
+	selector := req.GetSelector()
+
+	ctx := server.Context()
+
+	err := s.mux.register(ctx, selector, muxPayload)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case payload := <-muxPayload:
+			err := server.Send(&syncv1.SyncFlagsResponse{FlagConfiguration: payload.flags})
+			if err != nil {
+				s.log.Debug(fmt.Sprintf("error sending stream response: %v", err))
+				return fmt.Errorf("error sending stream response: %w", err)
+			}
+		case <-ctx.Done():
+			s.mux.unregister(ctx, selector)
+			s.log.Debug("context done, exiting stream request")
+			return nil
+		}
+	}
 }
 
-func (s syncHandler) FetchAllFlags(ctx context.Context, c *connect.Request[syncv1.FetchAllFlagsRequest]) (*connect.Response[syncv1.FetchAllFlagsResponse], error) {
-	//TODO implement me
-	panic("implement me")
+func (s syncHandler) FetchAllFlags(_ context.Context, req *syncv1.FetchAllFlagsRequest) (
+	*syncv1.FetchAllFlagsResponse, error,
+) {
+	flags, err := s.mux.getALlFlags(req.GetSelector())
+	if err != nil {
+		return nil, err
+	}
+
+	return &syncv1.FetchAllFlagsResponse{
+		FlagConfiguration: flags,
+	}, nil
 }
 
-func (s syncHandler) GetMetadata(ctx context.Context, c *connect.Request[syncv1.GetMetadataRequest]) (*connect.Response[syncv1.GetMetadataResponse], error) {
-	//TODO implement me
-	panic("implement me")
+func (s syncHandler) GetMetadata(_ context.Context, _ *syncv1.GetMetadataRequest) (
+	*syncv1.GetMetadataResponse, error,
+) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"sources": s.mux.sourcesAsMetadata(),
+	})
+	if err != nil {
+		s.log.Warn(fmt.Sprintf("error from struct creation: %v", err))
+		return nil, fmt.Errorf("error constructing response")
+	}
+
+	return &syncv1.GetMetadataResponse{
+			Metadata: metadata,
+		},
+		nil
 }

--- a/flagd/pkg/service/flag-sync/handler.go
+++ b/flagd/pkg/service/flag-sync/handler.go
@@ -1,0 +1,26 @@
+package flag_sync
+
+import (
+	syncv1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
+	"connectrpc.com/connect"
+	"context"
+)
+
+// Request handler
+type syncHandler struct {
+}
+
+func (s syncHandler) SyncFlags(ctx context.Context, c *connect.Request[syncv1.SyncFlagsRequest], c2 *connect.ServerStream[syncv1.SyncFlagsResponse]) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s syncHandler) FetchAllFlags(ctx context.Context, c *connect.Request[syncv1.FetchAllFlagsRequest]) (*connect.Response[syncv1.FetchAllFlagsResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s syncHandler) GetMetadata(ctx context.Context, c *connect.Request[syncv1.GetMetadataRequest]) (*connect.Response[syncv1.GetMetadataResponse], error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/flagd/pkg/service/flag-sync/handler.go
+++ b/flagd/pkg/service/flag-sync/handler.go
@@ -46,7 +46,7 @@ func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.F
 func (s syncHandler) FetchAllFlags(_ context.Context, req *syncv1.FetchAllFlagsRequest) (
 	*syncv1.FetchAllFlagsResponse, error,
 ) {
-	flags, err := s.mux.GetALlFlags(req.GetSelector())
+	flags, err := s.mux.GetAllFlags(req.GetSelector())
 	if err != nil {
 		return nil, err
 	}

--- a/flagd/pkg/service/flag-sync/handler.go
+++ b/flagd/pkg/service/flag-sync/handler.go
@@ -37,7 +37,7 @@ func (s syncHandler) SyncFlags(req *syncv1.SyncFlagsRequest, server syncv1grpc.F
 			}
 		case <-ctx.Done():
 			s.mux.Unregister(ctx, selector)
-			s.log.Debug("context done, exiting stream request")
+			s.log.Debug("context complete and exiting stream request")
 			return nil
 		}
 	}
@@ -64,7 +64,7 @@ func (s syncHandler) GetMetadata(_ context.Context, _ *syncv1.GetMetadataRequest
 	})
 	if err != nil {
 		s.log.Warn(fmt.Sprintf("error from struct creation: %v", err))
-		return nil, fmt.Errorf("error constructing response")
+		return nil, fmt.Errorf("error constructing metadata response")
 	}
 
 	return &syncv1.GetMetadataResponse{

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -23,7 +23,7 @@ type Multiplexer struct {
 	allFlags      string            // pre-calculated all flags in store as a string
 	selectorFlags map[string]string // pre-calculated selector scoped flags in store as strings
 
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 type subscription struct {
@@ -136,6 +136,9 @@ func (r *Multiplexer) Unregister(id interface{}, selector string) {
 
 // GetAllFlags per specific source
 func (r *Multiplexer) GetAllFlags(source string) (string, error) {
+	r.mu.RLocker()
+	defer r.mu.RUnlock()
+
 	if source == "" {
 		return r.allFlags, nil
 	}
@@ -149,8 +152,8 @@ func (r *Multiplexer) GetAllFlags(source string) (string, error) {
 
 // SourcesAsMetadata returns all known sources, comma separated to be used as service metadata
 func (r *Multiplexer) SourcesAsMetadata() string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLocker()
+	defer r.mu.RUnlock()
 
 	return strings.Join(r.sources, ",")
 }

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -1,0 +1,6 @@
+package flag_sync
+
+// multiplex data sync to listeners
+
+type syncMultiplexer struct {
+}

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -134,8 +134,8 @@ func (r *Multiplexer) Unregister(id interface{}, selector string) {
 	delete(from, id)
 }
 
-// GetALlFlags per specific source
-func (r *Multiplexer) GetALlFlags(source string) (string, error) {
+// GetAllFlags per specific source
+func (r *Multiplexer) GetAllFlags(source string) (string, error) {
 	if source == "" {
 		return r.allFlags, nil
 	}

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -152,7 +152,7 @@ func (r *syncMultiplexer) extract() error {
 	clear(r.selectorFlags)
 
 	all := r.store.GetAll()
-	bytes, err := json.Marshal(all)
+	bytes, err := json.Marshal(map[string]interface{}{"flags": all})
 	if err != nil {
 		return fmt.Errorf("error from marshallin: %w", err)
 	}
@@ -173,7 +173,7 @@ func (r *syncMultiplexer) extract() error {
 	}
 
 	for source, flags := range collector {
-		bytes, err := json.Marshal(flags)
+		bytes, err := json.Marshal(map[string]interface{}{"flags": flags})
 		if err != nil {
 			return fmt.Errorf("unable to marshal flags: %w", err)
 		}

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -1,6 +1,185 @@
-package flag_sync
+package sync
 
-// multiplex data sync to listeners
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/open-feature/flagd/core/pkg/model"
+	"github.com/open-feature/flagd/core/pkg/store"
+)
 
 type syncMultiplexer struct {
+	store   *store.Flags
+	sources []string
+
+	subs         map[interface{}]subscription            // subscriptions on all sources
+	selectorSubs map[string]map[interface{}]subscription // source specific subscriptions
+
+	allFlags      string            // pre-calculated all flags in store as a string
+	selectorFlags map[string]string // pre-calculated selector scoped flags
+
+	mu sync.Mutex
+}
+
+type subscription struct {
+	id      interface{}
+	channel chan payload
+}
+
+type payload struct {
+	flags string
+}
+
+func newMux(store *store.Flags, sources []string) *syncMultiplexer {
+	return &syncMultiplexer{
+		store:         store,
+		sources:       sources,
+		subs:          map[interface{}]subscription{},
+		selectorSubs:  map[string]map[interface{}]subscription{},
+		selectorFlags: map[string]string{},
+	}
+}
+
+func (r *syncMultiplexer) register(id interface{}, source string, con chan payload) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if source != "" && !slices.Contains(r.sources, source) {
+		return fmt.Errorf("no flag watcher setup for source %s", source)
+	}
+
+	var initSync string
+	var err error
+
+	if source == "" {
+		// subscribe for flags from all source
+		r.subs[id] = subscription{
+			id:      id,
+			channel: con,
+		}
+
+		initSync, err = r.store.String()
+		if err != nil {
+			return fmt.Errorf("errpr getting all flags: %w", err)
+		}
+	} else {
+		// subscribe for specific source
+		s, ok := r.selectorSubs[source]
+		if ok {
+			s[id] = subscription{
+				id:      id,
+				channel: con,
+			}
+		} else {
+			r.selectorSubs[source] = map[interface{}]subscription{
+				id: {
+					id:      id,
+					channel: con,
+				},
+			}
+		}
+
+		initSync = r.selectorFlags[source]
+	}
+
+	// Initial sync
+	con <- payload{flags: initSync}
+	return nil
+}
+
+func (r *syncMultiplexer) pushUpdates() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	err := r.extract()
+	if err != nil {
+		return err
+	}
+
+	// push to all source subs
+	for _, sub := range r.subs {
+		sub.channel <- payload{r.allFlags}
+	}
+
+	// push to selector subs
+	for source, flags := range r.selectorFlags {
+		for _, s := range r.selectorSubs[source] {
+			s.channel <- payload{flags}
+		}
+	}
+
+	return nil
+}
+
+func (r *syncMultiplexer) unregister(id interface{}, selector string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var from map[interface{}]subscription
+
+	if selector == "" {
+		from = r.subs
+	} else {
+		from = r.selectorSubs[selector]
+	}
+
+	delete(from, id)
+}
+
+func (r *syncMultiplexer) getALlFlags(source string) (string, error) {
+	if source != "" && !slices.Contains(r.sources, source) {
+		return "", fmt.Errorf("no flag watcher setup for source %s", source)
+	}
+
+	if source == "" {
+		return r.allFlags, nil
+	}
+
+	return r.selectorFlags[source], nil
+}
+
+func (r *syncMultiplexer) sourcesAsMetadata() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return strings.Join(r.store.FlagSources, ",")
+}
+
+func (r *syncMultiplexer) extract() error {
+	clear(r.selectorFlags)
+
+	all := r.store.GetAll()
+	bytes, err := json.Marshal(all)
+	if err != nil {
+		return fmt.Errorf("error from marshallin: %w", err)
+	}
+
+	r.allFlags = string(bytes)
+
+	collector := map[string]map[string]model.Flag{}
+
+	for key, flag := range all {
+		c, ok := collector[flag.Source]
+		if ok {
+			c[key] = flag
+		} else {
+			collector[flag.Source] = map[string]model.Flag{
+				key: flag,
+			}
+		}
+	}
+
+	for source, flags := range collector {
+		bytes, err := json.Marshal(flags)
+		if err != nil {
+			return fmt.Errorf("unable to marshal flags: %w", err)
+		}
+
+		r.selectorFlags[source] = string(bytes)
+	}
+
+	return nil
 }

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -151,7 +151,7 @@ func TestGetAllFlags(t *testing.T) {
 	}
 
 	// when - get all with open scope
-	flags, err := mux.GetALlFlags("")
+	flags, err := mux.GetAllFlags("")
 	if err != nil {
 		t.Fatal("error when retrieving all flags")
 		return
@@ -163,7 +163,7 @@ func TestGetAllFlags(t *testing.T) {
 	}
 
 	// when - get all with a scope
-	flags, err = mux.GetALlFlags("A")
+	flags, err = mux.GetAllFlags("A")
 	if err != nil {
 		t.Fatal("error when retrieving all flags")
 		return

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestRegistration(t *testing.T) {
 	// given
-	mux := newMux(getSimpleFlagStore())
-	err := mux.extract()
+	mux := NewMux(getSimpleFlagStore())
+	err := mux.reFill()
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
@@ -57,7 +57,7 @@ func TestRegistration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			// when
-			err := mux.register(test.id, test.source, test.connection)
+			err := mux.Register(test.id, test.source, test.connection)
 
 			// then
 			if !test.expectError && err != nil {
@@ -93,8 +93,8 @@ func TestRegistration(t *testing.T) {
 
 func TestUpdateAndRemoval(t *testing.T) {
 	// given
-	mux := newMux(getSimpleFlagStore())
-	err := mux.extract()
+	mux := NewMux(getSimpleFlagStore())
+	err := mux.reFill()
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
@@ -102,7 +102,7 @@ func TestUpdateAndRemoval(t *testing.T) {
 
 	identifier := context.Background()
 	channel := make(chan payload, 1)
-	err = mux.register(identifier, "", channel)
+	err = mux.Register(identifier, "", channel)
 	if err != nil {
 		t.Fatal("error during subscription registration")
 		return
@@ -116,7 +116,7 @@ func TestUpdateAndRemoval(t *testing.T) {
 	}
 
 	// when - updates are triggered
-	err = mux.pushUpdates()
+	err = mux.Publish()
 	if err != nil {
 		t.Fatal("failure to trigger update request on multiplexer")
 		return
@@ -131,8 +131,8 @@ func TestUpdateAndRemoval(t *testing.T) {
 	}
 
 	// when - subscription removed & update triggered
-	mux.unregister(identifier, "")
-	err = mux.pushUpdates()
+	mux.Unregister(identifier, "")
+	err = mux.Publish()
 	if err != nil {
 		t.Fatal("failure to trigger update request on multiplexer")
 		return
@@ -149,15 +149,15 @@ func TestUpdateAndRemoval(t *testing.T) {
 
 func TestGetAllFlags(t *testing.T) {
 	// given
-	mux := newMux(getSimpleFlagStore())
-	err := mux.extract()
+	mux := NewMux(getSimpleFlagStore())
+	err := mux.reFill()
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
 	}
 
 	// when - get all with open scope
-	flags, err := mux.getALlFlags("")
+	flags, err := mux.GetALlFlags("")
 	if err != nil {
 		t.Fatal("error when retrieving all flags")
 		return
@@ -169,7 +169,7 @@ func TestGetAllFlags(t *testing.T) {
 	}
 
 	// when - get all with a scope
-	flags, err = mux.getALlFlags("A")
+	flags, err = mux.GetALlFlags("A")
 	if err != nil {
 		t.Fatal("error when retrieving all flags")
 		return

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -1,0 +1,208 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-feature/flagd/core/pkg/model"
+	"github.com/open-feature/flagd/core/pkg/store"
+)
+
+func TestRegistration(t *testing.T) {
+	// given
+	mux := newMux(getSimpleFlagStore())
+	err := mux.extract()
+	if err != nil {
+		t.Fatal("error during flag extraction")
+		return
+	}
+
+	tests := []struct {
+		testName    string
+		id          interface{}
+		source      string
+		connection  chan payload
+		expectError bool
+	}{
+		{
+			testName:   "subscribe to all flags",
+			id:         context.Background(),
+			connection: make(chan payload, 1),
+		},
+		{
+			testName:   "subscribe to source A",
+			id:         context.Background(),
+			source:     "A",
+			connection: make(chan payload, 1),
+		},
+		{
+			testName:   "subscribe to source B",
+			id:         context.Background(),
+			source:     "B",
+			connection: make(chan payload, 1),
+		},
+		{
+			testName:    "subscribe to non-existing",
+			id:          context.Background(),
+			source:      "C",
+			connection:  make(chan payload, 1),
+			expectError: true,
+		},
+	}
+
+	// validate registration
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			// when
+			err := mux.register(test.id, test.source, test.connection)
+
+			// then
+			if !test.expectError && err != nil {
+				t.Fatal("expected no errors, but got error")
+			}
+
+			if test.expectError && err != nil {
+				// pass
+				return
+			}
+
+			// validate subscription
+			var initSync payload
+			select {
+			case <-time.After(2 * time.Second):
+				t.Fatal("data sync did not complete for initial sync within an acceptable timeframe")
+
+			case initSync = <-test.connection:
+				break
+			}
+
+			if initSync.flags == "" {
+				t.Fatal("expected non empty flag payload, but got empty")
+			}
+
+			// validate source of flag
+			if test.source != "" && !strings.Contains(initSync.flags, fmt.Sprintf("\"source\":\"%s\"", test.source)) {
+				t.Fatal("expected initial flag response to contain flags from source, but failed to find source")
+			}
+		})
+	}
+}
+
+func TestUpdateAndRemoval(t *testing.T) {
+	// given
+	mux := newMux(getSimpleFlagStore())
+	err := mux.extract()
+	if err != nil {
+		t.Fatal("error during flag extraction")
+		return
+	}
+
+	identifier := context.Background()
+	channel := make(chan payload, 1)
+	err = mux.register(identifier, "", channel)
+	if err != nil {
+		t.Fatal("error during subscription registration")
+		return
+	}
+
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("data sync did not complete for initial sync within an acceptable timeframe")
+	case <-channel:
+		break
+	}
+
+	// when - updates are triggered
+	err = mux.pushUpdates()
+	if err != nil {
+		t.Fatal("failure to trigger update request on multiplexer")
+		return
+	}
+
+	// then
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("data sync did not complete for initial sync within an acceptable timeframe")
+	case <-channel:
+		break
+	}
+
+	// when - subscription removed & update triggered
+	mux.unregister(identifier, "")
+	err = mux.pushUpdates()
+	if err != nil {
+		t.Fatal("failure to trigger update request on multiplexer")
+		return
+	}
+
+	// then
+	select {
+	case <-time.After(2 * time.Second):
+		break
+	case <-channel:
+		t.Fatal("expected no sync but got an update as removal was not performed")
+	}
+}
+
+func TestGetAllFlags(t *testing.T) {
+	// given
+	mux := newMux(getSimpleFlagStore())
+	err := mux.extract()
+	if err != nil {
+		t.Fatal("error during flag extraction")
+		return
+	}
+
+	// when - get all with open scope
+	flags, err := mux.getALlFlags("")
+	if err != nil {
+		t.Fatal("error when retrieving all flags")
+		return
+	}
+
+	if len(flags) == 0 {
+		t.Fatal("expected no empty flags")
+		return
+	}
+
+	// when - get all with a scope
+	flags, err = mux.getALlFlags("A")
+	if err != nil {
+		t.Fatal("error when retrieving all flags")
+		return
+	}
+
+	if len(flags) == 0 || !strings.Contains(flags, fmt.Sprintf("\"source\":\"%s\"", "A")) {
+		t.Fatal("expected flags to be scoped")
+		return
+	}
+}
+
+// getSimpleFlagStore returns a flag store pre-filled with flags from sources A & B
+func getSimpleFlagStore() (*store.Flags, []string) {
+	variants := map[string]any{
+		"true":  true,
+		"false": false,
+	}
+
+	flagStore := store.NewFlags()
+
+	flagStore.Set("flagA", model.Flag{
+		State:          "ENABLED",
+		DefaultVariant: "false",
+		Variants:       variants,
+		Source:         "A",
+	})
+
+	flagStore.Set("flagB", model.Flag{
+		State:          "ENABLED",
+		DefaultVariant: "true",
+		Variants:       variants,
+		Source:         "B",
+	})
+
+	return flagStore, []string{"A", "B"}
+}

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -6,15 +6,11 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/open-feature/flagd/core/pkg/model"
-	"github.com/open-feature/flagd/core/pkg/store"
 )
 
 func TestRegistration(t *testing.T) {
 	// given
-	mux := NewMux(getSimpleFlagStore())
-	err := mux.reFill()
+	mux, err := NewMux(getSimpleFlagStore())
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
@@ -93,8 +89,7 @@ func TestRegistration(t *testing.T) {
 
 func TestUpdateAndRemoval(t *testing.T) {
 	// given
-	mux := NewMux(getSimpleFlagStore())
-	err := mux.reFill()
+	mux, err := NewMux(getSimpleFlagStore())
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
@@ -149,8 +144,7 @@ func TestUpdateAndRemoval(t *testing.T) {
 
 func TestGetAllFlags(t *testing.T) {
 	// given
-	mux := NewMux(getSimpleFlagStore())
-	err := mux.reFill()
+	mux, err := NewMux(getSimpleFlagStore())
 	if err != nil {
 		t.Fatal("error during flag extraction")
 		return
@@ -179,30 +173,4 @@ func TestGetAllFlags(t *testing.T) {
 		t.Fatal("expected flags to be scoped")
 		return
 	}
-}
-
-// getSimpleFlagStore returns a flag store pre-filled with flags from sources A & B
-func getSimpleFlagStore() (*store.Flags, []string) {
-	variants := map[string]any{
-		"true":  true,
-		"false": false,
-	}
-
-	flagStore := store.NewFlags()
-
-	flagStore.Set("flagA", model.Flag{
-		State:          "ENABLED",
-		DefaultVariant: "false",
-		Variants:       variants,
-		Source:         "A",
-	})
-
-	flagStore.Set("flagB", model.Flag{
-		State:          "ENABLED",
-		DefaultVariant: "true",
-		Variants:       variants,
-		Source:         "B",
-	})
-
-	return flagStore, []string{"A", "B"}
 }

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -107,7 +107,7 @@ func (s *Service) Start(ctx context.Context) error {
 }
 
 func (s *Service) Emit(isResync bool, source string) {
-	s.startupTracker.trackAndUpdate(source)
+	s.startupTracker.trackAndRemove(source)
 
 	if !isResync {
 		err := s.mux.Publish()
@@ -137,7 +137,8 @@ func (t *syncTracker) done() <-chan interface{} {
 	return t.doneChan
 }
 
-func (t *syncTracker) trackAndUpdate(source string) {
+// trackAndRemove tracks sources and remove channel if all sources that are tracking are complete.
+func (t *syncTracker) trackAndRemove(source string) {
 	index := slices.Index(t.sources, source)
 	if index < 0 {
 		return

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -1,22 +1,22 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"net"
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/store"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
 
 type ISyncService interface {
 	// Start the sync service
-	Start() error
+	Start(context.Context) error
 	// Emit updates for sync listeners
 	Emit()
-	// Shutdown the sync service
-	Shutdown()
 }
 
 type SvcConfigurations struct {
@@ -60,10 +60,28 @@ func NewSyncService(cfg SvcConfigurations) (*Service, error) {
 	}, nil
 }
 
-func (s *Service) Start() error {
-	err := s.server.Serve(s.listener)
+func (s *Service) Start(ctx context.Context) error {
+	// derive errgroup so we track ctx for exit as well as startup errors
+	g, lCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		err := s.server.Serve(s.listener)
+		if err != nil {
+			s.logger.Info(fmt.Sprintf("error from sync server start: %v", err))
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		<-lCtx.Done()
+		s.shutdown()
+
+		return nil
+	})
+
+	err := g.Wait()
 	if err != nil {
-		return fmt.Errorf("error from server start: %w", err)
+		return fmt.Errorf("error from sync service: %w", err)
 	}
 
 	return nil
@@ -77,7 +95,7 @@ func (s *Service) Emit() {
 	}
 }
 
-func (s *Service) Shutdown() {
+func (s *Service) shutdown() {
 	err := s.listener.Close()
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("error closing the listener: %v", err))
@@ -89,15 +107,11 @@ func (s *Service) Shutdown() {
 // This can be used as a default implementation and avoid unnecessary null checks or service enabled checks in runtime.
 type NoopSyncService struct{}
 
-func (n *NoopSyncService) Start() error {
+func (n *NoopSyncService) Start(context.Context) error {
 	// NOOP
 	return nil
 }
 
 func (n *NoopSyncService) Emit() {
-	// NOOP
-}
-
-func (n *NoopSyncService) Shutdown() {
 	// NOOP
 }

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -77,7 +77,7 @@ func (s *Service) Start(ctx context.Context) error {
 		// delay server start until we see all syncs from known sync sources OR timeout
 		select {
 		case <-time.After(5 * time.Second):
-			s.logger.Warn("timeout waiting for all sync sources to complete their initial sync. " +
+			s.logger.Warn("timeout while waiting for all sync sources to complete their initial sync. " +
 				"continuing sync service")
 			break
 		case <-s.startupTracker.done():

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -1,0 +1,58 @@
+package flag_sync
+
+import (
+	"buf.build/gen/go/open-feature/flagd/connectrpc/go/flagd/sync/v1/syncv1connect"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
+)
+
+// Service wrapper
+
+type SvcConfigurations struct {
+	Logger *logger.Logger
+	Port   uint16
+}
+
+type SyncService struct {
+	logger  *logger.Logger
+	server  *http.Server
+	sources []string
+}
+
+func NewSyncService(sources []string, cfg SvcConfigurations) SyncService {
+	l := cfg.Logger
+	path, h := syncv1connect.NewFlagSyncServiceHandler(&syncHandler{})
+	l.Info(fmt.Sprintf("serving flag syncs at %s", path))
+
+	server := http.Server{
+		Addr:    fmt.Sprintf(":%d", cfg.Port),
+		Handler: h,
+	}
+
+	return SyncService{
+		l,
+		&server,
+		sources,
+	}
+}
+
+func (s *SyncService) Serve() error {
+	err := s.server.ListenAndServe()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SyncService) Shutdown() error {
+	err := s.server.Shutdown(context.Background())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -11,8 +11,11 @@ import (
 )
 
 type ISyncService interface {
-	Serve() error
+	// Start the sync service
+	Start() error
+	// Emit updates for sync listeners
 	Emit()
+	// Shutdown the sync service
 	Shutdown()
 }
 
@@ -57,10 +60,10 @@ func NewSyncService(cfg SvcConfigurations) (*Service, error) {
 	}, nil
 }
 
-func (s *Service) Serve() error {
+func (s *Service) Start() error {
 	err := s.server.Serve(s.listener)
 	if err != nil {
-		return fmt.Errorf("error from server: %w", err)
+		return fmt.Errorf("error from server start: %w", err)
 	}
 
 	return nil
@@ -69,7 +72,7 @@ func (s *Service) Serve() error {
 func (s *Service) Emit() {
 	err := s.mux.Publish()
 	if err != nil {
-		s.logger.Warn(fmt.Sprintf("error: %v", err))
+		s.logger.Warn(fmt.Sprintf("error while publishing sync streams: %v", err))
 		return
 	}
 }
@@ -82,10 +85,11 @@ func (s *Service) Shutdown() {
 	s.server.Stop()
 }
 
-// NoopSyncService as a filler implementation of the sync service
+// NoopSyncService as a filler implementation of the sync service.
+// This can be used as a default implementation and avoid unnecessary null checks or service enabled checks in runtime.
 type NoopSyncService struct{}
 
-func (n *NoopSyncService) Serve() error {
+func (n *NoopSyncService) Start() error {
 	// NOOP
 	return nil
 }

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -10,6 +10,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+type ISyncService interface {
+	Serve() error
+	Emit()
+	Shutdown()
+}
+
 type SvcConfigurations struct {
 	Logger  *logger.Logger
 	Port    uint16
@@ -18,10 +24,10 @@ type SvcConfigurations struct {
 }
 
 type Service struct {
-	logger   *logger.Logger
-	server   *grpc.Server
 	listener net.Listener
+	logger   *logger.Logger
 	mux      *syncMultiplexer
+	server   *grpc.Server
 }
 
 func NewSyncService(cfg SvcConfigurations) (*Service, error) {
@@ -40,10 +46,10 @@ func NewSyncService(cfg SvcConfigurations) (*Service, error) {
 	}
 
 	return &Service{
-		l,
-		server,
-		listener,
-		mux,
+		listener: listener,
+		logger:   l,
+		mux:      mux,
+		server:   server,
 	}, nil
 }
 
@@ -66,4 +72,20 @@ func (s *Service) Emit() {
 
 func (s *Service) Shutdown() {
 	s.server.Stop()
+}
+
+// NoopSyncService as a filler implementation of the sync service
+type NoopSyncService struct{}
+
+func (n *NoopSyncService) Serve() error {
+	// NOOP
+	return nil
+}
+
+func (n *NoopSyncService) Emit() {
+	// NOOP
+}
+
+func (n *NoopSyncService) Shutdown() {
+	// NOOP
 }

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -26,13 +26,13 @@ type SvcConfigurations struct {
 type Service struct {
 	listener net.Listener
 	logger   *logger.Logger
-	mux      *syncMultiplexer
+	mux      *Multiplexer
 	server   *grpc.Server
 }
 
 func NewSyncService(cfg SvcConfigurations) (*Service, error) {
 	l := cfg.Logger
-	mux := newMux(cfg.Store, cfg.Sources)
+	mux := NewMux(cfg.Store, cfg.Sources)
 
 	server := grpc.NewServer()
 	syncv1grpc.RegisterFlagSyncServiceServer(server, &syncHandler{
@@ -63,7 +63,7 @@ func (s *Service) Serve() error {
 }
 
 func (s *Service) Emit() {
-	err := s.mux.pushUpdates()
+	err := s.mux.Publish()
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("error: %v", err))
 		return

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -149,16 +149,3 @@ func (t *syncTracker) trackAndUpdate(source string) {
 		close(t.doneChan)
 	}
 }
-
-// NoopSyncService as a filler implementation of the sync service.
-// This can be used as a default implementation and avoid unnecessary null checks or service enabled checks in runtime.
-type NoopSyncService struct{}
-
-func (n *NoopSyncService) Start(context.Context) error {
-	// NOOP
-	return nil
-}
-
-func (n *NoopSyncService) Emit(bool, string) {
-	// NOOP
-}

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -80,7 +80,7 @@ func (s *Service) Start(ctx context.Context) error {
 			s.logger.Warn("timeout while waiting for all sync sources to complete their initial sync. " +
 				"continuing sync service")
 			break
-		case <-s.startupTracker.done():
+		case <-s.startupTracker.getDone():
 			break
 		}
 
@@ -133,7 +133,7 @@ type syncTracker struct {
 	doneChan chan interface{}
 }
 
-func (t *syncTracker) done() <-chan interface{} {
+func (t *syncTracker) getDone() <-chan interface{} {
 	return t.doneChan
 }
 

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -1,0 +1,111 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
+	v1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestSyncServiceEndToEnd(t *testing.T) {
+	// given
+	port := 18016
+	store, sources := getSimpleFlagStore()
+
+	service, err := NewSyncService(SvcConfigurations{
+		Logger:  logger.NewLogger(nil, false),
+		Port:    uint16(port),
+		Sources: sources,
+		Store:   store,
+	})
+	if err != nil {
+		t.Fatal("error creating the service: %w", err)
+		return
+	}
+
+	group, ctx := errgroup.WithContext(context.Background())
+	group.Go(func() error {
+		err := service.Serve()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// when - dial the server
+	con, err := grpc.DialContext(ctx, fmt.Sprintf("localhost:%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(fmt.Printf("error creating grpc dial ctx: %v", err))
+		return
+	}
+
+	serviceClient := syncv1grpc.NewFlagSyncServiceClient(con)
+
+	// then
+
+	// sync flags
+	flags, err := serviceClient.SyncFlags(ctx, &v1.SyncFlagsRequest{})
+	if err != nil {
+		t.Fatal(fmt.Printf("error from sync request: %v", err))
+		return
+	}
+
+	syncRsp, err := flags.Recv()
+	if err != nil {
+		t.Fatal(fmt.Printf("stream error: %v", err))
+		return
+	}
+
+	if len(syncRsp.GetFlagConfiguration()) == 0 {
+		t.Error("expected non empty sync response, but got empty")
+	}
+
+	// fetch all flags
+	allRsp, err := serviceClient.FetchAllFlags(ctx, &v1.FetchAllFlagsRequest{})
+	if err != nil {
+		t.Fatal(fmt.Printf("fetch all error: %v", err))
+		return
+	}
+
+	if allRsp.GetFlagConfiguration() != syncRsp.GetFlagConfiguration() {
+		t.Errorf("expected both sync and fetch all responses to be same, but got %s from sync & %s from fetch all",
+			syncRsp.GetFlagConfiguration(), allRsp.GetFlagConfiguration())
+	}
+
+	// metadata request
+	metadataRsp, err := serviceClient.GetMetadata(ctx, &v1.GetMetadataRequest{})
+	if err != nil {
+		t.Fatal(fmt.Printf("metadata error: %v", err))
+		return
+	}
+
+	asMap := metadataRsp.GetMetadata().AsMap()
+
+	// expect `sources` to be present
+	if asMap["sources"] == nil {
+		t.Fatal("expected sources entry in the metadata, but got nil")
+	}
+
+	if asMap["sources"] != "A,B" {
+		t.Fatal("incorrect sources entry in metadata")
+	}
+
+	// validate shutdown
+	go func() {
+		service.Shutdown()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(2 * time.Second):
+		t.Fatal("service did not exist within sufficient timeframe")
+	}
+}

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -32,14 +32,14 @@ func TestSyncServiceEndToEnd(t *testing.T) {
 
 	group, ctx := errgroup.WithContext(context.Background())
 	group.Go(func() error {
-		err := service.Serve()
+		err := service.Start()
 		if err != nil {
 			return err
 		}
 		return nil
 	})
 
-	// when - dial the server
+	// when - derive a client for sync service
 	con, err := grpc.DialContext(ctx, fmt.Sprintf("localhost:%d", port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatal(fmt.Printf("error creating grpc dial ctx: %v", err))
@@ -96,6 +96,8 @@ func TestSyncServiceEndToEnd(t *testing.T) {
 	if asMap["sources"] != "A,B" {
 		t.Fatal("incorrect sources entry in metadata")
 	}
+
+	//
 
 	// validate shutdown
 	go func() {

--- a/flagd/pkg/service/flag-sync/util_test.go
+++ b/flagd/pkg/service/flag-sync/util_test.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"github.com/open-feature/flagd/core/pkg/model"
+	"github.com/open-feature/flagd/core/pkg/store"
+)
+
+// getSimpleFlagStore returns a flag store pre-filled with flags from sources A & B
+func getSimpleFlagStore() (*store.Flags, []string) {
+	variants := map[string]any{
+		"true":  true,
+		"false": false,
+	}
+
+	flagStore := store.NewFlags()
+
+	flagStore.Set("flagA", model.Flag{
+		State:          "ENABLED",
+		DefaultVariant: "false",
+		Variants:       variants,
+		Source:         "A",
+	})
+
+	flagStore.Set("flagB", model.Flag{
+		State:          "ENABLED",
+		DefaultVariant: "true",
+		Variants:       variants,
+		Source:         "B",
+	})
+
+	return flagStore, []string{"A", "B"}
+}


### PR DESCRIPTION
## This PR

Introduce flag sync capability to flagd as discussed at [1] and fixes https://github.com/open-feature/flagd/issues/1230 .

**What's changed ?**

The change included with this PR introduces the gRPC sync contract [2]. This allows flagd to expose its store to in-process provider which consumes gRPC flag stream. 

![image](https://github.com/open-feature/flagd/assets/8186721/871ed21f-612a-46d4-95b6-6459d43cb077)

**How to use ?**

flagd will start sync service on port `8015`. You can alter the default sync port by providing desired port to the startup flag `syncPort` (`--sync-port=8686`) 

**Implementation details**

- Sync service startup is delayed to allow configured flag sources to complete their initial loading (dealy is 5 seconds)
- Sync request's `selector` can be used to specify the specific flag source. If unset, all flags will be sent
- A new stream response will be created whenever there are updates from flag sources 


[1] - https://github.com/open-feature/flagd/discussions/1153 
[2] - https://github.com/open-feature/flagd-schemas/blob/main/protobuf/flagd/sync/v1/sync.proto
