### PR TITLE
docs: relax CO headers for schemas

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,9 @@
     poetry install -v &&
     mkdocs build
   """
+
+[[headers]]
+  # Relax cross origin restrictions for schemas, so they can be requested by front-end apps.
+  for = "/schema/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
See title. This just allows frontend apps to pull schemas instead of getting blocked by the CO policy.

EDIT:

Tested in the netlify preview and works as expected. Only the `schemas` path is impacted, no CORS on rest of site.