### PR TITLE
docs: disable social plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,8 @@ nav:
   - 'FAQ': 'faq.md'
   - 'Troubleshooting': 'troubleshooting.md'
 plugins:
-  - social
+  # Disabling social until https://github.com/squidfunk/mkdocs-material/issues/6983 is resolved
+  # - social
   - search
   # https://github.com/mondeja/mkdocs-include-markdown-plugin
   - include-markdown


### PR DESCRIPTION
## This PR

- disables the social plugin in mkdocs

### Notes

Disables the social plugin until the Google Font issue is resolved.

https://github.com/squidfunk/mkdocs-material/issues/6983
