### PR TITLE
fix: fixes store merge when selector is used

### DIFF
--- a/core/pkg/evaluator/json.go
+++ b/core/pkg/evaluator/json.go
@@ -121,11 +121,11 @@ func (je *JSON) SetState(payload sync.DataSync) (map[string]interface{}, bool, e
 
 	switch payload.Type {
 	case sync.ALL:
-		events, reSync = je.store.Merge(je.Logger, payload.Source, newFlags.Flags)
+		events, reSync = je.store.Merge(je.Logger, payload.Source, payload.Selector, newFlags.Flags)
 	case sync.ADD:
-		events = je.store.Add(je.Logger, payload.Source, newFlags.Flags)
+		events = je.store.Add(je.Logger, payload.Source, payload.Selector, newFlags.Flags)
 	case sync.UPDATE:
-		events = je.store.Update(je.Logger, payload.Source, newFlags.Flags)
+		events = je.store.Update(je.Logger, payload.Source, payload.Selector, newFlags.Flags)
 	case sync.DELETE:
 		events = je.store.DeleteFlags(je.Logger, payload.Source, newFlags.Flags)
 	default:

--- a/core/pkg/evaluator/json_test.go
+++ b/core/pkg/evaluator/json_test.go
@@ -905,6 +905,7 @@ func TestState_Evaluator(t *testing.T) {
 						  "defaultVariant": "recursive",
 						  "state": "ENABLED",
 						  "source":"",
+						  "selector":"",
 						  "targeting": {
 							"if": [
 							  {
@@ -965,6 +966,7 @@ func TestState_Evaluator(t *testing.T) {
 						  "defaultVariant": "recursive",
 						  "state": "ENABLED",
 						  "source":"",
+						  "selector":"",
 						  "targeting": {
 							"if": [
 							  {
@@ -1023,7 +1025,6 @@ func TestState_Evaluator(t *testing.T) {
 						},
 						"defaultVariant": "recursive",
 						"state": "ENABLED",
-						"source":"",
 						"targeting": {
 						"if": [
 							{
@@ -1077,6 +1078,7 @@ func TestState_Evaluator(t *testing.T) {
 						"defaultVariant": "recursive",
 						"state": "ENABLED",
 						"source":"",
+						"selector":"",
 						"targeting": {
 						"if": [
 							{
@@ -1095,6 +1097,7 @@ func TestState_Evaluator(t *testing.T) {
 						},
 						"defaultVariant": "off",
 						"source":"",
+						"selector":"",
 						"targeting": {
 							"if": [
 								{

--- a/core/pkg/model/flag.go
+++ b/core/pkg/model/flag.go
@@ -8,6 +8,7 @@ type Flag struct {
 	Variants       map[string]any  `json:"variants"`
 	Targeting      json.RawMessage `json:"targeting,omitempty"`
 	Source         string          `json:"source"`
+	Selector       string          `json:"selector"`
 }
 
 type Evaluators struct {

--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -76,7 +76,7 @@ func (g *Sync) Init(ctx context.Context) error {
 }
 
 func (g *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error {
-	res, err := g.client.FetchAllFlags(ctx, &v1.FetchAllFlagsRequest{})
+	res, err := g.client.FetchAllFlags(ctx, &v1.FetchAllFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
 	if err != nil {
 		err = fmt.Errorf("error fetching all flags: %w", err)
 		g.Logger.Error(err.Error())
@@ -181,6 +181,7 @@ func (g *Sync) handleFlagSync(stream syncv1grpc.FlagSyncService_SyncFlagsClient,
 		dataSync <- sync.DataSync{
 			FlagData: data.FlagConfiguration,
 			Source:   g.URI,
+			Selector: g.Selector,
 			Type:     sync.ALL,
 		}
 

--- a/core/pkg/sync/isync.go
+++ b/core/pkg/sync/isync.go
@@ -57,6 +57,7 @@ type ISync interface {
 type DataSync struct {
 	FlagData string
 	Source   string
+	Selector string
 	Type
 }
 


### PR DESCRIPTION
## This PR

This change address https://github.com/open-feature/open-feature-operator/issues/664.

**Background**

We allow using multiple flag source CRDs when using flagd-proxy with OFO. Internally, this converts to flagd using gRPC syncs with scopes, where scopes specify the CRD names that need to source flags from. 

**Bug**

We had two bugs, first gRPC resyncs never contained `scope`. This is why we observed `unable to build sync from URI for target` message. Secondly, we triggered resyncs only considering source equility. This is not valid with flagd-proxy as we always go through the proxy for any CRD.

**Fix**

Fix here adds scope to gRPC resyncs and considers both source and selector equality when triggering a resync 

**How to validate the fix**

[Use this image](https://hub.docker.com/repository/docker/kavindudodanduwa/flagd/general) with OFO sidecar image override 

```helm upgrade --install openfeature openfeature/open-feature-operator --set sidecarConfiguration.image.tag=1,sidecarConfiguration.image.repository=kavindudodanduwa/flagd```