### PR TITLE
feat: support `FLAGD_DEBUG` / `--debug` / `-x`

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ description: troubleshooting flagd
 If a flag or targeting rule isn't proceeding the way you'd expect, you may want to enable more verbose logging.
 
 flagd and flagd providers typically have debug or verbose logging modes that you can use for this sort of troubleshooting.
-You can do this in the standalone version of flagd by starting it with the `--debug` flag (see [CLI](./reference/flagd-cli/flagd.md) for more information).
+You can do this in the standalone version of flagd by starting it with the `--debug` flag (see [CLI](./reference/flagd-cli/flagd.md) for more information) or through `FLAGD_DEBUG` env variable.
 
 _In-process_ providers which embed the flag evaluation engine use a logging consistent with their implementation language and SDK.
 See your provider's documentation for details on how to enable verbose logging.

--- a/flagd/cmd/root.go
+++ b/flagd/cmd/root.go
@@ -47,6 +47,10 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "x", false, "verbose logging")
+	// Bind the cobra flag to viper key
+	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {
+		fmt.Fprintln(os.Stderr, "error when binding flags", err.Error())
+	}
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.agent.yaml)")
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(versionCmd)
@@ -69,6 +73,7 @@ func initConfig() {
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
+	Debug = viper.GetBool("debug")
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Observes debug env variable [with or prefix will be `FLAGD_DEBUG`] and binds `--debug` and `-x` flags to it.

### Related Issues
Fixes #1323

