### PR TITLE
feat!: support emitting errors from the bulk evaluator

### DIFF
--- a/core/pkg/evaluator/fractional.go
+++ b/core/pkg/evaluator/fractional.go
@@ -27,7 +27,7 @@ func NewFractional(logger *logger.Logger) *Fractional {
 func (fe *Fractional) Evaluate(values, data any) any {
 	valueToDistribute, feDistributions, err := parseFractionalEvaluationData(values, data)
 	if err != nil {
-		fe.Logger.Error(fmt.Sprintf("parse fractional evaluation data: %v", err))
+		fe.Logger.Warn(fmt.Sprintf("parse fractional evaluation data: %v", err))
 		return nil
 	}
 

--- a/core/pkg/evaluator/ievaluator.go
+++ b/core/pkg/evaluator/ievaluator.go
@@ -77,5 +77,5 @@ type IResolver interface {
 	ResolveAllValues(
 		ctx context.Context,
 		reqID string,
-		context map[string]any) (values []AnyValue)
+		context map[string]any) (values []AnyValue, err error)
 }

--- a/core/pkg/evaluator/json_test.go
+++ b/core/pkg/evaluator/json_test.go
@@ -335,7 +335,11 @@ func TestResolveAllValues(t *testing.T) {
 	}
 	const reqID = "default"
 	for _, test := range tests {
-		vals := evaluator.ResolveAllValues(context.TODO(), reqID, test.context)
+		vals, err := evaluator.ResolveAllValues(context.TODO(), reqID, test.context)
+		if err != nil {
+			t.Error("error from resolver", err)
+		}
+
 		for _, val := range vals {
 			// disabled flag must be ignored from bulk evaluation
 			if val.FlagKey == DisabledFlag {
@@ -1234,21 +1238,30 @@ func TestFlagStateSafeForConcurrentReadWrites(t *testing.T) {
 		"Add_ResolveAllValues": {
 			dataSyncType: sync.ADD,
 			flagResolution: func(evaluator *evaluator.JSON) error {
-				evaluator.ResolveAllValues(context.TODO(), "", nil)
+				_, err := evaluator.ResolveAllValues(context.TODO(), "", nil)
+				if err != nil {
+					return err
+				}
 				return nil
 			},
 		},
 		"Update_ResolveAllValues": {
 			dataSyncType: sync.UPDATE,
 			flagResolution: func(evaluator *evaluator.JSON) error {
-				evaluator.ResolveAllValues(context.TODO(), "", nil)
+				_, err := evaluator.ResolveAllValues(context.TODO(), "", nil)
+				if err != nil {
+					return err
+				}
 				return nil
 			},
 		},
 		"Delete_ResolveAllValues": {
 			dataSyncType: sync.DELETE,
 			flagResolution: func(evaluator *evaluator.JSON) error {
-				evaluator.ResolveAllValues(context.TODO(), "", nil)
+				_, err := evaluator.ResolveAllValues(context.TODO(), "", nil)
+				if err != nil {
+					return err
+				}
 				return nil
 			},
 		},

--- a/core/pkg/evaluator/mock/ievaluator.go
+++ b/core/pkg/evaluator/mock/ievaluator.go
@@ -57,11 +57,12 @@ func (mr *MockIEvaluatorMockRecorder) GetState() *gomock.Call {
 }
 
 // ResolveAllValues mocks base method.
-func (m *MockIEvaluator) ResolveAllValues(ctx context.Context, reqID string, context map[string]any) []evaluator.AnyValue {
+func (m *MockIEvaluator) ResolveAllValues(ctx context.Context, reqID string, context map[string]any) ([]evaluator.AnyValue, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, context)
 	ret0, _ := ret[0].([]evaluator.AnyValue)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ResolveAllValues indicates an expected call of ResolveAllValues.
@@ -188,4 +189,146 @@ func (m *MockIEvaluator) SetState(payload sync.DataSync) (map[string]any, bool, 
 func (mr *MockIEvaluatorMockRecorder) SetState(payload any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockIEvaluator)(nil).SetState), payload)
+}
+
+// MockIResolver is a mock of IResolver interface.
+type MockIResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockIResolverMockRecorder
+}
+
+// MockIResolverMockRecorder is the mock recorder for MockIResolver.
+type MockIResolverMockRecorder struct {
+	mock *MockIResolver
+}
+
+// NewMockIResolver creates a new mock instance.
+func NewMockIResolver(ctrl *gomock.Controller) *MockIResolver {
+	mock := &MockIResolver{ctrl: ctrl}
+	mock.recorder = &MockIResolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIResolver) EXPECT() *MockIResolverMockRecorder {
+	return m.recorder
+}
+
+// ResolveAllValues mocks base method.
+func (m *MockIResolver) ResolveAllValues(ctx context.Context, reqID string, context map[string]any) ([]evaluator.AnyValue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, context)
+	ret0, _ := ret[0].([]evaluator.AnyValue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveAllValues indicates an expected call of ResolveAllValues.
+func (mr *MockIResolverMockRecorder) ResolveAllValues(ctx, reqID, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAllValues", reflect.TypeOf((*MockIResolver)(nil).ResolveAllValues), ctx, reqID, context)
+}
+
+// ResolveAsAnyValue mocks base method.
+func (m *MockIResolver) ResolveAsAnyValue(ctx context.Context, reqID, flagKey string, context map[string]any) evaluator.AnyValue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveAsAnyValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(evaluator.AnyValue)
+	return ret0
+}
+
+// ResolveAsAnyValue indicates an expected call of ResolveAsAnyValue.
+func (mr *MockIResolverMockRecorder) ResolveAsAnyValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAsAnyValue", reflect.TypeOf((*MockIResolver)(nil).ResolveAsAnyValue), ctx, reqID, flagKey, context)
+}
+
+// ResolveBooleanValue mocks base method.
+func (m *MockIResolver) ResolveBooleanValue(ctx context.Context, reqID, flagKey string, context map[string]any) (bool, string, string, map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveBooleanValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(map[string]any)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// ResolveBooleanValue indicates an expected call of ResolveBooleanValue.
+func (mr *MockIResolverMockRecorder) ResolveBooleanValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBooleanValue", reflect.TypeOf((*MockIResolver)(nil).ResolveBooleanValue), ctx, reqID, flagKey, context)
+}
+
+// ResolveFloatValue mocks base method.
+func (m *MockIResolver) ResolveFloatValue(ctx context.Context, reqID, flagKey string, context map[string]any) (float64, string, string, map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveFloatValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(map[string]any)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// ResolveFloatValue indicates an expected call of ResolveFloatValue.
+func (mr *MockIResolverMockRecorder) ResolveFloatValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFloatValue", reflect.TypeOf((*MockIResolver)(nil).ResolveFloatValue), ctx, reqID, flagKey, context)
+}
+
+// ResolveIntValue mocks base method.
+func (m *MockIResolver) ResolveIntValue(ctx context.Context, reqID, flagKey string, context map[string]any) (int64, string, string, map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveIntValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(map[string]any)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// ResolveIntValue indicates an expected call of ResolveIntValue.
+func (mr *MockIResolverMockRecorder) ResolveIntValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIntValue", reflect.TypeOf((*MockIResolver)(nil).ResolveIntValue), ctx, reqID, flagKey, context)
+}
+
+// ResolveObjectValue mocks base method.
+func (m *MockIResolver) ResolveObjectValue(ctx context.Context, reqID, flagKey string, context map[string]any) (map[string]any, string, string, map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveObjectValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(map[string]any)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// ResolveObjectValue indicates an expected call of ResolveObjectValue.
+func (mr *MockIResolverMockRecorder) ResolveObjectValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveObjectValue", reflect.TypeOf((*MockIResolver)(nil).ResolveObjectValue), ctx, reqID, flagKey, context)
+}
+
+// ResolveStringValue mocks base method.
+func (m *MockIResolver) ResolveStringValue(ctx context.Context, reqID, flagKey string, context map[string]any) (string, string, string, map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveStringValue", ctx, reqID, flagKey, context)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(map[string]any)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// ResolveStringValue indicates an expected call of ResolveStringValue.
+func (mr *MockIResolverMockRecorder) ResolveStringValue(ctx, reqID, flagKey, context any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveStringValue", reflect.TypeOf((*MockIResolver)(nil).ResolveStringValue), ctx, reqID, flagKey, context)
 }

--- a/core/pkg/service/ofrep/models.go
+++ b/core/pkg/service/ofrep/models.go
@@ -73,10 +73,17 @@ func ContextErrorResponseFrom(key string) EvaluationError {
 	}
 }
 
-func BulkEvaluationContextErrorFrom() BulkEvaluationError {
+func BulkEvaluationContextError() BulkEvaluationError {
 	return BulkEvaluationError{
 		ErrorCode:    model.InvalidContextCode,
 		ErrorDetails: "Provider context is not valid",
+	}
+}
+
+func BulkEvaluationContextErrorFrom(code string, details string) BulkEvaluationError {
+	return BulkEvaluationError{
+		ErrorCode:    code,
+		ErrorDetails: details,
 	}
 }
 

--- a/flagd/pkg/service/flag-evaluation/flag_evaluator.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator.go
@@ -69,7 +69,13 @@ func (s *OldFlagEvaluationService) ResolveAll(
 	if e := req.Msg.GetContext(); e != nil {
 		evalCtx = e.AsMap()
 	}
-	values := s.eval.ResolveAllValues(sCtx, reqID, evalCtx)
+
+	values, err := s.eval.ResolveAllValues(sCtx, reqID, evalCtx)
+	if err != nil {
+		s.logger.WarnWithID(reqID, fmt.Sprintf("error resolving all flags: %v", err))
+		return nil, fmt.Errorf("error resolving flags. Tracking ID: %s", reqID)
+	}
+
 	span.SetAttributes(attribute.Int("feature_flag.count", len(values)))
 	for _, value := range values {
 		// register the impression and reason for each flag evaluated

--- a/flagd/pkg/service/flag-evaluation/flag_evaluator_test.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator_test.go
@@ -118,7 +118,7 @@ func TestConnectService_ResolveAll(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			eval := mock.NewMockIEvaluator(ctrl)
 			eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-				tt.evalRes,
+				tt.evalRes, nil,
 			).AnyTimes()
 			metrics, exp := getMetricReader()
 			s := NewOldFlagEvaluationService(

--- a/flagd/pkg/service/flag-evaluation/flag_evaluator_v2.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator_v2.go
@@ -68,7 +68,12 @@ func (s *FlagEvaluationService) ResolveAll(
 		evalCtx = e.AsMap()
 	}
 
-	values := s.eval.ResolveAllValues(sCtx, reqID, evalCtx)
+	values, err := s.eval.ResolveAllValues(sCtx, reqID, evalCtx)
+	if err != nil {
+		s.logger.WarnWithID(reqID, fmt.Sprintf("error resolving all flags: %v", err))
+		return nil, fmt.Errorf("error resolving flags. Tracking ID: %s", reqID)
+	}
+
 	span.SetAttributes(attribute.Int("feature_flag.count", len(values)))
 	for _, value := range values {
 		// register the impression and reason for each flag evaluated

--- a/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service_test.go
@@ -19,7 +19,9 @@ func Test_OfrepServiceStartStop(t *testing.T) {
 	port := 18282
 	eval := mock.NewMockIEvaluator(gomock.NewController(t))
 
-	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).Return([]evaluator.AnyValue{})
+	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]evaluator.AnyValue{}, nil)
+
 	cfg := SvcConfiguration{
 		Logger: logger.NewLogger(nil, false),
 		Port:   uint16(port),

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -163,7 +163,11 @@ func (r *Multiplexer) SourcesAsMetadata() string {
 func (r *Multiplexer) reFill() error {
 	clear(r.selectorFlags)
 
-	all := r.store.GetAll(context.Background())
+	all, err := r.store.GetAll(context.Background())
+	if err != nil {
+		return fmt.Errorf("error retrieving flags from the store: %w", err)
+	}
+
 	bytes, err := json.Marshal(map[string]interface{}{"flags": all})
 	if err != nil {
 		return fmt.Errorf("error from marshallin: %w", err)


### PR DESCRIPTION
Fixes #1328

### Improvement

flagd's core components are intended to be reused. This PR change the`IStore` interface by allowing an error to be returned from `GetAll`.  This error is then propagated through `ResolveAllValues`. This change enables custom `IStore` implementations to return errors and propagate them through the resolver layer.

With this change, I have upgrade OFREP bulk evaluator and flagd RPC  `ResolveAll` with error propagation.

OFREP - Log warning with resolver error and return HTTP 500 with a tracking reference
RPC - Log warning with resolver error and return an error with a tracking reference