### PR TITLE
feat: add mandatory flags property in bulk response

### DIFF
--- a/core/pkg/service/ofrep/models.go
+++ b/core/pkg/service/ofrep/models.go
@@ -20,7 +20,7 @@ type EvaluationSuccess struct {
 }
 
 type BulkEvaluationResponse struct {
-	Flags []interface{} `json:"flags,omitempty"`
+	Flags []interface{} `json:"flags"`
 }
 
 type EvaluationError struct {


### PR DESCRIPTION
This PR improves flagd bulk evaluation empty response by adding required `flags` property. 

Related - https://github.com/open-feature/protocol/pull/27 