### PR TITLE
feat!: DISABLED flags signal return grpc precondition_failed

### DIFF
--- a/flagd/pkg/service/flag-evaluation/flag_evaluator.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator.go
@@ -335,12 +335,14 @@ func formatContextKeys(context *structpb.Struct) []string {
 func errFormat(err error) error {
 	ReadableErrorMsg := model.GetErrorMessage(err.Error())
 	switch err.Error() {
-	case model.FlagNotFoundErrorCode, model.FlagDisabledErrorCode:
+	case model.FlagNotFoundErrorCode:
 		return connect.NewError(connect.CodeNotFound, fmt.Errorf("%s", ReadableErrorMsg))
 	case model.TypeMismatchErrorCode:
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%s", ReadableErrorMsg))
 	case model.ParseErrorCode:
 		return connect.NewError(connect.CodeDataLoss, fmt.Errorf("%s", ReadableErrorMsg))
+	case model.FlagDisabledErrorCode:
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("%s", ReadableErrorMsg))
 	case model.GeneralErrorCode:
 		return connect.NewError(connect.CodeUnknown, fmt.Errorf("%s", ReadableErrorMsg))
 	}

--- a/flagd/pkg/service/flag-evaluation/flag_evaluator_test.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator_test.go
@@ -962,7 +962,7 @@ func TestFlag_Evaluation_ErrorCodes(t *testing.T) {
 		},
 		{
 			err:  errors.New(model.FlagDisabledErrorCode),
-			code: connect.CodeNotFound,
+			code: connect.CodeFailedPrecondition,
 		},
 		{
 			err:  errors.New(model.GeneralErrorCode),

--- a/flagd/pkg/service/flag-evaluation/flag_evaluator_v2_test.go
+++ b/flagd/pkg/service/flag-evaluation/flag_evaluator_v2_test.go
@@ -931,7 +931,7 @@ func TestFlag_EvaluationV2_ErrorCodes(t *testing.T) {
 		},
 		{
 			err:  errors.New(model.FlagDisabledErrorCode),
-			code: connect.CodeNotFound,
+			code: connect.CodeFailedPrecondition,
 		},
 		{
 			err:  errors.New(model.GeneralErrorCode),


### PR DESCRIPTION
DISABLED flags now return gRPC error code `precondition_failed` instead of `not_found`.

Relates to: https://github.com/open-feature/flagd/issues/1345

This will allow us to specially catch this error in providers and return the default instead of throwing. `precondition_failed` seems like an appropriate error code: 

> The operation was rejected because the system is not in a state required for the operation's execution. For example, the directory to be deleted is non-empty, an rmdir operation is applied to a non-directory, etc. Service implementors can use the following guidelines to decide between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE: (a) Use UNAVAILABLE if the client can retry just the failing call. (b) Use ABORTED if the client should retry at a higher level (e.g., when a client-specified test-and-set fails, indicating the client should restart a read-modify-write sequence). (c) Use FAILED_PRECONDITION if the client should not retry until the system state has been explicitly fixed. E.g., if an "rmdir" fails because the directory is non-empty, FAILED_PRECONDITION should be returned since the client should not retry unless the files are deleted from the directory.

https://grpc.github.io/grpc/core/md_doc_statuscodes.html