### PR TITLE
fix: invalid scoped-sync responses for empty flags

### DIFF
--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -12,7 +12,9 @@ import (
 	"github.com/open-feature/flagd/core/pkg/store"
 )
 
-const emptyConfig = "{\"flags\":{}}"
+var emptyConfigBytes, _ = json.Marshal(map[string]map[string]string{
+	"flags": {},
+})
 
 // Multiplexer abstract subscription handling and storage processing.
 // Flag configurations will be lazy loaded using reFill logic upon the calls to publish.
@@ -166,7 +168,7 @@ func (r *Multiplexer) reFill() error {
 	clear(r.selectorFlags)
 	// start all sources with empty config
 	for _, source := range r.sources {
-		r.selectorFlags[source] = emptyConfig
+		r.selectorFlags[source] = string(emptyConfigBytes)
 	}
 
 	all, err := r.store.GetAll(context.Background())

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/store"
 )
 
+//nolint:errchkjson
 var emptyConfigBytes, _ = json.Marshal(map[string]map[string]string{
 	"flags": {},
 })

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -56,7 +56,7 @@ func TestRegistration(t *testing.T) {
 			source:     "C",
 			connection: make(chan payload, 1),
 			flagStringValidator: func(flagString string, testSource string, testName string) {
-				assert.Equal(t, flagString, emptyConfig)
+				assert.Equal(t, flagString, string(emptyConfigBytes))
 			},
 			expectError: false,
 		},
@@ -196,5 +196,5 @@ func TestGetAllFlags(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, flags, "{\"flags\":{}}")
+	assert.Equal(t, flags, string(emptyConfigBytes))
 }

--- a/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const emptyConfigString = "{\"flags\":{}}"
+
 func TestRegistration(t *testing.T) {
 	// given
 	mux, err := NewMux(getSimpleFlagStore())
@@ -56,7 +58,7 @@ func TestRegistration(t *testing.T) {
 			source:     "C",
 			connection: make(chan payload, 1),
 			flagStringValidator: func(flagString string, testSource string, testName string) {
-				assert.Equal(t, flagString, string(emptyConfigBytes))
+				assert.Equal(t, flagString, emptyConfigString)
 			},
 			expectError: false,
 		},
@@ -196,5 +198,5 @@ func TestGetAllFlags(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, flags, string(emptyConfigBytes))
+	assert.Equal(t, flags, emptyConfigString)
 }

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -128,7 +128,7 @@ func TestSyncServiceEndToEnd(t *testing.T) {
 		t.Fatal("expected sources entry in the metadata, but got nil")
 	}
 
-	if asMap["sources"] != "A,B" {
+	if asMap["sources"] != "A,B,C" {
 		t.Fatal("incorrect sources entry in metadata")
 	}
 

--- a/flagd/pkg/service/flag-sync/util_test.go
+++ b/flagd/pkg/service/flag-sync/util_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/store"
 )
 
-// getSimpleFlagStore returns a flag store pre-filled with flags from sources A & B
+// getSimpleFlagStore returns a flag store pre-filled with flags from sources A & B & C, which C empty
 func getSimpleFlagStore() (*store.Flags, []string) {
 	variants := map[string]any{
 		"true":  true,
@@ -28,5 +28,5 @@ func getSimpleFlagStore() (*store.Flags, []string) {
 		Source:         "B",
 	})
 
-	return flagStore, []string{"A", "B"}
+	return flagStore, []string{"A", "B", "C"}
 }


### PR DESCRIPTION
Fixes an issue where invalid flag payloads were returned on sync requests with scopes if the flag set was empty.

Below is an example of the bug.

```shell
$ grpcurl -import-path /home/todd/temp -proto sync.proto -plaintext localhost:8015 flagd.sync.v1.FlagSyncService/FetchAllFlags
{
  "flagConfiguration": "{\"flags\":{}}"
}
$ grpcurl -import-path /home/todd/temp -proto sync.proto -plaintext -d '{"selector":"../config/samples/example_flags.flagd.json"}' localhost:8015 flagd.sync.v1.FlagSyncService/FetchAllFlags 
{}
```