### PR TITLE
docs: fix typo

### DIFF
--- a/docs/reference/openfeature-operator/overview.md
+++ b/docs/reference/openfeature-operator/overview.md
@@ -1,5 +1,5 @@
 # OpenFeature Operator
 
-The OpenFeature Operator provides a convent way to using flagd in your Kubernetes cluster.
+The OpenFeature Operator provides a convenient way to use flagd in your Kubernetes cluster.
 It allows you to define feature flags as custom resources, inject flagd as a sidecar, and more.
 Please see the [installation guide](https://github.com/open-feature/open-feature-operator/blob/main/docs/installation.md) to get started.


### PR DESCRIPTION
## This PR
Fixes a typo in `docs/reference/openfeature-operator/overview.md`
