### PR TITLE
feat: support stricter type checking behavior as a Resolver configura…

### DIFF
--- a/core/pkg/evaluator/fractional_test.go
+++ b/core/pkg/evaluator/fractional_test.go
@@ -461,7 +461,7 @@ func TestFractionalEvaluation(t *testing.T) {
 			je := NewJSON(log, store.NewFlags())
 			je.store.Flags = tt.flags.Flags
 
-			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 			if value != tt.expectedValue {
 				t.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)
@@ -590,7 +590,7 @@ func BenchmarkFractionalEvaluation(b *testing.B) {
 			je := NewJSON(log, &store.Flags{Flags: tt.flags.Flags})
 			for i := 0; i < b.N; i++ {
 				value, variant, reason, _, err := resolve[string](
-					ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+					ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 				if value != tt.expectedValue {
 					b.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)

--- a/core/pkg/evaluator/legacy_fractional_test.go
+++ b/core/pkg/evaluator/legacy_fractional_test.go
@@ -275,7 +275,7 @@ func TestLegacyFractionalEvaluation(t *testing.T) {
 			je := NewJSON(log, store.NewFlags())
 			je.store.Flags = tt.flags.Flags
 
-			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 			if value != tt.expectedValue {
 				t.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)

--- a/core/pkg/evaluator/semver_test.go
+++ b/core/pkg/evaluator/semver_test.go
@@ -704,7 +704,7 @@ func TestJSONEvaluator_semVerEvaluation(t *testing.T) {
 			je := NewJSON(log, store.NewFlags())
 			je.store.Flags = tt.flags.Flags
 
-			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 			if value != tt.expectedValue {
 				t.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)

--- a/core/pkg/evaluator/string_comparison_test.go
+++ b/core/pkg/evaluator/string_comparison_test.go
@@ -188,7 +188,7 @@ func TestJSONEvaluator_startsWithEvaluation(t *testing.T) {
 			je := NewJSON(log, store.NewFlags())
 			je.store.Flags = tt.flags.Flags
 
-			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 			if value != tt.expectedValue {
 				t.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)
@@ -386,7 +386,7 @@ func TestJSONEvaluator_endsWithEvaluation(t *testing.T) {
 
 			je.store.Flags = tt.flags.Flags
 
-			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant)
+			value, variant, reason, _, err := resolve[string](ctx, reqID, tt.flagKey, tt.context, je.evaluateVariant, ResolverConfiguration{})
 
 			if value != tt.expectedValue {
 				t.Errorf("expected value '%s', got '%s'", tt.expectedValue, value)

--- a/core/pkg/model/error.go
+++ b/core/pkg/model/error.go
@@ -9,6 +9,7 @@ const (
 	GeneralErrorCode      = "GENERAL"
 	FlagDisabledErrorCode = "FLAG_DISABLED"
 	InvalidContextCode    = "INVALID_CONTEXT"
+	TypeCheckingError     = "TYPE_CHECKING_ERROR"
 )
 
 var ReadableErrorMessage = map[string]string{
@@ -18,6 +19,7 @@ var ReadableErrorMessage = map[string]string{
 	GeneralErrorCode:      "General error",
 	FlagDisabledErrorCode: "Flag is disabled",
 	InvalidContextCode:    "Invalid context provided",
+	TypeCheckingError:     "Type checking error due to selected type checking behavior",
 }
 
 func GetErrorMessage(code string) string {


### PR DESCRIPTION
## This PR
- Adds ResolverConfiguration that can be set when creating a new JSON evaluator. Configuration can be used to set stricter flag variants type checking (a couple of flavors).

### Follow-up Tasks
- Changes to go-sdk-contrib flagd provider will be needed to take advantage of this new functionality
- Adding flagd command line flags to enable this will be needed