### PR TITLE
build(renovate): Utilize default OpenFeature Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,24 +3,11 @@
   "constraints": {
     "go": "1.22"
   },
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["github>open-feature/community-tooling"],
   "includePaths": [
     "flagd/**",
     "flagd-proxy/**",
     "core/**",
     "test/**"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    }
   ]
 }


### PR DESCRIPTION
We do have a default OpenFeature Renovate configuration within our community-tooling repository. (https://github.com/open-feature/community-tooling/blob/main/renovate.json)

To reduce maintenance efforts, we should stick to the general one as a basis.
