### PR TITLE
chore: add global maintainers to the codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 #
 # Managed by Peribolos: https://github.com/open-feature/community/blob/main/config/open-feature/cloud-native/workgroup.yaml
 #
-* @open-feature/cloud-native-maintainers
+* @open-feature/cloud-native-maintainers @open-feature/maintainers


### PR DESCRIPTION
global maintainers approvals etc should have the same effect as the one of the flagd maintainers