### PR TITLE
docs: clarify that bucketing keys are strings

### DIFF
--- a/docs/reference/custom-operations/fractional-operation.md
+++ b/docs/reference/custom-operations/fractional-operation.md
@@ -64,7 +64,9 @@ The `defaultVariant` is `red`, but it contains a [targeting rule](../flag-defini
 In this case, `25%` of the evaluations will receive `red`, `25%` will receive `blue`, and so on.
 
 Assignment is deterministic (sticky) based on the expression supplied as the first parameter (`{ "cat": [{ "var": "$flagd.flagKey" }, { "var": "email" }]}`, in this case).
-The value retrieved by this expression is referred to as the "bucketing value".
+The value retrieved by this expression is referred to as the "bucketing value" and must be a string.
+Other primitive types can be used by casting the value using `"cat"` operator.
+For example, a less deterministic distribution can be achieved using `{ "cat": [{ "var": "$flagd.timestamp" }]}`.
 The bucketing value expression can be omitted, in which case a concatenation of the `targetingKey` and the `flagKey` will be used.
 
 The `fractional` operation is a custom JsonLogic operation which deterministically selects a variant based on

--- a/docs/schema/v0/targeting.json
+++ b/docs/schema/v0/targeting.json
@@ -476,7 +476,7 @@
       "$comment": "there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case",
       "items": [
         {
-          "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
+          "description": "Bucketing value used in pseudorandom assignment; should be a string that is unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
           "$ref": "#/definitions/anyRule"
         },
         {


### PR DESCRIPTION
## This PR

- clarifies that bucketing keys are strings

### Related Issues

Fixes #1601
