### PR TITLE
refactor: removed hardcoded metric export interval and use otel default

### DIFF
--- a/core/pkg/telemetry/builder.go
+++ b/core/pkg/telemetry/builder.go
@@ -30,7 +30,6 @@ import (
 
 const (
 	metricsExporterOtel = "otel"
-	exportInterval      = 2 * time.Second
 )
 
 type CollectorConfig struct {
@@ -196,7 +195,7 @@ func buildMetricReader(ctx context.Context, cfg Config) (metric.Reader, error) {
 		return nil, fmt.Errorf("error creating otel metric exporter: %w", err)
 	}
 
-	return metric.NewPeriodicReader(otelExporter, metric.WithInterval(exportInterval)), nil
+	return metric.NewPeriodicReader(otelExporter), nil
 }
 
 // buildOtlpExporter is a helper to build grpc backed otlp trace exporter


### PR DESCRIPTION
## This PR

- removed the 2 second hardcoded metric export interval
- use OTel default 60 second metric export interval
- the export interval can be overridden via the env var `OTEL_METRIC_EXPORT_INTERVAL`

### Related Issues

Fixes #1603 

### Notes

Removing the hardcoded value will allow users to override the default interval via environment variables.
This 

- https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#WithInterval
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#periodic-exporting-metricreader

