### PR TITLE
docs: improve content tab anchors on getting started

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,9 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - tables
   - attr_list
   - md_in_html


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- I noticed the URLs generated in the content tab were not that appealing. This ensures they follow a consistent pattern and are more user-friendly

### Before

![image](https://github.com/user-attachments/assets/2b13cd05-f936-4609-8d82-bfe1e58e8b7a)

### After

![image](https://github.com/user-attachments/assets/fa27c053-714f-45d2-afb7-3f14ebdaae1c)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Follows on from #1626

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

