### PR TITLE
docs(ADR): add architecture decision template

### DIFF
--- a/docs/architecture-decisions/.template.md
+++ b/docs/architecture-decisions/.template.md
@@ -1,0 +1,70 @@
+---
+# Valid statuses: draft | proposed | rejected | accepted | superseded
+status: draft
+author: Your Name
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Title
+
+<!--
+This section should be one or two paragraphs that just explains what the goal of this decision is going to be, but without diving too deeply into the "why", "why now", "how", etc.
+Ensure anyone opening the document will form a clear understanding of the intent from reading this paragraph(s).
+-->
+
+## Background
+
+<!--
+The next section is the "Background" section. This section should be at least two paragraphs and can take up to a whole page in some cases.
+The guiding goal of the background section is: as a newcomer to this project (new employee, team transfer), can I read the background section and follow any links to get the full context of why this change is necessary?
+
+If you can't show a random engineer the background section and have them acquire nearly full context on the necessity for the RFC, then the background section is not full enough. To help achieve this, link to prior RFCs, discussions, and more here as necessary to provide context so you don't have to simply repeat yourself.
+-->
+
+## Considered Options
+
+<!--
+This section lists all the options that were considered for addressing the need outlined in the background section. 
+Each option should be clearly defined with a descriptive title.
+This provides a comprehensive overview of the solution space that was explored before making a decision.
+The options will be evaluated in the proposal section, where the chosen approach is justified.
+-->
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Proposal
+
+<!--
+The next required section is "Proposal" or "Goal".
+Given the background above, this section proposes a solution.
+This should be an overview of the "how" for the solution.
+Include content like diagrams, prototypes, and high-level requirements.
+-->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Open questions
+
+* {Question 1}
+* … <!-- numbers of question can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+<!--
+This section provides additional context, evidence, or documentation to support the decision.
+It can include team agreements, implementation timelines, conditions for revisiting the decision,
+and links to related decisions or resources.
+Use this space to provide any supplementary information that would be helpful for future readers
+to fully understand the decision and its implications.
+-->


### PR DESCRIPTION
## This PR

- adds a ADR template based on [OFEP](https://github.com/open-feature/ofep) and [MADR](https://github.com/adr/madr)

### Notes

The goal of the ADR is to capture why important architectural decisions were made. I tried to keep the template short while challenging the author to consider alternative approaches.

This proposed template doesn't use a number prefix. This simplifies the creation and management of ADRs but may make it more difficult to understand the order in which they were added at a glance. I felt we won't have enough ADRs for this to become an issue. Please let me know if you disagree, and I'll reconsider.

### Follow-up Tasks

- Update the contributing doc to explain the ADR process
- Port relevant OFEPs to flagd


