### PR TITLE
fix: general err if targeting variant not in variants

### DIFF
--- a/core/pkg/evaluator/json.go
+++ b/core/pkg/evaluator/json.go
@@ -390,7 +390,7 @@ func (je *Resolver) evaluateVariant(ctx context.Context, reqID string, flagKey s
 		}
 		je.Logger.ErrorWithID(reqID,
 			fmt.Sprintf("invalid or missing variant: %s for flagKey: %s, variant is not valid", variant, flagKey))
-		return "", flag.Variants, model.ErrorReason, metadata, errors.New(model.ParseErrorCode)
+		return "", flag.Variants, model.ErrorReason, metadata, errors.New(model.GeneralErrorCode)
 	}
 
 	if flag.DefaultVariant == "" {

--- a/core/pkg/evaluator/legacy_fractional_test.go
+++ b/core/pkg/evaluator/legacy_fractional_test.go
@@ -196,7 +196,7 @@ func TestLegacyFractionalEvaluation(t *testing.T) {
 			expectedVariant:   "",
 			expectedValue:     "",
 			expectedReason:    model.ErrorReason,
-			expectedErrorCode: model.ParseErrorCode,
+			expectedErrorCode: model.GeneralErrorCode,
 		},
 		"fallback to default variant if invalid variant as result of fractional evaluation": {
 			flags: Flags{
@@ -229,7 +229,7 @@ func TestLegacyFractionalEvaluation(t *testing.T) {
 			expectedVariant:   "",
 			expectedValue:     "",
 			expectedReason:    model.ErrorReason,
-			expectedErrorCode: model.ParseErrorCode,
+			expectedErrorCode: model.GeneralErrorCode,
 		},
 		"fallback to default variant if percentages don't sum to 100": {
 			flags: Flags{


### PR DESCRIPTION
This makes the RPC mode consistent with our in-process evaluations when a variant is returned from targeting which is not in the variants list.

Relates to https://github.com/open-feature/flagd-testbed/commit/758fbd5b84731c1a96dbd186484c46d3b8f746ed