### PR TITLE
chore: add back file-delete test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ export GOPRIVATE=buf.build/gen/go
 
 ### Manual testing
 
-flagd has a number of interfaces (you can read more about than at [flagd.dev](https://flagd.dev/)) which can be used to evaluate flags, or deliver flag configurations so that they can be evaluated by _in-process_ providers.
+flagd has a number of interfaces (you can read more about them at [flagd.dev](https://flagd.dev/)) which can be used to evaluate flags, or deliver flag configurations so that they can be evaluated by _in-process_ providers.
 
 You can manually test this functionality by starting flagd (from the flagd/ directory) with `go run main.go start -f file:../config/samples/example_flags.flagd.json`.
 
@@ -69,7 +69,7 @@ curl -X POST  -d '{"context":{}}' 'http://localhost:8016/ofrep/v1/evaluate/flags
 grpcurl -import-path schemas/protobuf/flagd/evaluation/v1/ -proto evaluation.proto -plaintext -d '{"flagKey":"myBoolFlag"}' localhost:8013 flagd.evaluation.v1.Service/ResolveBoolean | jq
 ```
 
-#### Remote bulk evaluation via via HTTP1.1/OFREP
+#### Remote bulk evaluation via HTTP1.1/OFREP
 
 ```sh
 # evaluates flags in bulk
@@ -93,7 +93,7 @@ grpcurl -import-path schemas/protobuf/flagd/sync/v1/ -proto sync.proto -plaintex
 #### Flag synchronization stream via gRPC
 
 ```sh
-# will open a persistent stream which sends flag changes when the watched source is modified 
+# will open a persistent stream which sends flag changes when the watched source is modified
 grpcurl -import-path schemas/protobuf/flagd/sync/v1/ -proto sync.proto -plaintext localhost:8015 flagd.sync.v1.FlagSyncService/SyncFlags | jq
 ```
 

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -58,6 +58,7 @@ func TestSimpleReSync(t *testing.T) {
 func TestSimpleSync(t *testing.T) {
 	readDirName := t.TempDir()
 	updateDirName := t.TempDir()
+	deleteDirName := t.TempDir()
 	tests := map[string]struct {
 		manipulationFuncs []func(t *testing.T)
 		expectedDataSync  []sync.DataSync
@@ -95,6 +96,27 @@ func TestSimpleSync(t *testing.T) {
 				{
 					FlagData: "new content",
 					Source:   fmt.Sprintf("%s/%s", updateDirName, fetchFileName),
+				},
+			},
+		},
+		"delete-event": {
+			fetchDirName: deleteDirName,
+			manipulationFuncs: []func(t *testing.T){
+				func(t *testing.T) {
+					writeToFile(t, deleteDirName, fetchFileContents)
+				},
+				func(t *testing.T) {
+					deleteFile(t, deleteDirName, fetchFileName)
+				},
+			},
+			expectedDataSync: []sync.DataSync{
+				{
+					FlagData: fetchFileContents,
+					Source:   fmt.Sprintf("%s/%s", deleteDirName, fetchFileName),
+				},
+				{
+					FlagData: defaultState,
+					Source:   fmt.Sprintf("%s/%s", deleteDirName, fetchFileName),
 				},
 			},
 		},

--- a/core/pkg/sync/http/http_sync_test.go
+++ b/core/pkg/sync/http/http_sync_test.go
@@ -290,16 +290,16 @@ func TestHTTPSync_Fetch(t *testing.T) {
 					newETag := `"c2e01ce63d90109c4c7f4f6dcea97ed1bb2b51e3647f36caf5acbe27413a24bb"`
 
 					return &http.Response{
-						Header:     map[string][]string{
+						Header: map[string][]string{
 							"Content-Type": {"application/json"},
-							"Etag":        {newETag},
+							"Etag":         {newETag},
 						},
 						Body:       io.NopCloser(strings.NewReader(newContent)),
 						StatusCode: http.StatusOK,
 					}, nil
 				})
 			},
-			uri:         "http://localhost",
+			uri:        "http://localhost",
 			eTagHeader: `"1af17a664e3fa8e419b8ba05c2a173169df76162a5a286e0c405b460d478f7ef"`,
 			handleResponse: func(t *testing.T, httpSync Sync, _ string, err error) {
 				if err != nil {
@@ -370,7 +370,7 @@ func TestSync_Init(t *testing.T) {
 func TestHTTPSync_Resync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	source := "http://localhost"
-	emptyeFlagData := "{}"
+	emptyFlagData := "{}"
 
 	tests := map[string]struct {
 		setup             func(t *testing.T, client *syncmock.MockClient)
@@ -385,7 +385,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
 				client.EXPECT().Do(gomock.Any()).Return(&http.Response{
 					Header:     map[string][]string{"Content-Type": {"application/json"}},
-					Body:       io.NopCloser(strings.NewReader(emptyeFlagData)),
+					Body:       io.NopCloser(strings.NewReader(emptyFlagData)),
 					StatusCode: http.StatusOK,
 				}, nil)
 			},
@@ -402,7 +402,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 			wantErr: false,
 			wantNotifications: []sync.DataSync{
 				{
-					FlagData: emptyeFlagData,
+					FlagData: emptyFlagData,
 					Source:   source,
 				},
 			},


### PR DESCRIPTION
Adds back a test that was inappropriately removed (as explained [here](https://github.com/beeme1mr/flagd/pull/16/files#r2223712589)).

Also fixes some typos.