### PR TITLE
refactor: store cleanup

### DIFF
--- a/core/pkg/evaluator/json.go
+++ b/core/pkg/evaluator/json.go
@@ -64,13 +64,13 @@ func WithEvaluator(name string, evalFunc func(interface{}, interface{}) interfac
 
 // JSON evaluator
 type JSON struct {
-	store          *store.Store
+	store          store.IStore
 	Logger         *logger.Logger
 	jsonEvalTracer trace.Tracer
 	Resolver
 }
 
-func NewJSON(logger *logger.Logger, s *store.Store, opts ...JSONEvaluatorOption) *JSON {
+func NewJSON(logger *logger.Logger, s store.IStore, opts ...JSONEvaluatorOption) *JSON {
 	logger = logger.WithFields(
 		zap.String("component", "evaluator"),
 		zap.String("evaluator", "json"),

--- a/core/pkg/store/store.go
+++ b/core/pkg/store/store.go
@@ -31,7 +31,8 @@ type IStore interface {
 
 // store is the in-memory implementation of IStore. It should not be used directly by consumers.
 type store struct {
-	mx                sync.RWMutex
+	flagMx            sync.RWMutex
+	metaMx            sync.RWMutex
 	db                *memdb.MemDB
 	logger            *logger.Logger
 	FlagSources       []string
@@ -114,16 +115,15 @@ func (f *store) Get(_ context.Context, key string) (model.Flag, model.Metadata, 
 }
 
 func (f *store) SelectorForFlag(_ context.Context, flag model.Flag) string {
-	f.mx.RLock()
-	defer f.mx.RUnlock()
-
+	f.metaMx.RLock()
+	defer f.metaMx.RUnlock()
 	return f.SourceDetails[flag.Source].Selector
 }
 
 func (f *store) String() (string, error) {
 	f.logger.Debug("dumping flags to string")
-	f.mx.RLock()
-	defer f.mx.RUnlock()
+	f.flagMx.RLock()
+	defer f.flagMx.RUnlock()
 
 	state, _, err := f.GetAll(context.Background())
 	if err != nil {
@@ -171,8 +171,11 @@ func (f *store) Update(
 	defer txn.Abort()
 	storedFlags, _, _ := f.GetAll(context.Background())
 
-	f.mx.Lock()
+	f.metaMx.Lock()
 	f.setSourceMetadata(source, metadata)
+	f.metaMx.Unlock()
+
+	f.flagMx.Lock()
 	for key, v := range storedFlags {
 		if v.Source == source && v.Selector == selector {
 			if _, ok := flags[key]; !ok {
@@ -198,7 +201,7 @@ func (f *store) Update(
 			}
 		}
 	}
-	f.mx.Unlock()
+	f.flagMx.Unlock()
 	for key, newFlag := range flags {
 		newFlag.Source = source
 		newFlag.Selector = selector
@@ -242,8 +245,8 @@ func (f *store) Update(
 }
 
 func (f *store) GetMetadataForSource(source string) model.Metadata {
-	f.mx.RLock()
-	defer f.mx.RUnlock()
+	f.metaMx.RLock()
+	defer f.metaMx.RUnlock()
 	perSource, ok := f.MetadataPerSource[source]
 	if ok && perSource != nil {
 		return maps.Clone(perSource)
@@ -252,8 +255,8 @@ func (f *store) GetMetadataForSource(source string) model.Metadata {
 }
 
 func (f *store) SyncConfig(providers []syncpkg.SourceConfig) []string {
-	f.mx.Lock()
-	defer f.mx.Unlock()
+	f.metaMx.Lock()
+	defer f.metaMx.Unlock()
 	f.FlagSources = nil
 	f.SourceDetails = map[string]SourceDetails{}
 	sources := make([]string, 0, len(providers))
@@ -270,8 +273,8 @@ func (f *store) SyncConfig(providers []syncpkg.SourceConfig) []string {
 
 // TODO: this is a temporary solution to merge metadata in the case of error; properly handle it with https://github.com/open-feature/flagd/issues/1675
 func (f *store) getMetadata() model.Metadata {
-	f.mx.RLock()
-	defer f.mx.RUnlock()
+	f.metaMx.RLock()
+	defer f.metaMx.RUnlock()
 	metadata := model.Metadata{}
 	for _, perSource := range f.MetadataPerSource {
 		for key, entry := range perSource {

--- a/core/pkg/store/store.go
+++ b/core/pkg/store/store.go
@@ -11,19 +11,26 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
+	syncpkg "github.com/open-feature/flagd/core/pkg/sync"
 )
 
 type del = struct{}
 
 var deleteMarker *del
 
+// IStore is the interface for a flag store. All consumers should use this interface.
 type IStore interface {
 	GetAll(ctx context.Context) (map[string]model.Flag, model.Metadata, error)
 	Get(ctx context.Context, key string) (model.Flag, model.Metadata, bool)
 	SelectorForFlag(ctx context.Context, flag model.Flag) string
+	GetMetadataForSource(source string) model.Metadata
+	Update(source string, selector string, flags map[string]model.Flag, metadata model.Metadata) (map[string]interface{}, bool)
+	String() (string, error)
+	SyncConfig(providers []syncpkg.SourceConfig) []string
 }
 
-type Store struct {
+// store is the in-memory implementation of IStore. It should not be used directly by consumers.
+type store struct {
 	mx                sync.RWMutex
 	db                *memdb.MemDB
 	logger            *logger.Logger
@@ -37,7 +44,7 @@ type SourceDetails struct {
 	Selector string
 }
 
-func (f *Store) hasPriority(stored string, new string) bool {
+func (f *store) hasPriority(stored string, new string) bool {
 	if stored == new {
 		return true
 	}
@@ -52,7 +59,8 @@ func (f *Store) hasPriority(stored string, new string) bool {
 	return true
 }
 
-func NewStore(logger *logger.Logger) (*Store, error) {
+// NewStore returns a new in-memory implementation of IStore.
+func NewStore(logger *logger.Logger) (IStore, error) {
 
 	schema := &memdb.DBSchema{
 		Tables: map[string]*memdb.TableSchema{
@@ -76,7 +84,7 @@ func NewStore(logger *logger.Logger) (*Store, error) {
 		return nil, fmt.Errorf("unable to initialize flag database: %w", err)
 	}
 
-	return &Store{
+	return &store{
 		SourceDetails:     map[string]SourceDetails{},
 		MetadataPerSource: map[string]model.Metadata{},
 		db:                db,
@@ -85,7 +93,7 @@ func NewStore(logger *logger.Logger) (*Store, error) {
 }
 
 // Deprecated: use NewStore instead
-func NewFlags() *Store {
+func NewFlags() IStore {
 	state, err := NewStore(logger.NewLogger(nil, false))
 	if err != nil {
 		panic(fmt.Sprintf("unable to create flag store: %v", err))
@@ -93,7 +101,7 @@ func NewFlags() *Store {
 	return state
 }
 
-func (f *Store) Get(_ context.Context, key string) (model.Flag, model.Metadata, bool) {
+func (f *store) Get(_ context.Context, key string) (model.Flag, model.Metadata, bool) {
 	f.logger.Debug(fmt.Sprintf("getting flag %s", key))
 	txn := f.db.Txn(false)
 
@@ -105,14 +113,14 @@ func (f *Store) Get(_ context.Context, key string) (model.Flag, model.Metadata, 
 	return flag, f.GetMetadataForSource(flag.Source), true
 }
 
-func (f *Store) SelectorForFlag(_ context.Context, flag model.Flag) string {
+func (f *store) SelectorForFlag(_ context.Context, flag model.Flag) string {
 	f.mx.RLock()
 	defer f.mx.RUnlock()
 
 	return f.SourceDetails[flag.Source].Selector
 }
 
-func (f *Store) String() (string, error) {
+func (f *store) String() (string, error) {
 	f.logger.Debug("dumping flags to string")
 	f.mx.RLock()
 	defer f.mx.RUnlock()
@@ -131,7 +139,7 @@ func (f *Store) String() (string, error) {
 }
 
 // GetAll returns a copy of the store's state (copy in order to be concurrency safe)
-func (f *Store) GetAll(_ context.Context) (map[string]model.Flag, model.Metadata, error) {
+func (f *store) GetAll(_ context.Context) (map[string]model.Flag, model.Metadata, error) {
 	txn := f.db.Txn(false)
 
 	flags := make(map[string]model.Flag)
@@ -150,7 +158,7 @@ func (f *Store) GetAll(_ context.Context) (map[string]model.Flag, model.Metadata
 }
 
 // Update the flag state with the provided flags.
-func (f *Store) Update(
+func (f *store) Update(
 	source string,
 	selector string,
 	flags map[string]model.Flag,
@@ -233,7 +241,7 @@ func (f *Store) Update(
 	return notifications, resyncRequired
 }
 
-func (f *Store) GetMetadataForSource(source string) model.Metadata {
+func (f *store) GetMetadataForSource(source string) model.Metadata {
 	f.mx.RLock()
 	defer f.mx.RUnlock()
 	perSource, ok := f.MetadataPerSource[source]
@@ -243,8 +251,25 @@ func (f *Store) GetMetadataForSource(source string) model.Metadata {
 	return model.Metadata{}
 }
 
+func (f *store) SyncConfig(providers []syncpkg.SourceConfig) []string {
+	f.mx.Lock()
+	defer f.mx.Unlock()
+	f.FlagSources = nil
+	f.SourceDetails = map[string]SourceDetails{}
+	sources := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		f.FlagSources = append(f.FlagSources, provider.URI)
+		f.SourceDetails[provider.URI] = SourceDetails{
+			Source:   provider.URI,
+			Selector: provider.Selector,
+		}
+		sources = append(sources, provider.URI)
+	}
+	return sources
+}
+
 // TODO: this is a temporary solution to merge metadata in the case of error; properly handle it with https://github.com/open-feature/flagd/issues/1675
-func (f *Store) getMetadata() model.Metadata {
+func (f *store) getMetadata() model.Metadata {
 	f.mx.RLock()
 	defer f.mx.RUnlock()
 	metadata := model.Metadata{}
@@ -267,7 +292,7 @@ func (f *Store) getMetadata() model.Metadata {
 	return metadata
 }
 
-func (f *Store) setSourceMetadata(source string, metadata model.Metadata) {
+func (f *store) setSourceMetadata(source string, metadata model.Metadata) {
 	if f.MetadataPerSource == nil {
 		f.MetadataPerSource = map[string]model.Metadata{}
 	}

--- a/core/pkg/store/store_test.go
+++ b/core/pkg/store/store_test.go
@@ -13,7 +13,7 @@ func TestMergeFlags(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T) *Store
+		setup       func(t *testing.T) IStore
 		new         map[string]model.Flag
 		newSource   string
 		newSelector string
@@ -23,7 +23,7 @@ func TestMergeFlags(t *testing.T) {
 	}{
 		{
 			name: "both nil",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -36,7 +36,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "both empty flags",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -49,7 +49,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "empty new",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -62,7 +62,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "merging with new source",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -84,7 +84,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "override by new update",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -110,7 +110,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "identical update so empty notifications",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -130,7 +130,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "deleted flag & trigger resync for same source",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -150,7 +150,7 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "no deleted & no resync for same source but different selector",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
@@ -171,12 +171,12 @@ func TestMergeFlags(t *testing.T) {
 		},
 		{
 			name: "no merge due to low priority",
-			setup: func(t *testing.T) *Store {
+			setup: func(t *testing.T) IStore {
 				s, err := NewStore(logger.NewLogger(nil, false))
 				if err != nil {
 					t.Fatalf("NewStore failed: %v", err)
 				}
-				s.FlagSources = []string{"B", "A"}
+				s.(*store).FlagSources = []string{"B", "A"}
 				s.Update("A", "", map[string]model.Flag{
 					"hello": {DefaultVariant: "off"},
 				}, model.Metadata{})

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -85,16 +85,7 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 		return nil, fmt.Errorf("error creating flag store: %w", err)
 	}
 
-	sources := []string{}
-
-	for _, provider := range config.SyncProviders {
-		s.FlagSources = append(s.FlagSources, provider.URI)
-		s.SourceDetails[provider.URI] = store.SourceDetails{
-			Source:   provider.URI,
-			Selector: provider.Selector,
-		}
-		sources = append(sources, provider.URI)
-	}
+	sources := s.SyncConfig(config.SyncProviders)
 
 	// derive evaluator
 	jsonEvaluator := evaluator.NewJSON(logger, s)

--- a/flagd/pkg/service/flag-sync/sync-multiplexer.go
+++ b/flagd/pkg/service/flag-sync/sync-multiplexer.go
@@ -20,7 +20,7 @@ var emptyConfigBytes, _ = json.Marshal(map[string]map[string]string{
 // Multiplexer abstract subscription handling and storage processing.
 // Flag configurations will be lazy loaded using reFill logic upon the calls to publish.
 type Multiplexer struct {
-	store   *store.Store
+	store   store.IStore
 	sources []string
 
 	subs         map[interface{}]subscription            // subscriptions on all sources
@@ -42,7 +42,7 @@ type payload struct {
 }
 
 // NewMux creates a new sync multiplexer
-func NewMux(store *store.Store, sources []string) (*Multiplexer, error) {
+func NewMux(store store.IStore, sources []string) (*Multiplexer, error) {
 	m := &Multiplexer{
 		store:         store,
 		sources:       sources,

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -28,7 +28,7 @@ type SvcConfigurations struct {
 	Logger              *logger.Logger
 	Port                uint16
 	Sources             []string
-	Store               *store.Store
+	Store               store.IStore
 	ContextValues       map[string]any
 	CertPath            string
 	KeyPath             string

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -273,7 +273,7 @@ func TestSyncServiceDeadlineEndToEnd(t *testing.T) {
 func createAndStartSyncService(
 	port int,
 	sources []string,
-	store *store.Store,
+	store store.IStore,
 	certPath string,
 	keyPath string,
 	socketPath string,

--- a/flagd/pkg/service/flag-sync/util_test.go
+++ b/flagd/pkg/service/flag-sync/util_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // getSimpleFlagStore is a test util which returns a flag store pre-filled with flags from sources A & B & C, which C empty
-func getSimpleFlagStore(t testing.TB) (*store.Store, []string) {
+func getSimpleFlagStore(t testing.TB) (store.IStore, []string) {
 	t.Helper()
 
 	variants := map[string]any{


### PR DESCRIPTION

## This PR
IStore interface usage instead of Store implementation
Separate locks for flag data and metadata in store


