### PR TITLE
refactor: removed unused Selector from Flag and Store.

### DIFF
--- a/core/pkg/evaluator/json_test.go
+++ b/core/pkg/evaluator/json_test.go
@@ -1042,7 +1042,6 @@ func TestState_Evaluator(t *testing.T) {
 						  "defaultVariant": "recursive",
 						  "state": "ENABLED",
 						  "source":"testSource",
-						  "selector":"",
 						  "targeting": {
 							"if": [
 							  {
@@ -1102,7 +1101,6 @@ func TestState_Evaluator(t *testing.T) {
 						  "defaultVariant": "recursive",
 						  "state": "ENABLED",
 						  "source":"testSource",
-						  "selector":"",
 						  "targeting": {
 							"if": [
 							  {
@@ -1212,7 +1210,6 @@ func TestState_Evaluator(t *testing.T) {
 						"defaultVariant": "recursive",
 						"state": "ENABLED",
 						"source":"testSource",
-						"selector":"",
 						"targeting": {
 						"if": [
 							{
@@ -1231,7 +1228,6 @@ func TestState_Evaluator(t *testing.T) {
 						},
 						"defaultVariant": "off",
 						"source":"testSource",
-						"selector":"",
 						"targeting": {
 							"if": [
 								{

--- a/core/pkg/model/flag.go
+++ b/core/pkg/model/flag.go
@@ -16,7 +16,6 @@ type Flag struct {
 	Variants       map[string]any  `json:"variants"`
 	Targeting      json.RawMessage `json:"targeting,omitempty"`
 	Source         string          `json:"source"`
-	Selector       string          `json:"selector"`
 	Metadata       Metadata        `json:"metadata,omitempty"`
 }
 

--- a/core/pkg/notifications/notifications.go
+++ b/core/pkg/notifications/notifications.go
@@ -47,6 +47,5 @@ func flagsEqual(a, b model.Flag) bool {
 		reflect.DeepEqual(a.Variants, b.Variants) &&
 		reflect.DeepEqual(a.Targeting, b.Targeting) &&
 		a.Source == b.Source &&
-		a.Selector == b.Selector &&
 		reflect.DeepEqual(a.Metadata, b.Metadata)
 }

--- a/core/pkg/store/store.go
+++ b/core/pkg/store/store.go
@@ -38,11 +38,6 @@ type Store struct {
 	FlagSources []string
 }
 
-type SourceDetails struct {
-	Source   string
-	Selector string
-}
-
 // NewStore creates a new in-memory store with the given sources.
 // The order of sources in the slice determines their priority, when queries result in duplicate flags (queries without source or flagSetId), the higher priority source "wins".
 func NewStore(logger *logger.Logger, sources []string) (*Store, error) {


### PR DESCRIPTION
## This PR

This pull request removes the unused `Selector` field from the `Flag` struct and deletes the `SourceDetails` struct, which is no longer in use.

These changes are part of a cleanup effort following the major refactoring in PR #1702, which made these components obsolete.

### Related Issues

Follow-up to #1702

### How to test

All existing tests should continue to pass.
