### PR TITLE
feat: add support for http-based ofrep metrics

### DIFF
--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -107,6 +107,7 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 	ofrepService, err := ofrep.NewOfrepService(jsonEvaluator, config.CORS, ofrep.SvcConfiguration{
 		Logger: logger.WithFields(zap.String("component", "OFREPService")),
 		Port:   config.OfrepServicePort,
+		MetricsRecorder: recorder,
 	},
 		config.ContextValues,
 		config.HeaderToContextKeyMappings,

--- a/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service_test.go
@@ -12,6 +12,7 @@ import (
 	mock "github.com/open-feature/flagd/core/pkg/evaluator/mock"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
+	"github.com/open-feature/flagd/core/pkg/telemetry"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/errgroup"
 )
@@ -26,6 +27,7 @@ func Test_OfrepServiceStartStop(t *testing.T) {
 	cfg := SvcConfiguration{
 		Logger: logger.NewLogger(nil, false),
 		Port:   uint16(port),
+		MetricsRecorder: &telemetry.NoopMetricsRecorder{},
 	}
 
 	service, err := NewOfrepService(eval, []string{"*"}, cfg, nil, nil)


### PR DESCRIPTION
## This PR

- adds support for HTTP-based OFREP metrics

### Notes

The middleware to capture HTTP-based metrics was never registered in OFREP service. This PR leverages the same metric configuration used for RPC evaluations.

The original question came from Slack:

https://cloud-native.slack.com/archives/C03J36ZP020/p1758305815794859

### How to test

Run flagd locally and use a local Prometheus instance.

https://flagd.dev/reference/monitoring/

Here's a screenshot of the results.

<img width="2555" height="981" alt="image" src="https://github.com/user-attachments/assets/e8b4ed90-d66b-49b5-a359-cf57d1fdd77a" />

