### PR TITLE
test: add `buildHeaders` function for http sync tests

### DIFF
--- a/core/pkg/sync/http/http_sync_test.go
+++ b/core/pkg/sync/http/http_sync_test.go
@@ -16,10 +16,12 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func buildHeaders(m map[string]string) http.Header {
+func buildHeaders(m map[string][]string) http.Header {
 	h := http.Header{}
 	for k, v := range m {
-		h.Set(k, v)
+		for _, val := range v {
+			h.Add(k, val)
+		}
 	}
 	return h
 }
@@ -35,7 +37,7 @@ func TestSimpleSync(t *testing.T) {
 	mockClient := syncmock.NewMockClient(ctrl)
 	responseBody := "test response"
 	resp := &http.Response{
-		Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+		Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 		StatusCode: http.StatusOK,
 	}
@@ -78,7 +80,7 @@ func TestExtensionWithQSSync(t *testing.T) {
 	mockClient := syncmock.NewMockClient(ctrl)
 	responseBody := "test response"
 	resp := &http.Response{
-		Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+		Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 		Body:       io.NopCloser(strings.NewReader(responseBody)),
 		StatusCode: http.StatusOK,
 	}
@@ -125,7 +127,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 		"success": {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
 				client.EXPECT().Do(gomock.Any()).Return(&http.Response{
-					Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+					Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 					Body:       io.NopCloser(strings.NewReader("test response")),
 					StatusCode: http.StatusOK,
 				}, nil)
@@ -152,7 +154,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 		"update last body sha": {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
 				client.EXPECT().Do(gomock.Any()).Return(&http.Response{
-					Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+					Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 					Body:       io.NopCloser(strings.NewReader("test response")),
 					StatusCode: http.StatusOK,
 				}, nil)
@@ -181,7 +183,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 						t.Fatalf("expected Authorization header to be 'Bearer %s', got %s", expectedToken, actualAuthHeader)
 					}
 					return &http.Response{
-						Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+						Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 						Body:       io.NopCloser(strings.NewReader("test response")),
 						StatusCode: http.StatusOK,
 					}, nil
@@ -212,7 +214,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 						t.Fatalf("expected Authorization header to be '%s', got %s", expectedHeader, actualAuthHeader)
 					}
 					return &http.Response{
-						Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+						Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 						Body:       io.NopCloser(strings.NewReader("test response")),
 						StatusCode: http.StatusOK,
 					}, nil
@@ -237,7 +239,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 		"unauthorized request": {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
 				client.EXPECT().Do(gomock.Any()).Return(&http.Response{
-					Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+					Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 					Body:       io.NopCloser(strings.NewReader("test response")),
 					StatusCode: http.StatusUnauthorized,
 				}, nil)
@@ -258,7 +260,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 						t.Fatalf("expected If-None-Match header to be '%s', got %s", expectedIfNoneMatch, actualIfNoneMatch)
 					}
 					return &http.Response{
-						Header:     buildHeaders(map[string]string{"ETag": expectedIfNoneMatch}),
+						Header:     buildHeaders(map[string][]string{"ETag": {expectedIfNoneMatch}}),
 						Body:       io.NopCloser(strings.NewReader("")),
 						StatusCode: http.StatusNotModified,
 					}, nil
@@ -298,9 +300,9 @@ func TestHTTPSync_Fetch(t *testing.T) {
 					newETag := `"c2e01ce63d90109c4c7f4f6dcea97ed1bb2b51e3647f36caf5acbe27413a24bb"`
 
 					return &http.Response{
-						Header: buildHeaders(map[string]string{
-							"Content-Type": "application/json",
-							"ETag":         newETag,
+						Header: buildHeaders(map[string][]string{
+							"Content-Type": {"application/json"},
+							"ETag":         {newETag},
 						}),
 						Body:       io.NopCloser(strings.NewReader(newContent)),
 						StatusCode: http.StatusOK,
@@ -373,6 +375,7 @@ func TestSync_Init(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 func TestHTTPSync_Resync(t *testing.T) {
@@ -392,7 +395,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 		"success": {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
 				client.EXPECT().Do(gomock.Any()).Return(&http.Response{
-					Header:     buildHeaders(map[string]string{"Content-Type": "application/json"}),
+					Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
 					Body:       io.NopCloser(strings.NewReader(emptyFlagData)),
 					StatusCode: http.StatusOK,
 				}, nil)


### PR DESCRIPTION
## This PR

The previous way of building HTTP headers with raw map is not reliable in some edge cases.

An example is case-sensitive issue for `ETag` header which requires `Etag` (lower case `t`) to be the map key when building the response with a raw map, in order to receive it via `resp.Header.Get("ETag")` on the other end.

Having a `buildHeaders` function to utilize `Set` built-in function of `http.Header` would solve this concern.

### How to test
```bash
go test ./core/pkg/sync/http/...
```

