### PR TITLE
revert: use go 1.24 in go.mod for core package

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,8 +1,6 @@
 module github.com/open-feature/flagd/core
 
-go 1.25.5
-
-toolchain go1.25.5
+go 1.24.0
 
 require (
 	buf.build/gen/go/open-feature/flagd/grpc/go v1.5.1-20250529171031-ebdc14163473.2


### PR DESCRIPTION
## This PR

- Keeps Go 1.24 as the minimum supported version for the core package.
  While development may use newer Go releases (e.g. 1.25.x), go.mod
  should reflect the lowest compatible version to avoid unnecessarily
  restricting downstream users.

### Related Issues

<!-- add here the GitHub issue that this PR resolves if applicable -->

Closes #1843 

### Notes

<!-- any additional notes for this PR -->

```sh
$ make build

$ go version -v bin/flagd

bin/flagd: go1.25.5

$ govulncheck -mode=binary -show verbose bin/flagd

=== Symbol Results ===

No vulnerabilities found.

=== Package Results ===

No other vulnerabilities found.

=== Module Results ===

Vulnerability #1: GO-2022-0646
    CBC padding oracle issue in AWS S3 Crypto SDK for golang in
    github.com/aws/aws-sdk-go
  More info: https://pkg.go.dev/vuln/GO-2022-0646
  Module: github.com/aws/aws-sdk-go
    Found in: github.com/aws/aws-sdk-go@v1.55.6
    Fixed in: N/A

Vulnerability #2: GO-2022-0635
    In-band key negotiation issue in AWS S3 Crypto SDK for golang in
    github.com/aws/aws-sdk-go
  More info: https://pkg.go.dev/vuln/GO-2022-0635
  Module: github.com/aws/aws-sdk-go
    Found in: github.com/aws/aws-sdk-go@v1.55.6
    Fixed in: N/A

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 2
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.