### PR TITLE
fix: use go 1.24.11

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-feature/flagd/core
 
-go 1.24.0
+go 1.24.11
 
 require (
 	buf.build/gen/go/open-feature/flagd/grpc/go v1.5.1-20250529171031-ebdc14163473.2


### PR DESCRIPTION
I think this is somewhat redundant, because the latest Go version will be used at release, but I think it's good to explicitly set this because of the the related CVEs: https://github.com/open-feature/flagd/security/advisories