### PR TITLE
docs(adr): unified flagd evaluator

### DIFF
--- a/docs/architecture-decisions/unified-evaluator.md
+++ b/docs/architecture-decisions/unified-evaluator.md
@@ -7,6 +7,8 @@ updated: 2026-01-20
 
 # Unified Evaluator:  Centralizing Flag Evaluation Logic Across the OpenFeature Ecosystem
 
+> **Status**: This ADR is in `proposed` state and represents a transparent statement of goals and community discussion, not a final design decision. Implementation approaches and specific technologies (such as WASM) have not been conclusively determined. The community is actively researching alternatives including FFI bindings and other approaches. We will seek to find solutions (such as "Bring Your Own Evaluator") if consensus cannot be reached on specific targets and runtimes.
+
 Adopt a unified evaluation engine to replace fragmented, language-specific evaluation implementations across OpenFeature SDKs, reducing maintenance burden and ensuring behavioral consistency.
 
 ## Background


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This pull request introduces a comprehensive Architecture Decision Record (ADR) detailing the strategic move towards a unified flag evaluation engine within the OpenFeature ecosystem. The core objective is to consolidate the currently fragmented, language-specific evaluation implementations into a single, robust solution. By leveraging Rust for its performance and cross-compilation capabilities (WASM and native bindings), the proposal aims to significantly reduce maintenance burden, ensure consistent behavioral outcomes across all SDKs, and accelerate feature development. The ADR meticulously outlines the scope, technical considerations, and a phased adoption plan, emphasizing a gradual, opt-in migration to ensure stability and community validation.

* **Introduction of Unified Evaluator ADR**: This pull request adds a new Architecture Decision Record (ADR) proposing a 'Unified Evaluator' for the OpenFeature ecosystem. This evaluator aims to centralize flag evaluation logic, currently fragmented across various language-specific SDKs.
* **Problem Statement and Proposed Solution**: The ADR identifies issues like maintenance overhead, inconsistent behavior, and duplicated effort due to disparate SDK implementations. It proposes a single, canonical evaluator implemented in Rust, designed to compile to WebAssembly (WASM) for portability and native bindings (PyO3, napi-rs) for performance-critical languages.
* **Scope and Responsibilities**: The unified evaluator will be responsible for evaluation logic, in-memory flag storage, and JSON schema validation (maximal scope). SDKs will become thinner adapters, focusing on OpenFeature API compliance, language-specific concerns, and sync protocol implementation.
* **Migration Strategy**: A phased, experimental opt-in rollout strategy is outlined to minimize risk and gather feedback, eventually leading to the unified evaluator becoming the default implementation across all SDKs.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1842

