### PR TITLE
docs(ADR): Proposal for the Semantic Versioning policy for flagd

### DIFF
--- a/docs/architecture-decisions/semantic-versioning-policy.md
+++ b/docs/architecture-decisions/semantic-versioning-policy.md
@@ -1,6 +1,6 @@
 ---
 # Valid statuses: draft | proposed | rejected | accepted | superseded
-status: proposed
+status: accepted
 author: Maks Osowski (@cupofcat)
 created: 2026-01-22
 ---
@@ -104,9 +104,9 @@ The [Flag Definition Schema](https://flagd.dev/reference/schema/?h=schema) repre
 
 **Version Alignment and Validation**:
 
-*   **New Features**: When new features (e.g., a "regex" operator in targeting) are added to the schema, support for them is rolled out via **minor** version releases of the flagd binary and providers.
-*   **Validation**: If a user attempts to load a flag definition that uses features not present in the provider's or flagd binary's bundled schema version, the schema will fail to validate. The component will output specific error messages indicating the incompatibility, ensuring users know which version upgrade is required to support their configuration.
-*   A **patch** version upgrade of a flagd binary or provider will **NOT** change the bundled schema version to ensure stability.
+* **New Features**: When new features (e.g., a "regex" operator in targeting) are added to the schema, support for them is rolled out via **minor** version releases of the flagd binary and providers.
+* **Validation**: If a user attempts to load a flag definition that uses features not present in the provider's or flagd binary's bundled schema version, the schema will fail to validate. The component will output specific error messages indicating the incompatibility, ensuring users know which version upgrade is required to support their configuration.
+* A **patch** version upgrade of a flagd binary or provider will **NOT** change the bundled schema version to ensure stability.
 
 ### flagd Providers and OpenFeature SDKs
 


### PR DESCRIPTION
## This PR
Establishes a comprehensive versioning policy for flagd binaries and providers, aiming for stability and predictable upgrades. This policy creates a "Modified SemVer" contract where the ecosystem stays on v1.x.y indefinitely, with specific rules for breaking changes and support windows.

**Addresses:**
- Define API stability guarantees (Providers expect API support, no forward/backward guarantees).
- Define "breaking change" (Detailed sections for configuration, observability, runtime behavior).
- Create deprecation policy (Announced in minor, supported for 3 minors/12 months).
- Set per-minor release cadence (Feature-driven/Ad-hoc, not calendar-based).
- Define active-support windows (Support latest + 3 previous minor releases).
- Create policy for back-porting (Roll-forward preferred; backporting for severe bugs/security only).

**Out of Scope / Future Work:**
- Create requirements for authoring migration guides.
- Publish conformance reports with each minor release.
- Include benchmark report with each minor release.

**Key Components:**
- **Release Strategy**: Ad-hoc minor releases based on feature readiness; Patch releases for critical fixes.
- **Artifacts**: Immutable artifacts with published hashes.
- **Provider Alignment**: Strives for minor version alignment for feature parity.

### Related Issues
- https://github.com/open-feature/flagd/issues/1754