### PR TITLE
fix: improve error context in store Watch function

### DIFF
--- a/core/pkg/store/query.go
+++ b/core/pkg/store/query.go
@@ -116,6 +116,25 @@ func (s Selector) ToQuery() (indexId string, constraints []interface{}) {
 	return indexId, constraints
 }
 
+// String returns a human-readable representation of the Selector for logging purposes.
+func (s *Selector) String() string {
+	if s == nil || len(s.indexMap) == 0 {
+		return "<empty selector>"
+	}
+
+	keys := make([]string, 0, len(s.indexMap))
+	for key := range s.indexMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(s.indexMap))
+	for _, key := range keys {
+		parts = append(parts, key+"="+s.indexMap[key])
+	}
+	return strings.Join(parts, ", ")
+}
+
 // ToMetadata converts the selector's internal map to metadata for logging or tracing purposes.
 // Only includes known indices to avoid leaking sensitive information, and is usually returned as the "top level" metadata
 func (s *Selector) ToMetadata() model.Metadata {

--- a/core/pkg/store/query_test.go
+++ b/core/pkg/store/query_test.go
@@ -171,6 +171,44 @@ func TestSelector_ToMetadata(t *testing.T) {
 	}
 }
 
+func TestSelector_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector *Selector
+		want     string
+	}{
+		{
+			name:     "nil selector",
+			selector: nil,
+			want:     "<empty selector>",
+		},
+		{
+			name:     "empty indexMap",
+			selector: &Selector{indexMap: map[string]string{}},
+			want:     "<empty selector>",
+		},
+		{
+			name:     "single key",
+			selector: &Selector{indexMap: map[string]string{"source": "abc"}},
+			want:     "source=abc",
+		},
+		{
+			name:     "multiple keys sorted alphabetically",
+			selector: &Selector{indexMap: map[string]string{"source": "abc", "flagSetId": "1234"}},
+			want:     "flagSetId=1234, source=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.selector.String()
+			if got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewSelector(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/core/pkg/store/store.go
+++ b/core/pkg/store/store.go
@@ -313,7 +313,7 @@ func (s *Store) Watch(ctx context.Context, selector *Selector, watcher chan<- Fl
 			ws := memdb.NewWatchSet()
 			it, err := s.selectOrAll(selector)
 			if err != nil {
-				s.logger.Error(fmt.Sprintf("error watching flags: %v", err))
+				s.logger.Error(fmt.Sprintf("error watching flags: failed to select flags with selector [%s]: %v", selector.String(), err))
 				close(watcher)
 				return
 			}
@@ -326,7 +326,7 @@ func (s *Store) Watch(ctx context.Context, selector *Selector, watcher chan<- Fl
 			}
 
 			if err = ws.WatchCtx(ctx); err != nil {
-				s.logger.Error(fmt.Sprintf("error watching flags: %v", err))
+				s.logger.Error(fmt.Sprintf("error watching flags: context error with selector [%s]: %v", selector.String(), err))
 				close(watcher)
 				return
 			}


### PR DESCRIPTION
## Summary
Improves error context in the store Watch function to include selector and relevant details for better troubleshooting.

When the store Watch function fails (e.g., due to context canceled), the error log message previously only stated "error watching flags: context canceled." This made troubleshooting very hard, as we missed context about which flag, selector, or parameters were involved.

Fixes #1863

## Changes
- Add `String()` method to `Selector` type for human-readable representation in logs
- Include selector information in Watch error logs:
  - "error watching flags: failed to select flags with selector [source=abc]: ..."
  - "error watching flags: context error with selector [source=abc]: ..."
- Add comprehensive unit tests for the new `Selector.String()` method

## Example
Before:
```
error watching flags: context canceled
```

After:
```
error watching flags: context error with selector [source=mySource]: context canceled
```

## Testing
- [x] go build ./... passes
- [x] go test ./... passes
- [x] Error messages now include helpful context

## AI Transparency
This PR was created with the assistance of AI (Claude by Anthropic) for code generation and review.