### PR TITLE
docs: ADR proposing "rollout" operator

### DIFF
--- a/docs/architecture-decisions/fractional.md
+++ b/docs/architecture-decisions/fractional.md
@@ -2,7 +2,7 @@
 status: draft
 author: @toddbaert
 created: 2025-06-06
-updated: 2025-06-06
+updated: 2026-03-13
 ---
 
 # Fractional Operator
@@ -111,6 +111,21 @@ Note that in this example, we've also specified a custom bucketing value.
 }
 ```
 
+**Dynamic weights** are also supported: the weight argument in each variant array can be a JSONLogic expression that evaluates to a numeric value, not only a hard-coded integer.
+This enables use cases such as time-based progressive rollouts, where the weight changes dynamically based on the evaluation context (e.g., `$flagd.timestamp`).
+Negative weight values (which can result from dynamic expressions) must be clamped to 0.
+
+```jsonc
+// Time-based progressive rollout using dynamic weights:
+// the "on" weight grows as time advances, "off" weight shrinks.
+{
+  "fractional": [
+    ["on",  { "-": [{ "var": "$flagd.timestamp" }, 1740000000] }],
+    ["off", { "-": [1800000000, { "var": "$flagd.timestamp" }] }]
+  ]
+}
+```
+
 ### Consequences
 
 - Good, because Murmur3 is fast, has good avalanche properties, and we don't need "cryptographic" randomness
@@ -118,4 +133,3 @@ Note that in this example, we've also specified a custom bucketing value.
 - Good, because our bucketing algorithm is relatively stable when new variants are added
 - Bad, because we only support string bucketing values
 - Bad, because we don't have bucket resolution finer than 1:99
-- Bad, because we don't support JSONLogic expressions within bucket definitions

--- a/docs/architecture-decisions/rollout-operator.md
+++ b/docs/architecture-decisions/rollout-operator.md
@@ -1,13 +1,16 @@
 ---
-status: draft
+status: rejected
 author: @toddbaert
 created: 2026-02-06
-updated: 2026-02-06
+updated: 2026-03-13
 ---
 
 # Rollout Operator
 
-The rollout operator enables time-based progressive feature rollouts.
+**Status: Rejected**: After discussion, this proposal was rejected in favor of enhancing the existing `fractional` operator to accept JSONLogic expressions as weight arguments (see the [Alternative Proposal](#alternative-proposal-enhanced-fractional-with-dynamic-weights) section below and the [Fractional Operator ADR](fractional.md)).
+The rollout/rollback operators are largely syntactic sugar over `fractional` with dynamic weights, and the additional operator surface area across all language SDKs is not justified at this time.
+The enhanced `fractional` approach has been proven to support both progressive rollouts and FILO rollbacks using only existing primitives.
+A dedicated operator may be reconsidered in the future if strong user need emerges, perhaps "compiled" to the fractional alternative described.
 
 ## Background
 


### PR DESCRIPTION
Proposes a "rollout operator". Facilitates linear, progressive rollouts as a fundamental feature flag use case: gradually shifting traffic from one variant to another over time.

See ADR for justification and full proposal.

See also:
- draft implementation **WITH DEMO** in flagd: https://github.com/open-feature/flagd/pull/1868
  - run demo with: `make build-flagd && ./demo-rollout.sh`
- draft schema changes: https://github.com/open-feature/flagd-schemas/pull/205


![output](https://github.com/user-attachments/assets/7eaeafea-bc60-40db-a1ac-65d9c15f82a4)

