### PR TITLE
feat: add rollout op

### DIFF
--- a/config/samples/example_flags.flagd.json
+++ b/config/samples/example_flags.flagd.json
@@ -157,6 +157,12 @@
       }
     }
   },
+  "demo": {
+    "state": "ENABLED",
+    "variants": { "old": "OLD", "new": "NEW" },
+    "defaultVariant": "old",
+    "targeting": { "rollout": [1770406165, 1770406195, "new"] }
+  },
   "$evaluators": {
     "emailWithFaas": {
       "in": ["@faas.com", {

--- a/core/pkg/evaluator/json.go
+++ b/core/pkg/evaluator/json.go
@@ -154,6 +154,7 @@ func NewResolver(store store.IStore, logger *logger.Logger, jsonEvalTracer trace
 	jsonlogic.AddOperator(StartsWithEvaluationName, NewStringComparisonEvaluator(logger).StartsWithEvaluation)
 	jsonlogic.AddOperator(EndsWithEvaluationName, NewStringComparisonEvaluator(logger).EndsWithEvaluation)
 	jsonlogic.AddOperator(SemVerEvaluationName, NewSemVerComparison(logger).SemVerEvaluation)
+	jsonlogic.AddOperator(RolloutEvaluationName, NewRollout(logger).Evaluate)
 
 	return Resolver{store: store, Logger: logger, tracer: jsonEvalTracer}
 }

--- a/core/pkg/evaluator/rollout.go
+++ b/core/pkg/evaluator/rollout.go
@@ -1,0 +1,242 @@
+package evaluator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"github.com/twmb/murmur3"
+)
+
+const RolloutEvaluationName = "rollout"
+
+// Rollout is a custom JSONLogic operator for time-based progressive feature rollouts.
+// It gradually transitions users from one variant/expression to another over a specified time period.
+// For complex distributions, compose with the "fractional" operator.
+//
+// Syntax:
+//
+// Shorthand (roll from defaultVariant to target):
+//
+//	{"rollout": [<startTime>, <endTime>, <to>]}
+//
+// Longhand (explicit from and to):
+//
+//	{"rollout": [<startTime>, <endTime>, <from>, <to>]}
+//
+// With custom bucketBy:
+//
+//	{"rollout": [<bucketBy>, <startTime>, <endTime>, <from>, <to>]}
+//
+// Parameters:
+//   - bucketBy: Optional. JSONLogic expression (e.g., {"var": "email"}).
+//     If omitted, uses flagKey + targetingKey (same as fractional).
+//   - startTime: Unix timestamp (int32) when rollout begins (0% on to)
+//   - endTime: Unix timestamp (int32) when rollout completes (100% on to)
+//   - from: The starting variant/expression. Can be a string, bool, int, or JSONLogic.
+//   - to: The target variant/expression. Can be a string, bool, int, or JSONLogic.
+//
+// The rollout linearly increases the percentage of users seeing toVariant from 0% at
+// startTime to 100% at endTime. For more complex distributions at either end, use
+// the fractional operator as the from/to value.
+//
+// Examples:
+//
+// 1. Simple rollout to "new":
+//
+//	{"rollout": [1704067200, 1706745600, "new"]}
+//
+// 2. Explicit from/to:
+//
+//	{"rollout": [1704067200, 1706745600, "old", "new"]}
+//
+// 3. With custom bucketBy:
+//
+//	{"rollout": [{"var": "email"}, 1704067200, 1706745600, "old", "new"]}
+//
+// 4. Rollout to a fractional split (50% A, 50% B):
+//
+//	{"rollout": [1704067200, 1706745600, "old", {"fractional": [["a", 1], ["b", 1]]}]}
+//
+// 5. Phased rollout using if + timestamp:
+//
+//	{
+//	  "if": [
+//	    {"<": [{"var": "$flagd.timestamp"}, 1736294400]},
+//	    {"rollout": [1735689600, 1736294400, "old", "new"]},
+//	    "new"
+//	  ]
+//	}
+type Rollout struct {
+	Logger *logger.Logger
+}
+
+type rolloutConfig struct {
+	bucketBy    string
+	from        any // string, bool, int, or JSONLogic node
+	to          any // string, bool, int, or JSONLogic node
+	startTime   int32
+	endTime     int32
+	currentTime int32
+	data        any // original data context for evaluating nested JSONLogic
+}
+
+func NewRollout(logger *logger.Logger) *Rollout {
+	return &Rollout{Logger: logger}
+}
+
+func (r *Rollout) Evaluate(values, data any) any {
+	config, err := r.parseRolloutData(values, data)
+	if err != nil {
+		r.Logger.Warn(fmt.Sprintf("parse rollout evaluation data: %v", err))
+		return nil
+	}
+
+	return r.determineVariant(config)
+}
+
+func (r *Rollout) parseRolloutData(values, data any) (*rolloutConfig, error) {
+	valuesArray, ok := values.([]any)
+	if !ok {
+		return nil, errors.New("rollout evaluation data is not an array")
+	}
+
+	if len(valuesArray) < 3 {
+		return nil, errors.New("rollout requires at least 3 arguments: startTime, endTime, toVariant")
+	}
+
+	dataMap, ok := data.(map[string]any)
+	if !ok {
+		return nil, errors.New("data isn't of type map[string]any")
+	}
+
+	properties, _ := getFlagdProperties(dataMap)
+	config := &rolloutConfig{
+		currentTime: int32(properties.Timestamp),
+		data:        data,
+	}
+
+	if config.currentTime == 0 {
+		return nil, errors.New("timestamp not available in context for rollout")
+	}
+
+	argIndex := 0
+
+	if _, err := extractInt(valuesArray[0]); err != nil {
+		// first arg is not a number — it's a bucketBy value.
+		// Note: JSONLogic pre-evaluates all custom operator arguments via parseValues(),
+		// so expressions like {"var": "email"} or {"cat": [...]} arrive here already
+		// resolved to their string, bool, or numeric result.
+		switch v := valuesArray[0].(type) {
+		case string:
+			config.bucketBy = v
+			argIndex = 1
+		case bool:
+			config.bucketBy = fmt.Sprintf("%v", v)
+			argIndex = 1
+		case float64:
+			config.bucketBy = fmt.Sprintf("%v", v)
+			argIndex = 1
+		case nil:
+			argIndex = 1
+		default:
+			return nil, fmt.Errorf("invalid first argument type %T: expected string, bool, number, or nil", valuesArray[0])
+		}
+	}
+
+	// if no explicit bucketBy, use flagKey + targetingKey
+	if config.bucketBy == "" {
+		targetingKey, ok := dataMap[targetingKeyKey].(string)
+		if !ok {
+			return nil, errors.New("bucketing value not supplied and no targetingKey in context")
+		}
+		config.bucketBy = fmt.Sprintf("%s%s", properties.FlagKey, targetingKey)
+	}
+
+	// parse startTime
+	if argIndex >= len(valuesArray) {
+		return nil, errors.New("missing startTime argument")
+	}
+	startTime, err := extractInt(valuesArray[argIndex])
+	if err != nil {
+		return nil, fmt.Errorf("startTime: %w", err)
+	}
+	config.startTime = startTime
+	argIndex++
+
+	// parse endTime
+	if argIndex >= len(valuesArray) {
+		return nil, errors.New("missing endTime argument")
+	}
+	endTime, err := extractInt(valuesArray[argIndex])
+	if err != nil {
+		return nil, fmt.Errorf("endTime: %w", err)
+	}
+	config.endTime = endTime
+	argIndex++
+
+	if config.endTime <= config.startTime {
+		return nil, errors.New("endTime must be after startTime")
+	}
+
+	// parse variants
+	remaining := len(valuesArray) - argIndex
+
+	if remaining == 1 {
+		// shorthand: just toVariant, from = nil (defaultVariant)
+		config.from = nil
+		config.to = valuesArray[argIndex]
+	} else if remaining >= 2 {
+		// longhand: fromVariant, toVariant
+		config.from = valuesArray[argIndex]
+		config.to = valuesArray[argIndex+1]
+	} else {
+		return nil, errors.New("missing variant argument(s)")
+	}
+
+	return config, nil
+}
+
+// extractInt extracts an int32 from a JSON number (always float64 in Go).
+func extractInt(val any) (int32, error) {
+	v, ok := val.(float64)
+	if !ok {
+		return 0, fmt.Errorf("must be a number, got %T", val)
+	}
+	return int32(v), nil
+}
+
+// calculateProgress returns the rollout progress as elapsed time since start
+func (r *Rollout) calculateElapsed(config *rolloutConfig) (elapsed int64, duration int64) {
+	duration = int64(config.endTime - config.startTime)
+	if config.currentTime <= config.startTime {
+		return 0, duration
+	}
+	if config.currentTime >= config.endTime {
+		return duration, duration
+	}
+	elapsed = int64(config.currentTime - config.startTime)
+	return elapsed, duration
+}
+
+// determineVariant uses murmur3 hashing to deterministically select either from or to variant based on the rollout progress.
+func (r *Rollout) determineVariant(config *rolloutConfig) any {
+	elapsed, duration := r.calculateElapsed(config)
+
+	// edge cases:
+	if elapsed <= 0 {
+		return config.from
+	}
+	if elapsed >= duration {
+		return config.to
+	}
+
+	// use integer math for bucket assignment - maps hash to [0, duration) range, then compares against elapsed
+	hashValue := murmur3.StringSum32(config.bucketBy)
+	bucket := (uint64(hashValue) * uint64(duration)) >> 32
+
+	if bucket < uint64(elapsed) {
+		return config.to
+	}
+	return config.from
+}

--- a/core/pkg/evaluator/rollout_test.go
+++ b/core/pkg/evaluator/rollout_test.go
@@ -1,0 +1,501 @@
+package evaluator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"github.com/open-feature/flagd/core/pkg/model"
+	"github.com/open-feature/flagd/core/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRolloutEvaluate(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+	rollout := NewRollout(log)
+
+	startTime := int64(1704067200) // Jan 1, 2024
+	endTime := int64(1706745600)   // Jan 31, 2024
+
+	tests := []struct {
+		name     string
+		values   any
+		data     any
+		expected any
+	}{
+		{
+			name: "shorthand: before start returns nil (defaultVariant)",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": startTime - 1000,
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "shorthand: after end returns toVariant",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: "new",
+		},
+		{
+			name: "longhand: before start returns fromVariant",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				"old",
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": startTime - 1000,
+				},
+			},
+			expected: "old",
+		},
+		{
+			name: "longhand: after end returns toVariant",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				"old",
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: "new",
+		},
+		{
+			name: "string bucketBy (pre-evaluated by JSONLogic)",
+			values: []any{
+				"custom-bucket",
+				float64(startTime),
+				float64(endTime),
+				"old",
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: "new",
+		},
+		{
+			name: "with string bucketBy",
+			values: []any{
+				// JSONLogic pre-evaluates custom operator args, so bucketBy
+				// expressions like {"var": "email"} arrive as their resolved string.
+				"test@example.com",
+				float64(startTime),
+				float64(endTime),
+				"old",
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				"email":         "test@example.com",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: "new",
+		},
+		{
+			name: "bool from variant: before start",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				true,
+				false,
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": startTime - 1000,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "bool to variant: after end",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				true,
+				false,
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "numeric from variant: before start",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				float64(0),
+				float64(1),
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": startTime - 1000,
+				},
+			},
+			expected: float64(0),
+		},
+		{
+			name: "numeric to variant: after end",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				float64(0),
+				float64(1),
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": endTime + 1000,
+				},
+			},
+			expected: float64(1),
+		},
+		{
+			name:   "invalid: not an array",
+			values: "not an array",
+			data: map[string]any{
+				targetingKeyKey: "user123",
+			},
+			expected: nil,
+		},
+		{
+			name: "invalid: too few arguments",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+			},
+			data:     map[string]any{targetingKeyKey: "user123"},
+			expected: nil,
+		},
+		{
+			name: "invalid: endTime before startTime",
+			values: []any{
+				float64(endTime),
+				float64(startTime),
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": int64(1705406400),
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "during rollout: shorthand returns nil (from=defaultVariant) for this user hash",
+			values: []any{
+				float64(startTime),
+				float64(endTime),
+				"new",
+			},
+			data: map[string]any{
+				targetingKeyKey: "user123",
+				flagdPropertiesKey: map[string]any{
+					"flagKey":   "testFlag",
+					"timestamp": startTime + (endTime-startTime)/2, // midpoint
+				},
+			},
+			expected: nil, // This user's hash falls in the "from" bucket during rollout
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rollout.Evaluate(tt.values, tt.data)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRolloutDeterminism(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+	rollout := NewRollout(log)
+
+	startTime := int64(1704067200)
+	endTime := int64(1706745600)
+	midTime := startTime + (endTime-startTime)/2
+
+	values := []any{
+		float64(startTime),
+		float64(endTime),
+		"old",
+		"new",
+	}
+	data := map[string]any{
+		targetingKeyKey: "same-user@example.com",
+		flagdPropertiesKey: map[string]any{
+			"flagKey":   "testFlag",
+			"timestamp": midTime,
+		},
+	}
+
+	firstResult := rollout.Evaluate(values, data)
+
+	for i := 0; i < 100; i++ {
+		result := rollout.Evaluate(values, data)
+		assert.Equal(t, firstResult, result, "result should be deterministic")
+	}
+}
+
+func TestRolloutTimeProgression(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+	rollout := NewRollout(log)
+
+	startTime := int64(1704067200)
+	endTime := int64(1706745600)
+	duration := endTime - startTime
+
+	tests := []struct {
+		name        string
+		currentTime int64
+		minNewPct   float64
+		maxNewPct   float64
+	}{
+		{
+			name:        "at start (0%)",
+			currentTime: startTime,
+			minNewPct:   0,
+			maxNewPct:   0,
+		},
+		{
+			name:        "25% through",
+			currentTime: startTime + duration/4,
+			minNewPct:   0.20,
+			maxNewPct:   0.30,
+		},
+		{
+			name:        "50% through",
+			currentTime: startTime + duration/2,
+			minNewPct:   0.45,
+			maxNewPct:   0.55,
+		},
+		{
+			name:        "75% through",
+			currentTime: startTime + 3*duration/4,
+			minNewPct:   0.70,
+			maxNewPct:   0.80,
+		},
+		{
+			name:        "at end (100%)",
+			currentTime: endTime,
+			minNewPct:   1.0,
+			maxNewPct:   1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iterations := 5000
+			newCount := 0
+
+			for i := 0; i < iterations; i++ {
+				// Use default bucketBy (flagKey + targetingKey)
+				values := []any{
+					float64(startTime),
+					float64(endTime),
+					"old",
+					"new",
+				}
+				data := map[string]any{
+					targetingKeyKey: fmt.Sprintf("user-%d", i),
+					flagdPropertiesKey: map[string]any{
+						"flagKey":   "testFlag",
+						"timestamp": tt.currentTime,
+					},
+				}
+
+				result := rollout.Evaluate(values, data)
+				if result == "new" {
+					newCount++
+				}
+			}
+
+			actualPct := float64(newCount) / float64(iterations)
+			if actualPct < tt.minNewPct || actualPct > tt.maxNewPct {
+				t.Errorf("expected %.0f%%-%.0f%% 'new', got %.1f%%",
+					tt.minNewPct*100, tt.maxNewPct*100, actualPct*100)
+			}
+		})
+	}
+}
+
+func TestRolloutIntegration(t *testing.T) {
+	const source = "testSource"
+	ctx := context.Background()
+
+	flags := []model.Flag{
+		{
+			Key:            "rolloutFeature",
+			State:          "ENABLED",
+			DefaultVariant: "old",
+			Variants: map[string]any{
+				"old": "old-value",
+				"new": "new-value",
+			},
+			Targeting: []byte(`{
+				"rollout": [1704067200, 1706745600, "new"]
+			}`),
+		},
+		{
+			Key:            "rolloutFeatureLonghand",
+			State:          "ENABLED",
+			DefaultVariant: "old",
+			Variants: map[string]any{
+				"old": "old-value",
+				"new": "new-value",
+			},
+			Targeting: []byte(`{
+				"rollout": [1704067200, 1706745600, "old", "new"]
+			}`),
+		},
+		{
+			Key:            "conditionalRollout",
+			State:          "ENABLED",
+			DefaultVariant: "old",
+			Variants: map[string]any{
+				"old": "old-value",
+				"new": "new-value",
+			},
+			Targeting: []byte(`{
+				"if": [
+					{"ends_with": [{"var": "email"}, "@internal.com"]},
+					"new",
+					{"rollout": [1704067200, 1706745600, "old", "new"]}
+				]
+			}`),
+		},
+		{
+			// bucketBy uses {"var": "orgId"} — a JSONLogic operator that gets pre-evaluated to a string
+			Key:            "rolloutOperatorInBucketBy",
+			State:          "ENABLED",
+			DefaultVariant: "old",
+			Variants: map[string]any{
+				"old": "old-value",
+				"new": "new-value",
+			},
+			Targeting: []byte(`{
+				"rollout": [{"var": "orgId"}, 1704067200, 1706745600, "old", "new"]
+			}`),
+		},
+		{
+			// from/to use {"cat": [...]} — operators that get pre-evaluated to strings
+			Key:            "rolloutOperatorInVariants",
+			State:          "ENABLED",
+			DefaultVariant: "default",
+			Variants: map[string]any{
+				"default": "default-value",
+				"old":     "old-value",
+				"new":     "new-value",
+			},
+			Targeting: []byte(`{
+				"rollout": [1704067200, 1706745600, {"cat": ["ol","d"]}, {"cat": ["ne","w"]}]
+			}`),
+		},
+	}
+
+	log := logger.NewLogger(nil, false)
+	s := store.NewFlags()
+	s.Update(source, flags, nil)
+	je := NewJSON(log, s)
+
+	testCases := []struct {
+		name         string
+		flagKey      string
+		context      map[string]any
+		expectedUser string
+	}{
+		{
+			name:         "shorthand rollout after end returns new",
+			flagKey:      "rolloutFeature",
+			context:      map[string]any{targetingKeyKey: "user123"},
+			expectedUser: "new",
+		},
+		{
+			name:         "longhand rollout after end returns new",
+			flagKey:      "rolloutFeatureLonghand",
+			context:      map[string]any{targetingKeyKey: "user123"},
+			expectedUser: "new",
+		},
+		{
+			name:    "conditional rollout for internal user",
+			flagKey: "conditionalRollout",
+			context: map[string]any{
+				targetingKeyKey: "user123",
+				"email":         "test@internal.com",
+			},
+			expectedUser: "new",
+		},
+		{
+			name:         "operator in bucketBy",
+			flagKey:      "rolloutOperatorInBucketBy",
+			context:      map[string]any{targetingKeyKey: "user1", "orgId": "org1"},
+			expectedUser: "new",
+		},
+		{
+			name:         "operator in from/to variants",
+			flagKey:      "rolloutOperatorInVariants",
+			context:      map[string]any{targetingKeyKey: "user1"},
+			expectedUser: "new",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			value, variant, reason, _, err := je.ResolveStringValue(ctx, tt.name, tt.flagKey, tt.context)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedUser, variant)
+			assert.Equal(t, tt.expectedUser+"-value", value)
+			assert.Equal(t, model.TargetingMatchReason, reason)
+		})
+	}
+}

--- a/demo-rollout.sh
+++ b/demo-rollout.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Demo: Rollout operator - gradual migration over 30 seconds
+
+NUM_USERS=20
+DURATION=30
+FLAG_FILE="$(dirname "$0")/rollout-demo-flags.json"
+OFREP_PORT=8016
+
+# Kill any existing flagd
+pkill -9 -f "flagd start" 2>/dev/null || true
+sleep 1
+
+# Calculate timestamps - start 5 seconds in the future to allow setup
+START_TIME=$(($(date +%s) + 5))
+END_TIME=$((START_TIME + DURATION))
+
+# Create flag config - NOTE THE CONFIG DOES NOT CHANGE DURING THE DEMO - the rule itself is time-aware
+cat > "$FLAG_FILE" << EOF
+{
+  "flags": {
+    "demo": {
+      "state": "ENABLED",
+      "variants": { "old": "OLD", "new": "NEW" },
+      "defaultVariant": "old",
+      "targeting": { "rollout": [$START_TIME, $END_TIME, "new"] }
+    }
+  }
+}
+EOF
+
+# Generate random user keys
+declare -a USERS
+for i in $(seq 1 $NUM_USERS); do
+  USERS[$i]="user_$(head -c4 /dev/urandom | xxd -p)"
+done
+
+echo "Starting flagd (rollout: $START_TIME -> $END_TIME)..."
+./bin/flagd start -f "file:$FLAG_FILE" &>/dev/null &
+FLAGD_PID=$!
+trap "kill $FLAGD_PID 2>/dev/null" EXIT
+
+# Wait until rollout starts
+now=$(date +%s)
+wait_time=$((START_TIME - now))
+if [[ $wait_time -gt 0 ]]; then
+  echo "Waiting ${wait_time}s for rollout to begin..."
+  sleep $wait_time
+fi
+
+# Evaluate flag for a user
+eval_flag() {
+  curl -s "http://localhost:$OFREP_PORT/ofrep/v1/evaluate/flags/demo" \
+    -H "Content-Type: application/json" \
+    -d "{\"context\":{\"targetingKey\":\"$1\"}}" | grep -o '"value":"[^"]*"' | cut -d'"' -f4
+}
+
+# Header
+printf "\n%-6s" "TIME"
+for i in $(seq 1 $NUM_USERS); do printf "  U%-2d" "$i"; done
+printf "  %%NEW\n"
+printf "%s\n" "$(printf '=%.0s' {1..60})"
+
+# Poll every 2 seconds
+for t in $(seq 0 2 $DURATION); do
+  [[ $t -gt 0 ]] && sleep 2
+  
+  printf "%-6s" "${t}s"
+  new_count=0
+  
+  for i in $(seq 1 $NUM_USERS); do
+    result=$(eval_flag "${USERS[$i]}")
+    if [[ "$result" == "NEW" ]]; then
+      printf "  \033[32m%-3s\033[0m" "NEW"
+      new_count=$((new_count + 1))
+    else
+      printf "  \033[33m%-3s\033[0m" "OLD"
+    fi
+  done
+  
+  pct=$((new_count * 100 / NUM_USERS))
+  printf "  %3d%%\n" "$pct"
+done
+
+echo -e "\nRollout complete!"


### PR DESCRIPTION
Draft implementation of a `rollout` operator.

For a demo with virtual users in your console, do:

```sh
make build-flagd
./demo-rollout.sh
```

For full details and justification, please see ADR: https://github.com/open-feature/flagd/pull/1867


 