### PR TITLE
chore: remove homebrew publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -211,23 +211,3 @@ jobs:
             ./sbom.xml
             ./*.tar.gz
             ./*.zip
-  homebrew:
-    name: Bump homebrew-core formula
-    needs: release-please
-    runs-on: ubuntu-latest
-    # Only run on non-forked flagd releases
-    if: ${{ github.repository_owner == 'open-feature' && needs.release-please.outputs.flagd_tag_name }}
-    steps:
-      - uses: mislav/bump-homebrew-formula-action@v2
-        with:
-          formula-name: flagd
-          # https://github.com/mislav/bump-homebrew-formula-action/issues/58
-          formula-path: Formula/f/flagd.rb
-          tag-name: ${{ needs.release-please.outputs.flagd_tag_name }}
-          download-url: https://github.com/${{ github.repository }}.git
-          commit-message: |
-            {{formulaName}} ${{ needs.release-please.outputs.flagd_version }}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,12 +45,6 @@ You can also choose to run a Kubernetes service in front of a deployment with mu
 
 A systemd wrapper is available [here](https://github.com/open-feature/flagd/blob/main/systemd/flagd.service).
 
-### Homebrew
-
-```shell
-brew install flagd
-```
-
 ## Summary
 
 Once flagd is installed, you can start using it within your application.


### PR DESCRIPTION
Remove homebrew. It hasn't been working for a while and requires constant attention in another repo.

My justifications:
- flagd is a "cloud native" tool - it easily runs in docker, even on darwin/arm (homebrew is really not for cloud infra)
- maintenance burden
- low usage

Feel free to disagree, but if you do, you are committing to fixing it and taking care of it :grin: 