### PR TITLE
chore: exclude tests from dupe analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+# SonarCloud configuration
+sonar.projectKey=open-feature_flagd
+
+# Exclude test files from duplication detection
+sonar.cpd.exclusions=**/*_test.go,test/**,test-harness/**


### PR DESCRIPTION
See title.

Go tests can often contain some duplication, and sonar seems to be particularly annoyed with this. Or Go tests seem perfectly idiomatic for me. We use tables in most cases, but sonar still seems to think there's too much duplication in tests.