### PR TITLE
fix(security): pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,13 +78,13 @@ jobs:
           go-version-file: 'flagd/go.mod'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
@@ -95,7 +95,7 @@ jobs:
           tags: flagd-local:test
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           input: ${{ github.workspace }}/flagd-local.tar
           format: "sarif"

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "flagd/**",
     "flagd-proxy/**",
     "core/**",
-    "test/**"
+    "test/**",
+    ".github/**"
   ]
 }


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` from mutable tag `@0.28.0` to SHA-pinned `v0.35.0` (`57a97c7`) in response to CVE-2026-26189 / the Trivy supply chain incident on March 19, 2026
- Pin `docker/setup-qemu-action` and `docker/setup-buildx-action` from `@master` (!) to SHA-pinned `v3` tags in both `build.yaml` and `release-please.yaml`
- Pin `google-github-actions/release-please-action` from `@v3` to SHA-pinned `v3`
- Add `.github/**` to renovate `includePaths` so the shared `open-feature/community-tooling` config (which already includes `helpers:pinGitHubActionDigests`) can manage workflow action updates going forward

## Context

On March 19, 2026 an attacker force-pushed 75 existing tags in `aquasecurity/trivy-action` to malicious commits that exfiltrated CI/CD secrets. Any workflow referencing trivy-action by a mutable tag (rather than a commit SHA) was potentially vulnerable. See [Upwind's incident breakdown](https://www.upwind.io/feed/trivy-supply-chain-incident-github-actions-compromise-breakdown) for details.

### Impact assessment

**This repo was not impacted.** We verified via the GitHub Actions API that no runs of the `build` workflow occurred during the attack window (March 19, 17:00-23:13 UTC). The last origin run completed at 08:35 UTC, well before the compromise began.

Additionally, sensitive secrets (signing keys, publishing tokens, etc.) are only available in protected environments scoped to specific branches (e.g., `main`), so even if a PR branch run had been compromised, those secrets would not have been exposed.

However, the use of mutable tags left the repo vulnerable to this class of attack, and `docker/setup-qemu-action@master` and `docker/setup-buildx-action@master` were pinned to the `master` branch, which carries the same risk.

## Changes

| File | Change |
|---|---|
| `.github/workflows/build.yaml` | Pin `trivy-action` to `v0.35.0` SHA, pin `setup-qemu-action` and `setup-buildx-action` to `v3` SHAs |
| `.github/workflows/release-please.yaml` | Pin `release-please-action` to `v3` SHA, pin `setup-qemu-action` and `setup-buildx-action` to `v3` SHAs |
| `renovate.json` | Add `.github/**` to `includePaths` so Renovate manages action version updates |