### PR TITLE
fix(security): pin remaining unpinned actions in release-please.yaml

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         id: release
         with:
           command: manifest
@@ -93,13 +93,13 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ matrix.path }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build
         id: build


### PR DESCRIPTION
## Summary

Follow-up to #1911. Pins the remaining unpinned actions in `release-please.yaml` to commit SHA digests.

## Changes

| Action | Before | After |
|---|---|---|
| `google-github-actions/release-please-action` | `@v3` | `@db8f2c6...` (v3) |
| `docker/setup-qemu-action` | `@master` | `@c7c5346...` (v3) |
| `docker/setup-buildx-action` | `@master` | `@8d2750c...` (v3) |

These were the last unpinned actions in the repo. With the `renovate.json` change from #1911 (adding `.github/**` to `includePaths`), Renovate will now keep all workflow action SHAs up to date automatically.