### PR TITLE
fix: zombie process on metrics server fail

### DIFF
--- a/flagd/pkg/service/flag-evaluation/connect_service.go
+++ b/flagd/pkg/service/flag-evaluation/connect_service.go
@@ -69,9 +69,6 @@ type ConnectService struct {
 	server        *http.Server
 	metricsServer *http.Server
 
-	serverMtx        sync.RWMutex
-	metricsServerMtx sync.RWMutex
-
 	readinessEnabled bool
 }
 
@@ -106,28 +103,6 @@ func (s *ConnectService) Serve(ctx context.Context, svcConf service.Configuratio
 	})
 	g.Go(func() error {
 		return s.startMetricsServer(gCtx, svcConf)
-	})
-	g.Go(func() error {
-		<-gCtx.Done()
-		s.serverMtx.RLock()
-		defer s.serverMtx.RUnlock()
-		if s.server != nil {
-			if err := s.server.Shutdown(gCtx); err != nil {
-				return fmt.Errorf("error returned from flag evaluation server shutdown: %w", err)
-			}
-		}
-		return nil
-	})
-	g.Go(func() error {
-		<-gCtx.Done()
-		s.metricsServerMtx.RLock()
-		defer s.metricsServerMtx.RUnlock()
-		if s.metricsServer != nil {
-			if err := s.metricsServer.Shutdown(gCtx); err != nil {
-				return fmt.Errorf("error returned from metrics server shutdown: %w", err)
-			}
-		}
-		return nil
 	})
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("errgroup closed with error: %w", err)
@@ -210,13 +185,11 @@ func (s *ConnectService) setupServer(svcConf service.Configuration) (net.Listene
 		svcHandler = http.MaxBytesHandler(svcHandler, svcConf.MaxRequestBodyBytes)
 	}
 
-	s.serverMtx.Lock()
 	s.server = &http.Server{
 		ReadHeaderTimeout: time.Second,
 		Handler:           svcHandler,
 		MaxHeaderBytes:    int(svcConf.MaxRequestHeaderBytes),
 	}
-	s.serverMtx.Unlock()
 
 	// Add middlewares
 	metricsMiddleware := metricsmw.NewHTTPMetric(metricsmw.Config{
@@ -251,28 +224,44 @@ func (s *ConnectService) Shutdown() {
 	})
 }
 
+func serveWithShutdown(ctx context.Context, server *http.Server, serveFn func() error) error {
+	errChan := make(chan error, 1)
+	go func() { errChan <- serveFn() }()
+
+	select {
+	case err := <-errChan:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		// use a fresh context; ctx is already cancelled
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("error shutting down server: %w", err)
+		}
+		// wait for server to fully stop
+		<-errChan
+		return nil
+	}
+}
+
 func (s *ConnectService) startServer(ctx context.Context, svcConf service.Configuration) error {
 	lis, err := s.setupServer(svcConf)
 	if err != nil {
 		return err
 	}
 	s.logger.Info(fmt.Sprintf("Flag IResolver listening at %s", lis.Addr()))
+
 	if svcConf.CertPath != "" && svcConf.KeyPath != "" {
-		if err := s.server.ServeTLS(
-			lis,
-			svcConf.CertPath,
-			svcConf.KeyPath,
-		); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("error returned from flag evaluation server: %w", err)
-		}
-	} else {
-		if err := s.server.Serve(
-			lis,
-		); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("error returned from flag evaluation server: %w", err)
-		}
+		return serveWithShutdown(ctx, s.server, func() error {
+			return s.server.ServeTLS(lis, svcConf.CertPath, svcConf.KeyPath)
+		})
 	}
-	return nil
+	return serveWithShutdown(ctx, s.server, func() error {
+		return s.server.Serve(lis)
+	})
 }
 
 func (s *ConnectService) startMetricsServer(ctx context.Context, svcConf service.Configuration) error {
@@ -304,29 +293,11 @@ func (s *ConnectService) startMetricsServer(ctx context.Context, svcConf service
 		}
 	})
 
-	s.metricsServerMtx.Lock()
 	s.metricsServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", svcConf.ManagementPort),
 		ReadHeaderTimeout: 3 * time.Second,
 		Handler:           h2c.NewHandler(handler, &http2.Server{}), // we need to use h2c to support plaintext HTTP2
 	}
-	s.metricsServerMtx.Unlock()
 
-	errChan := make(chan error, 1)
-	go func() { errChan <- s.metricsServer.ListenAndServe() }()
-
-	select {
-	case err := <-errChan:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("error returned from metrics server: %w", err)
-		}
-		return nil
-	case <-ctx.Done():
-		if err := s.metricsServer.Shutdown(ctx); err != nil {
-			return fmt.Errorf("error shutting down metrics server: %w", err)
-		}
-		// wait for server to fully stop
-		<-errChan
-		return nil
-	}
+	return serveWithShutdown(ctx, s.metricsServer, s.metricsServer.ListenAndServe)
 }


### PR DESCRIPTION
Fixes an issue where a failure of the metrics server to start can cause a zombie process.

This is hard and relatively low value to test with unit tests, but I was able to easily reproduce it with this simple script:

```sh
#!/bin/bash

cd flagd && go build -o flagd .

# --port and --sync-port both set to 8015; flagd should exit due to the conflict
./flagd start --port 8015 --sync-port 8015 --uri file:../config/samples/example_flags.flagd.json &
PID=$!
sleep 5

if ps -p $PID > /dev/null 2>&1; then
    echo "OH NO, BUG! Process is still alive despite port conflict."
    kill -9 $PID
    exit 1
fi

echo "NO BUG"
```

After the simple context handling, the script confirms the bug is fixed.

Fixes: https://github.com/open-feature/flagd/issues/1807