### PR TITLE
fix: handle missing/null targeting keys in fractional evaluator

### DIFF
--- a/core/pkg/evaluator/fractional.go
+++ b/core/pkg/evaluator/fractional.go
@@ -90,6 +90,10 @@ if len(valuesArray) < 1 {
 			return "", nil, fmt.Errorf("flag %q: bucketing value not supplied and no targetingKey in context", flagKey)
 		}
 
+		if targetingKey == "" {
+			return "", nil, nil
+		}
+
 		bucketBy = fmt.Sprintf("%s%s", properties.FlagKey, targetingKey)
 	}
 

--- a/core/pkg/evaluator/fractional.go
+++ b/core/pkg/evaluator/fractional.go
@@ -48,6 +48,10 @@ func (fe *Fractional) Evaluate(values, data any) any {
 		return nil
 	}
 
+	if feDistributions == nil {
+		return nil
+	}
+
 	hashValue := uint32(murmur3.StringSum32(valueToDistribute))
 	return distributeValue(hashValue, feDistributions)
 }
@@ -78,6 +82,9 @@ if len(valuesArray) < 1 {
 			valuesArray = valuesArray[1:]
 		}
 
+		if dataMap[targetingKeyKey] == nil {
+			return "", nil, nil
+		}
 		targetingKey, ok := dataMap[targetingKeyKey].(string)
 		if !ok {
 			return "", nil, fmt.Errorf("flag %q: bucketing value not supplied and no targetingKey in context", flagKey)

--- a/core/pkg/evaluator/fractional_test.go
+++ b/core/pkg/evaluator/fractional_test.go
@@ -442,6 +442,67 @@ func TestFractionalEvaluation(t *testing.T) {
 			expectedValue:   blueHex,
 			expectedReason:  model.TargetingMatchReason,
 		},
+		"null targetingKey returns default variant": {
+			flags: []model.Flag{{
+				Key:            "headerColor",
+				State:          "ENABLED",
+				DefaultVariant: redVariant,
+				Variants:       colorVariants,
+				Targeting: []byte(`{
+							"fractional": [
+								["blue", 50],
+								["green", 50]
+							]
+						}`),
+			}},
+			flagKey: "headerColor",
+			context: map[string]any{
+				"targetingKey": nil,
+			},
+			expectedVariant: redVariant,
+			expectedValue:   redHex,
+			expectedReason:  model.DefaultReason,
+		},
+		"missing targetingKey returns default variant": {
+			flags: []model.Flag{{
+				Key:            "headerColor",
+				State:          "ENABLED",
+				DefaultVariant: redVariant,
+				Variants:       colorVariants,
+				Targeting: []byte(`{
+							"fractional": [
+								["blue", 50],
+								["green", 50]
+							]
+						}`),
+			}},
+			flagKey:         "headerColor",
+			context:         map[string]any{},
+			expectedVariant: redVariant,
+			expectedValue:   redHex,
+			expectedReason:  model.DefaultReason,
+		},
+		"empty targetingKey buckets by flagKey": {
+			flags: []model.Flag{{
+				Key:            "headerColor",
+				State:          "ENABLED",
+				DefaultVariant: redVariant,
+				Variants:       colorVariants,
+				Targeting: []byte(`{
+							"fractional": [
+								["blue", 50],
+								["green", 50]
+							]
+						}`),
+			}},
+			flagKey: "headerColor",
+			context: map[string]any{
+				"targetingKey": "",
+			},
+			expectedVariant: greenVariant,
+			expectedValue:   greenHex,
+			expectedReason:  model.TargetingMatchReason,
+		},
 		"single-entry always returns the sole variant": {
 			flags: []model.Flag{{
 				Key:            "headerColor",

--- a/core/pkg/evaluator/fractional_test.go
+++ b/core/pkg/evaluator/fractional_test.go
@@ -482,7 +482,7 @@ func TestFractionalEvaluation(t *testing.T) {
 			expectedValue:   redHex,
 			expectedReason:  model.DefaultReason,
 		},
-		"empty targetingKey buckets by flagKey": {
+		"empty targetingKey returns default variant": {
 			flags: []model.Flag{{
 				Key:            "headerColor",
 				State:          "ENABLED",
@@ -499,9 +499,9 @@ func TestFractionalEvaluation(t *testing.T) {
 			context: map[string]any{
 				"targetingKey": "",
 			},
-			expectedVariant: greenVariant,
-			expectedValue:   greenHex,
-			expectedReason:  model.TargetingMatchReason,
+			expectedVariant: redVariant,
+			expectedValue:   redHex,
+			expectedReason:  model.DefaultReason,
 		},
 		"single-entry always returns the sole variant": {
 			flags: []model.Flag{{


### PR DESCRIPTION
Fixes #1948

The fractional evaluator wasn't handling missing or null targeting keys the same way other SDKs did. Added nil checks to return the default variant when the key is missing or null. Also added tests for the three cases: missing key, null key, and empty string.