### PR TITLE
docs: fix code block language for fractional operation result

### DIFF
--- a/docs/reference/custom-operations/fractional-operation.md
+++ b/docs/reference/custom-operations/fractional-operation.md
@@ -143,7 +143,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 
 Result:
 
-```shell
+```json
 {"value":"#0000FF","reason":"TARGETING_MATCH","variant":"blue"}
 ```
 


### PR DESCRIPTION
## Summary
- Fix code fence language from `shell` to `json` on the first `ResolveString` result block in `docs/reference/custom-operations/fractional-operation.md` (L146), matching the second result block below it that already uses `json`.

## Test plan
- [x] Visual inspection of the rendered docs section

🤖 Generated with [Claude Code](https://claude.com/claude-code)