### PR TITLE
docs: fix code block language for custom operation results

### DIFF
--- a/docs/reference/custom-operations/fractional-operation.md
+++ b/docs/reference/custom-operations/fractional-operation.md
@@ -143,7 +143,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 
 Result:
 
-```shell
+```json
 {"value":"#0000FF","reason":"TARGETING_MATCH","variant":"blue"}
 ```
 

--- a/docs/reference/custom-operations/string-comparison-operation.md
+++ b/docs/reference/custom-operations/string-comparison-operation.md
@@ -73,7 +73,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 
 Result:
 
-```shell
+```json
 {"value":"#0000FF","reason":"TARGETING_MATCH","variant":"green"}
 ```
 
@@ -147,6 +147,6 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 
 Result:
 
-```shell
+```json
 {"value":"#0000FF","reason":"TARGETING_MATCH","variant":"green"}
 ```


### PR DESCRIPTION
## Summary
- Fix code block language from `shell` to `json` for JSON result examples in custom operation docs
- Affects fractional operation and string-comparison operation result examples

## Test plan
- [x] Verify rendered output shows JSON syntax highlighting instead of shell

(This supersedes #1951, which only covered the fractional operation fix.)