### PR TITLE
fix: override otel service name and version

### DIFF
--- a/core/pkg/telemetry/builder.go
+++ b/core/pkg/telemetry/builder.go
@@ -161,6 +161,7 @@ func buildResourceFor(ctx context.Context, serviceName string, serviceVersion st
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceVersionKey.String(serviceVersion)),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create resource identifier: %w", err)

--- a/core/pkg/telemetry/builder_test.go
+++ b/core/pkg/telemetry/builder_test.go
@@ -155,6 +155,23 @@ func TestBuildResourceFor(t *testing.T) {
 	}, "expected resource to contain service version")
 }
 
+func TestBuildResourceForEnvOverride(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.version=9.9.9,service.name=overridden-svc")
+
+	res, err := buildResourceFor(context.Background(), "defaultSvc", "0.0.1")
+	require.Nil(t, err, "expected no error, but got: %v", err)
+
+	attributes := res.Attributes()
+	require.Containsf(t, attributes, attribute.KeyValue{
+		Key:   semconv.ServiceNameKey,
+		Value: attribute.StringValue("overridden-svc"),
+	}, "expected OTEL_RESOURCE_ATTRIBUTES to override the programmatic service name")
+	require.Containsf(t, attributes, attribute.KeyValue{
+		Key:   semconv.ServiceVersionKey,
+		Value: attribute.StringValue("9.9.9"),
+	}, "expected OTEL_RESOURCE_ATTRIBUTES to override the programmatic service version")
+}
+
 func TestErrorIntercepted(t *testing.T) {
 	// register the OTel error handling
 	observedZapCore, observedLogs := observer.New(zap.DebugLevel)


### PR DESCRIPTION
Setting `service.name` or `service.version` via OTEL_RESOURCE_ATTRIBUTES (or OTEL_SERVICE_NAME) now correctly overrides the values flagd sets programmatically

Fixes https://github.com/open-feature/flagd/issues/1938



