### PR TITLE
feat: add custom headers support for HTTP and gRPC sync providers

### DIFF
--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -198,6 +198,7 @@ func (sb *SyncBuilder) newGRPC(config sync.SourceConfig, logger *logger.Logger) 
 		Selector:           config.Selector,
 		MaxMsgSize:         config.MaxMsgSize,
 		IncrementalUpdates: config.IncrementalUpdates,
+		Headers:            config.Headers,
 	}
 }
 

--- a/core/pkg/sync/builder/utils_test.go
+++ b/core/pkg/sync/builder/utils_test.go
@@ -126,6 +126,17 @@ func TestParseSource(t *testing.T) {
 			expectErr: true,
 			out:       []sync.SourceConfig{},
 		},
+		"with-headers": {
+			in:        `[{"uri":"http://test.com","provider":"http","headers":{"X-Custom":"value","X-Another":"val2"}}]`,
+			expectErr: false,
+			out: []sync.SourceConfig{
+				{
+					URI:      "http://test.com",
+					Provider: syncProviderHTTP,
+					Headers:  map[string]string{"X-Custom": "value", "X-Another": "val2"},
+				},
+			},
+		},
 	}
 
 	for name, tt := range test {

--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/open-feature/flagd/core/pkg/sync/grpc/nameresolvers" // initialize custom resolvers e.g. envoy.Init()
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -54,6 +55,7 @@ type Sync struct {
 	URI                     string
 	MaxMsgSize              int
 	IncrementalUpdates      bool
+	Headers                 map[string]string
 
 	client FlagSyncServiceClient
 	ready  bool
@@ -97,8 +99,19 @@ func (g *Sync) Init(_ context.Context) error {
 	return nil
 }
 
+func (g *Sync) contextWithHeaders(ctx context.Context) context.Context {
+	if len(g.Headers) == 0 {
+		return ctx
+	}
+	pairs := make([]string, 0, len(g.Headers)*2)
+	for k, v := range g.Headers {
+		pairs = append(pairs, k, v)
+	}
+	return metadata.AppendToOutgoingContext(ctx, pairs...)
+}
+
 func (g *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error {
-	res, err := g.client.FetchAllFlags(ctx, &v1.FetchAllFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+	res, err := g.client.FetchAllFlags(g.contextWithHeaders(ctx), &v1.FetchAllFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
 	if err != nil {
 		err = fmt.Errorf("error fetching all flags: %w", err)
 		g.Logger.Error(err.Error())
@@ -121,7 +134,7 @@ func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 
 	// Initialize SyncFlags client. This fails if server connection establishment fails (ex:- grpc server offline)
 	g.Logger.Debug(fmt.Sprintf("initial stream connection to %s", g.URI))
-	syncClient, err := g.client.SyncFlags(ctx, &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+	syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
 	if err != nil {
 		return fmt.Errorf("unable to sync flags: %w", err)
 	}
@@ -182,7 +195,7 @@ func (g *Sync) connectWithRetry(
 
 		g.Logger.Warn(fmt.Sprintf("connection re-establishment attempt in-progress for grpc target: %s", g.URI))
 
-		syncClient, err := g.client.SyncFlags(ctx, &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+		syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
 		if err != nil {
 			g.Logger.Debug(fmt.Sprintf("error opening service client: %s", err.Error()))
 			continue

--- a/core/pkg/sync/grpc/grpc_sync_test.go
+++ b/core/pkg/sync/grpc/grpc_sync_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -538,5 +539,144 @@ func (b *bufferedServer) FetchAllFlags(_ context.Context, _ *v1.FetchAllFlagsReq
 }
 
 func (b *bufferedServer) GetMetadata(_ context.Context, _ *v1.GetMetadataRequest) (*v1.GetMetadataResponse, error) {
+	return &v1.GetMetadataResponse{}, nil
+}
+
+func Test_contextWithHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         map[string]string
+		expectUnchanged bool
+	}{
+		{
+			name:            "nil headers returns unchanged context",
+			headers:         nil,
+			expectUnchanged: true,
+		},
+		{
+			name:            "empty headers returns unchanged context",
+			headers:         map[string]string{},
+			expectUnchanged: true,
+		},
+		{
+			name: "headers are appended as metadata",
+			headers: map[string]string{
+				"X-Proxy-Gateway-Host": "myhost.service",
+				"X-Tenant-ID":           "tenant1",
+			},
+			expectUnchanged: false,
+		},
+		{
+			name: "single header",
+			headers: map[string]string{
+				"Authorization": "Bearer token123",
+			},
+			expectUnchanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcSync := Sync{
+				Logger:  logger.NewLogger(nil, false),
+				Headers: tt.headers,
+			}
+
+			ctx := context.Background()
+			result := grpcSync.contextWithHeaders(ctx)
+
+			if tt.expectUnchanged {
+				require.Equal(t, ctx, result)
+				return
+			}
+
+			md, ok := metadata.FromOutgoingContext(result)
+			require.True(t, ok, "expected outgoing metadata in context")
+
+			for key, expectedVal := range tt.headers {
+				vals := md.Get(key)
+				require.Len(t, vals, 1, "expected exactly one value for key %s", key)
+				require.Equal(t, expectedVal, vals[0])
+			}
+		})
+	}
+}
+
+func Test_ReSyncWithHeaders(t *testing.T) {
+	const target = "localBufCon"
+
+	bufCon := bufconn.Listen(5)
+	receivedHeaders := make(chan map[string]string, 1)
+
+	server := grpc.NewServer()
+	syncv1grpc.RegisterFlagSyncServiceServer(server, &headerCapturingServer{
+		receivedHeaders: receivedHeaders,
+		response: &v1.FetchAllFlagsResponse{
+			FlagConfiguration: "{}",
+		},
+	})
+
+	go func() {
+		if err := server.Serve(bufCon); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+
+	dial, err := grpc.Dial(target,
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return bufCon.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	grpcSync := Sync{
+		URI:    target,
+		Logger: logger.NewLogger(nil, false),
+		Headers: map[string]string{
+			"x-proxy-gateway-host": "myhost.service",
+			"x-tenant-id":           "tenant1",
+		},
+		client: syncv1grpc.NewFlagSyncServiceClient(dial),
+	}
+
+	syncChan := make(chan sync.DataSync, 1)
+	err = grpcSync.ReSync(context.Background(), syncChan)
+	require.NoError(t, err)
+
+	select {
+	case headers := <-receivedHeaders:
+		require.Equal(t, "myhost.service", headers["x-proxy-gateway-host"])
+		require.Equal(t, "tenant1", headers["x-tenant-id"])
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for headers")
+	}
+}
+
+// headerCapturingServer captures incoming gRPC metadata headers
+type headerCapturingServer struct {
+	syncv1grpc.UnimplementedFlagSyncServiceServer
+	receivedHeaders chan map[string]string
+	response        *v1.FetchAllFlagsResponse
+}
+
+func (s *headerCapturingServer) FetchAllFlags(ctx context.Context, _ *v1.FetchAllFlagsRequest) (*v1.FetchAllFlagsResponse, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	headers := make(map[string]string)
+	if ok {
+		for k, v := range md {
+			if len(v) > 0 {
+				headers[k] = v[0]
+			}
+		}
+	}
+	s.receivedHeaders <- headers
+	return s.response, nil
+}
+
+func (s *headerCapturingServer) SyncFlags(_ *v1.SyncFlagsRequest, _ syncv1grpc.FlagSyncService_SyncFlagsServer) error {
+	return nil
+}
+
+func (s *headerCapturingServer) GetMetadata(_ context.Context, _ *v1.GetMetadataRequest) (*v1.GetMetadataResponse, error) {
 	return &v1.GetMetadataResponse{}, nil
 }

--- a/core/pkg/sync/http/http_sync.go
+++ b/core/pkg/sync/http/http_sync.go
@@ -30,6 +30,7 @@ type Sync struct {
 	lastBodySHA string
 	logger      *logger.Logger
 	authHeader  string
+	headers     map[string]string
 	interval    uint32
 	ready       bool
 	eTag        string
@@ -149,6 +150,16 @@ func (hs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 	return nil
 }
 
+func (hs *Sync) applyHeaders(req *http.Request) {
+	for key, value := range hs.headers {
+		if http.CanonicalHeaderKey(key) == "Host" {
+			req.Host = value
+		} else {
+			req.Header.Set(key, value)
+		}
+	}
+}
+
 func (hs *Sync) fetchBody(ctx context.Context, fetchAll bool) (string, bool, error) {
 	if hs.uri == "" {
 		return "", false, errors.New("no HTTP URL string set")
@@ -169,6 +180,9 @@ func (hs *Sync) fetchBody(ctx context.Context, fetchAll bool) (string, bool, err
 	if hs.eTag != "" && !fetchAll {
 		req.Header.Set("If-None-Match", hs.eTag)
 	}
+
+	hs.applyHeaders(req)
+
 	client := hs.getClient()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -279,6 +293,7 @@ func NewHTTP(config sync.SourceConfig, logger *logger.Logger, poller polling.Pol
 			zap.String("sync", "http"),
 		),
 		authHeader:      config.AuthHeader,
+		headers:         config.Headers,
 		interval:        interval,
 		poller:          poller,
 		oauthCredential: oauthCredential,

--- a/core/pkg/sync/http/http_sync_test.go
+++ b/core/pkg/sync/http/http_sync_test.go
@@ -320,6 +320,136 @@ func TestHTTPSync_Fetch(t *testing.T) {
 	}
 }
 
+func TestHTTPSync_CustomHeaders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := syncmock.NewMockClient(ctrl)
+
+	customHeaders := map[string]string{
+		"X-Interop-Gateway-Host": "myhost",
+		"X-Tenant-ID":           "tenant1",
+	}
+
+	mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		for key, expectedVal := range customHeaders {
+			actual := req.Header.Get(key)
+			if actual != expectedVal {
+				t.Errorf("expected header %s to be '%s', got '%s'", key, expectedVal, actual)
+			}
+		}
+		return &http.Response{
+			Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
+			Body:       io.NopCloser(strings.NewReader("test response")),
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+
+	httpSync := Sync{
+		uri:     "http://localhost",
+		client:  mockClient,
+		headers: customHeaders,
+		logger:  logger.NewLogger(nil, false),
+	}
+
+	fetched, err := httpSync.Fetch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "test response", fetched)
+}
+
+func TestNewHTTP_PassesHeaders(t *testing.T) {
+	headers := map[string]string{"X-Custom": "value"}
+	config := sync.SourceConfig{
+		URI:      "http://localhost",
+		Provider: "http",
+		Headers:  headers,
+	}
+	httpSync := NewHTTP(config, logger.NewLogger(nil, false), nil, 5)
+	require.Equal(t, headers, httpSync.headers)
+}
+
+func TestHTTPSync_HostHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := syncmock.NewMockClient(ctrl)
+
+	mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "custom-host.example.com", req.Host)
+		require.Empty(t, req.Header.Get("Host"))
+		return &http.Response{
+			Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+
+	httpSync := Sync{
+		uri:     "http://localhost",
+		client:  mockClient,
+		headers: map[string]string{"Host": "custom-host.example.com"},
+		logger:  logger.NewLogger(nil, false),
+	}
+
+	_, err := httpSync.Fetch(context.Background())
+	require.NoError(t, err)
+}
+
+func TestHTTPSync_HeadersOverwriteAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := syncmock.NewMockClient(ctrl)
+
+	mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		// Custom headers are applied after authHeader, so they take precedence
+		require.Equal(t, "Bearer custom-token", req.Header.Get("Authorization"))
+		require.Equal(t, "custom-value", req.Header.Get("X-Custom"))
+		return &http.Response{
+			Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+
+	httpSync := Sync{
+		uri:        "http://localhost",
+		client:     mockClient,
+		authHeader: "Bearer original-token",
+		headers: map[string]string{
+			"Authorization": "Bearer custom-token",
+			"X-Custom":      "custom-value",
+		},
+		logger: logger.NewLogger(nil, false),
+	}
+
+	_, err := httpSync.Fetch(context.Background())
+	require.NoError(t, err)
+}
+
+func TestHTTPSync_AuthHeaderWithoutOverride(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := syncmock.NewMockClient(ctrl)
+
+	mockClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		// When custom headers don't include Authorization, authHeader is preserved
+		require.Equal(t, "Bearer token123", req.Header.Get("Authorization"))
+		require.Equal(t, "custom-value", req.Header.Get("X-Custom"))
+		return &http.Response{
+			Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			StatusCode: http.StatusOK,
+		}, nil
+	})
+
+	httpSync := Sync{
+		uri:        "http://localhost",
+		client:     mockClient,
+		authHeader: "Bearer token123",
+		headers: map[string]string{
+			"X-Custom": "custom-value",
+		},
+		logger: logger.NewLogger(nil, false),
+	}
+
+	_, err := httpSync.Fetch(context.Background())
+	require.NoError(t, err)
+}
+
 func TestHTTPSync_Resync(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	source := "http://localhost"

--- a/core/pkg/sync/isync.go
+++ b/core/pkg/sync/isync.go
@@ -64,7 +64,7 @@ type SourceConfig struct {
 	// cleaned up; a restart or explicit empty update for the old flagSetId is
 	// required to purge them.
 	IncrementalUpdates bool `json:"incrementalUpdates,omitempty"`
-
+	Headers map[string]string `json:"headers,omitempty"`
 	OAuth *OAuthCredentialHandler `json:"oauth,omitempty"`
 }
 

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -60,6 +60,7 @@ Alternatively, these configurations can be passed to flagd via config file, spec
 | certPath           | optional `string`  | Used for grpcs sync when TLS certificate is needed. If not provided, system certificates will be used for TLS connection                                                                                                                                                                                                                                                                                                                                                                  |
 | maxMsgSize         | optional `int`     | Used for gRPC sync to set max receive message size (in bytes) e.g. 5242880 for 5MB. If not provided, the default is [4MB](https://pkg.go.dev/google.golang.org#grpc#MaxCallRecvMsgSize)                                                                                                                                                                                                                                                                                                   |
 | incrementalUpdates | optional `boolean` | **Experimental.** Used for gRPC sync. When true, each update only replaces flags matching the flagSetIds in the payload, allowing flags from other flagSetIds to accumulate. When false (default), each update replaces all flags for the source. See [caveats](#incremental-updates-experimental) below.                                                                                                                                                                                 |
+| headers            | optional `map[string]string` | Custom key-value pairs sent as HTTP headers or gRPC metadata with outbound sync requests. Can also be set globally via the `--sync-headers` CLI flag. Per-source values take precedence over global values for conflicting keys.                                                                                                                                                                                                                                                |
 
 The `uri` field values **do not** follow the [URI patterns](#uri-patterns). The provider type is instead derived
 from the `provider` field. Only exception is the remote provider where `http(s)://` is expected by default. Incorrect
@@ -146,6 +147,27 @@ sources:
 ```
 
 ### HTTP Configuration
+
+### Custom Headers
+
+Custom headers can be injected into all outbound sync requests (HTTP and gRPC) using the
+`--sync-headers` flag:
+
+```sh
+# CLI flag
+flagd start --sync-headers="X-Proxy-Gateway-Host=myhost,X-Tenant-ID=tenant1" \
+  --sources='[{"uri":"http://my-flags.com/flags","provider":"http"}]'
+
+
+Headers can also be set per-source in the JSON configuration:
+
+```json
+[{"uri":"http://my-flags.com/flags","provider":"http","headers":{"X-Custom":"value"}}]
+```
+
+When both global and per-source headers are specified, per-source values take
+precedence for conflicting keys.
+
 
 The HTTP Configuration also supports OAuth that allows to securely fetch feature flag configurations from an HTTP endpoint
 that requires OAuth-based authentication.

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -168,7 +168,6 @@ Headers can also be set per-source in the JSON configuration:
 When both global and per-source headers are specified, per-source values take
 precedence for conflicting keys.
 
-
 The HTTP Configuration also supports OAuth that allows to securely fetch feature flag configurations from an HTTP endpoint
 that requires OAuth-based authentication.
 

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -42,6 +42,7 @@ const (
 	streamDeadlineFlagName     = "stream-deadline"
 	maxRequestBodyFlagName     = "max-request-body"
 	maxRequestHeaderFlagName   = "max-request-header"
+	syncHeadersFlagName        = "sync-headers"
 )
 
 func init() {
@@ -96,6 +97,9 @@ func init() {
 	flags.Bool(disableSyncMetadata, false, "Disables the getMetadata endpoint of the sync service. Defaults to false, but will default to true in later versions.")
 	flags.Int64P(maxRequestBodyFlagName, "B", 1_000_000, "Maximum allowed request body size in bytes. Requests exceeding this are rejected with HTTP 413 (OFREP) or 429 (connect). Set to 0 to disable. WARNING: disabling this limit may allow memory exhaustion from oversized requests.")
 	flags.Int64P(maxRequestHeaderFlagName, "R", 1_000_000, "Maximum allowed request header size in bytes. Requests exceeding this are rejected with HTTP 431. Set to 0 to use Go's built-in default (1 MiB). WARNING: setting a very large or zero value may allow memory exhaustion from oversized headers.")
+	flags.StringToStringP(syncHeadersFlagName, "S", map[string]string{},
+		"Custom headers to inject into all sync provider requests (HTTP headers and gRPC metadata), "+
+			"formatted as key=value pairs")
 
 	bindFlags(flags)
 }
@@ -124,6 +128,7 @@ func bindFlags(flags *pflag.FlagSet) {
 	_ = viper.BindPFlag(disableSyncMetadata, flags.Lookup(disableSyncMetadata))
 	_ = viper.BindPFlag(maxRequestBodyFlagName, flags.Lookup(maxRequestBodyFlagName))
 	_ = viper.BindPFlag(maxRequestHeaderFlagName, flags.Lookup(maxRequestHeaderFlagName))
+	_ = viper.BindPFlag(syncHeadersFlagName, flags.Lookup(syncHeadersFlagName))
 }
 
 // startCmd represents the start command
@@ -167,6 +172,18 @@ var startCmd = &cobra.Command{
 			}
 		}
 		syncProviders = append(syncProviders, syncProvidersFromConfig...)
+
+		globalHeaders := viper.GetStringMapString(syncHeadersFlagName)
+		for i := range syncProviders {
+			if syncProviders[i].Headers == nil {
+				syncProviders[i].Headers = make(map[string]string)
+			}
+			for k, v := range globalHeaders {
+				if _, exists := syncProviders[i].Headers[k]; !exists {
+					syncProviders[i].Headers[k] = v
+				}
+			}
+		}
 
 		contextValuesToMap := make(map[string]any)
 		for k, v := range viper.GetStringMapString(contextValueFlagName) {


### PR DESCRIPTION
## Summary
Add support for custom headers in HTTP and gRPC sync providers, configurable globally via CLI flag and per-source in JSON configuration.

## Problem
flagd's sync providers cannot inject custom request headers into outbound requests. This limits integration with environments where intermediaries (API gateways, reverse proxies, service meshes) require specific headers for routing, tenant identification, or policy enforcement, resulting in errors like 421 Misdirected Request or misrouting.

## Solution
CLI flag: --sync-headers="Key=Value,Key2=Value2" injects headers into all sync requests globally.

Per-source config: "headers": {"Key": "Value"} in the source JSON for fine-grained control.

`flagd start --sources='[{"uri":"https://proxy-gateway.xyz.com/flags/sync","provider":"http","headers":{"X-Proxy-Gateway-Host":"backend-api.service"}}]' `

Global config: 

`flagd start --sync-headers="X-Proxy-Gateway-Host=backend-api.service" --sources='[{"uri":"https://interop-gateway.bk-eu-west6.service-mesh.dqs.booking.com/flags/sync","provider":"http"}]'`

Precedence: Per-source values override global values when keys conflict.

Headers are sent as HTTP request headers for HTTP sync and as gRPC metadata for gRPC sync.

## Examples:

_Global + per-source with precedence (HTTP)_:
```
flagd start \
  --sync-headers="X-Tenant-ID=tenant1,X-Gateway-Host=default-host" \
  --sources='[{"uri":"http://my-flags.com/flags","provider":"http","headers":{"X-Gateway-Host":"override-host"}}]'
```
→ X-Tenant-ID=tenant1 from global, X-Gateway-Host=override-host from per-source (wins over global).

_gRPC with per-source headers_:
```
flagd start \
  --sources='[{"uri":"proxy-gateway-server.xyz.com","provider":"grpc","selector":"features","headers":{"X-Routing-Target-Host":"b.flags-server.service"}}]'
```

## Scope & compatibility

Fully backward compatible, headers are optional and default to empty
No behavior change for existing configurations
Covers both HTTP and gRPC sync providers

## Test plan
Unit tests for HTTP sync header injection
Unit tests for gRPC sync metadata injection
Builder tests for header merging/precedence logic