### PR TITLE
docs: improve fractional non-string adr

### DIFF
--- a/docs/architecture-decisions/fractional-non-string-rand-units.md
+++ b/docs/architecture-decisions/fractional-non-string-rand-units.md
@@ -66,6 +66,8 @@ As such, the encodings for the following types as first argument (either as lite
 
 **array / sequence** will be explicitly not supported as the first argument in fractional so it's possible to distinguish between hashing input and variant bucket. Nevertheless, it can be a part of object type and its encoding needs to be standardized as well.
 
+**null** will be explicitly not supported as the first argument, as multiple provider implementations return `null` when an error occurs during evaluation, and JSON Logic returns `null` for a missing key in the evaluation context. Rejecting `null` prevents silent errors in common use cases.
+
 ## Non-requirements
 
 * This change does not need to be backward-compatible.
@@ -86,10 +88,11 @@ We will modify the evaluation logic for the `fractional` operator.
 
 When inspecting the first element of the `fractional` array:
 
-1. If the first element in `fractional` evaluates to a non-array type then deterministically encode it to a well defined byte array and hash the bytes.
-2. Otherwise, if `targetingKey` is a string, build a 2-elements array of `flagKey` and `targetingKey`, deterministically encode that and hash (**NOTE:** This is different than string concatenation used today).
-3. Otherwise, if `targetingKey` is non-string, report an error and return nil (as this breaks the [OpenFeature spec](https://openfeature.dev/specification/glossary/#targeting-key)).
-4. Otherwise, if `targetingKey` is missing, report an error and return nil
+1. If the first element in `fractional` evaluates to `null`, we report an error and return `nil`.
+2. If the first element in `fractional` evaluates to a non-array type then deterministically encode it to a well defined byte array and hash the bytes.
+3. Otherwise, if `targetingKey` is a string, build a 2-elements array of `flagKey` and `targetingKey`, deterministically encode that and hash (**NOTE:** This is different than string concatenation used today).
+4. Otherwise, if `targetingKey` is non-string, report an error and return `nil` (as this breaks the [OpenFeature spec](https://openfeature.dev/specification/glossary/#targeting-key)).
+5. Otherwise, if `targetingKey` is missing, report an error and return `nil`
 
 ```json
 // Will use the new logic
@@ -127,7 +130,6 @@ When inspecting the first element of the `fractional` array:
 To meet requirement (2) [RFC 8949 Concise Binary Object Representation (CBOR)](https://www.rfc-editor.org/rfc/rfc8949.html) will be used to decide on byte encodings.
 
 * `boolean` is major type 7
-* `null` is major type 7
 * `string` is major type 3
 * `integer`:
     * `unsigned integer` is major type 0
@@ -135,14 +137,32 @@ To meet requirement (2) [RFC 8949 Concise Binary Object Representation (CBOR)](h
 * `float` is major type 7
 * `map` (object, structure, dict) is major type 5
 * `array` (list, sequence) is major type 4
-* `datetime` is converted to POSIX epoch time (including fractional seconds for sub-second precision) and CBOR Tag 1 is used
+
+**NOTE: As JSONLogic doesn’t have any datetime type, currently we don’t leverage CBOR Tag 1. Any datetime type used within provider implementation and passed to the fractional operator causes undefined behavior. If a user wants to manage datetime, they can do it by leveraging POSIX epoch encoded as integer value, or as ISO 8601 standard encoded as string.**
 
 **ATTENTION: When encoding strings, CBOR appends the size of the encoding in first bytes. As such, even though the actual encoding of the string is still UTF-8, the resulting byte array will differ from raw UTF-8 encoding. As such, after this change, all hashes will change, which will result in rebucketing.**
 
-Additionally, it is required to use [4.2.1. Core Deterministic Encoding Requirements](https://www.rfc-editor.org/rfc/rfc8949.html#section-4.2.1) (which includes Preferred Serizalization), to ensure:
+However, to reach full cross-language consistency we need to fulfill those additional requirements:
+
+* **Number Normalization (Integer vs. Float):**
+JSON parsers natively lack strict differentiation between integers and floats (e.g., `1` vs `1.0`). To align with CBOR's distinct major types (Type 0/1 for integers, Type 7 for floats) and Section 6.2 of RFC 8949, all providers must implement a normalization step prior to encoding.
+To prevent overflow errors in strongly-typed languages (e.g. Go) and inconsistent BigInt tagging in languages with arbitrary-precision integers (e.g. Python), the number normalization is restricted to the range $[-2^{63}, 2^{64}-1]$ (covering both signed and unsigned 64-bit integers):
+
+1. If a numeric value has no fractional part (e.g., `val == math.Trunc(val)` in Go, or `val.is_integer()` in Python), the provider must attempt to cast it to a signed (if <0) or unsigned (if >=0) integer before encoding.
+2. If a numeric value has fractional part, or if it falls outside the range $[-2^{63}, 2^{64}-1]$ (e.g., `1.0e+176`), it **must not** be normalized to an integer. It must be encoded as a float (Major Type 7).
+
+**NOTE: Both -0.0 and 0.0 float values should be mapped to unsigned integer value 0.**
+
+**NOTE: As NaN and +/- infinity are not supported by JSON, operations on them are undefined behavior, even in languages that may support them. Using those values in live applications is discouraged.**
+
+* **CBOR Deterministic Encoding:**
+
+It is required to use [4.2.1. Core Deterministic Encoding Requirements](https://www.rfc-editor.org/rfc/rfc8949.html#section-4.2.1) (which includes Preferred Serialization), to ensure:
 
 1. **Map Key Ordering**: Implementations must strictly adhere to the requirement that keys in maps (objects/structures) must be sorted using bytewise lexicographic order of their deterministic encodings.
 2. **Preferred Serialization (Numbers)**: CBOR mandates using the shortest possible encoding. Providers must ensure consistency, especially between integer and float representations, and across different precisions. For example, if a value fits within a 32-bit float, it must be used instead of a 64-bit float, regardless of the native type in the provider's language.
+
+**NOTE: Since flag configurations are parsed from JSON, the maps (objects, structures, dicts) always have strings as keys. That’s why often there is no difference between Core Deterministic Encoding defined in [rfc8949 Section 4.2](https://www.rfc-editor.org/rfc/rfc8949.html#name-deterministically-encoded-c) and Canonical Encoding defined in [rfc7049 Section 3.9](https://www.rfc-editor.org/rfc/rfc7049#section-3.9). In some languages, due to the absence of libraries that can handle the updated standard, it is possible to use the older one. In such cases please add code comments explaining the implementation choice.**
 
 ### API changes
 


### PR DESCRIPTION
## This PR

While working on the non-string fractional ADR, we identified several critical pitfalls in the initial proposal and wanted to expand the requirements to ensure strict cross-language consistency.
This PR updates the ADR (fractional-non-string-rand-units.md) with the following key changes:

* **`null` Rejection:** Explicitly reject `null` as the first argument to prevent silent errors from evaluation failures.
* **Number Normalization:** Mandate normalization of numeric values (casting floats without fractional parts to integers) to ensure consistent CBOR major types across different language parsers.
* **Datetime Clarification:** Removed CBOR Tag 1 and marked datetime usage as undefined behavior, recommending POSIX epoch or ISO 8601 instead.
* **Encoding Flexibility:** Clarified deterministic encoding requirements, allowing fallback to RFC 7049 (Canonical Encoding) where RFC 8949 support is lacking in language libraries.
 
### Related Issues
Under scope of #1737 

### Notes
No Breaking Change: As none of the languages implemented this ADR yet, those changes won't affect any of the implementations, while avoiding pitfalls that could arise later on. The changes are purely semantic and do not affect the flagd JSON schema and the rest of the adr.

### Follow-up Tasks

We should update [reference specification of fractional operator on flagd page](https://flagd.dev/reference/specifications/custom-operations/fractional-operation-spec/)