### PR TITLE
feat(sync): forward S3 URI query parameters to the bucket URL

### DIFF
--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/sync"
@@ -291,8 +292,14 @@ func (sb *SyncBuilder) newS3(config sync.SourceConfig, logger *logger.Logger) (*
 	// Extract bucket uri and object name from the full URI:
 	// s3://bucket/path/to/object results in s3://bucket/ as bucketUri and
 	// path/to/object as an object name.
-	bucketURI := regS3.FindString(config.URI)
-	objectName := regS3.ReplaceAllString(config.URI, "")
+	rawURI, query, hasQuery := strings.Cut(config.URI, "?")
+	bucketURI := regS3.FindString(rawURI)
+	objectName := regS3.ReplaceAllString(rawURI, "")
+	if hasQuery && query != "" {
+		// s3blob reads use_path_style/region/etc. from the bucket URL query string;
+		// the bucket host must not carry a trailing slash before "?".
+		bucketURI = strings.TrimSuffix(bucketURI, "/") + "?" + query
+	}
 
 	interval, poller, err := newPoller(config)
 	if err != nil {

--- a/core/pkg/sync/builder/syncbuilder_test.go
+++ b/core/pkg/sync/builder/syncbuilder_test.go
@@ -464,6 +464,13 @@ func Test_S3Config(t *testing.T) {
 			expectedInterval: defaultInterval,
 		},
 		{
+			name:             "bucket options in query",
+			uri:              "s3://bucket/path/to/object?use_path_style=true",
+			expectedBucket:   "s3://bucket?use_path_style=true",
+			expectedObject:   "path/to/object",
+			expectedInterval: defaultInterval,
+		},
+		{
 			name:             "no object set", // Blob syncer will return error when fetching
 			uri:              "s3://bucket/",
 			expectedBucket:   "s3://bucket/",


### PR DESCRIPTION
## Summary

Forward S3 URI query parameters (`use_path_style`, `region`, `accelerate`, `disable_https`, etc.) to the bucket URL so gocloud's `s3blob` driver actually reads them. This lets flagd sync from path-style or non-AWS S3-compatible endpoints (MinIO, LocalStack, Ceph).

## Why this matters

`newS3` in `core/pkg/sync/builder/syncbuilder.go` splits the source URI with `regS3` (`^s3://.+?/`), which matches only up to the first `/`. For `s3://my-bucket/my-flag.json?use_path_style=true` that leaves the query string on the object name (`my-flag.json?use_path_style=true`) rather than on the bucket URL, which is where `s3blob.URLOpener` reads its options. The option is silently dropped and the object key is corrupted with a trailing `?...`.

This matches what the #1961 thread found: @kawingliu6 hit `strconv.ParseBool: parsing "true/"` when passing the parameter through, and @erka asked whether `s3://my-bucket/my-flag.json?use_path_style=true` should work. With this change it does.

## Changes

`newS3` now splits any `?query` off the URI before the bucket/object regex split, then re-attaches it to the bucket URL (trimming the trailing slash so the host stays well-formed) and leaves the object key clean. gcs and azblob are untouched; the fix is scoped to S3, where the issue and `s3blob`'s documented query options apply.

## Testing

Added a `Test_S3Config` case asserting `s3://bucket/path/to/object?use_path_style=true` resolves to bucket `s3://bucket?use_path_style=true` and object `path/to/object`. `go test ./pkg/sync/builder/...` passes in the `core` module; `gofmt` clean.

Closes #1961
