### PR TITLE
fix(sync): panic on s3 URI with query string

### DIFF
--- a/core/pkg/sync/blob/blob_sync.go
+++ b/core/pkg/sync/blob/blob_sync.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/sync"
+	"github.com/open-feature/flagd/core/pkg/sync/internal/bloburi"
 	"github.com/open-feature/flagd/core/pkg/sync/internal/polling"
 	"github.com/open-feature/flagd/core/pkg/utils"
 	"gocloud.dev/blob"
@@ -100,7 +101,7 @@ func (hs *Sync) sync(ctx context.Context, dataSync chan<- sync.DataSync, skipChe
 	if !skipCheckingModTime {
 		hs.lastUpdated = updated
 	}
-	dataSync <- sync.DataSync{FlagData: msg, Source: hs.Bucket + hs.Object}
+	dataSync <- sync.DataSync{FlagData: msg, Source: bloburi.Join(hs.Bucket, hs.Object)}
 	return nil
 }
 

--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strings"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/sync"
@@ -13,6 +12,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/sync/grpc"
 	"github.com/open-feature/flagd/core/pkg/sync/grpc/credentials"
 	httpSync "github.com/open-feature/flagd/core/pkg/sync/http"
+	"github.com/open-feature/flagd/core/pkg/sync/internal/bloburi"
 	"github.com/open-feature/flagd/core/pkg/sync/internal/polling"
 	"github.com/open-feature/flagd/core/pkg/sync/kubernetes"
 	"go.uber.org/zap"
@@ -229,8 +229,7 @@ func (sb *SyncBuilder) newGcs(config sync.SourceConfig, logger *logger.Logger) (
 	// Extract bucket uri and object name from the full URI:
 	// gs://bucket/path/to/object results in gs://bucket/ as bucketUri and
 	// path/to/object as an object name.
-	bucketURI := regGcs.FindString(config.URI)
-	objectName := regGcs.ReplaceAllString(config.URI, "")
+	bucketURI, objectName := bloburi.Split(config.URI, regGcs)
 
 	interval, poller, err := newPoller(config)
 	if err != nil {
@@ -265,8 +264,7 @@ func (sb *SyncBuilder) newAzblob(config sync.SourceConfig, logger *logger.Logger
 	// Extract bucket uri and object name from the full URI:
 	// azblob://bucket/path/to/object results in azblob://bucket/ as bucketUri and
 	// path/to/object as an object name.
-	bucketURI := regAzblob.FindString(config.URI)
-	objectName := regAzblob.ReplaceAllString(config.URI, "")
+	bucketURI, objectName := bloburi.Split(config.URI, regAzblob)
 
 	interval, poller, err := newPoller(config)
 	if err != nil {
@@ -291,15 +289,9 @@ func (sb *SyncBuilder) newAzblob(config sync.SourceConfig, logger *logger.Logger
 func (sb *SyncBuilder) newS3(config sync.SourceConfig, logger *logger.Logger) (*blobSync.Sync, error) {
 	// Extract bucket uri and object name from the full URI:
 	// s3://bucket/path/to/object results in s3://bucket/ as bucketUri and
-	// path/to/object as an object name.
-	rawURI, query, hasQuery := strings.Cut(config.URI, "?")
-	bucketURI := regS3.FindString(rawURI)
-	objectName := regS3.ReplaceAllString(rawURI, "")
-	if hasQuery && query != "" {
-		// s3blob reads use_path_style/region/etc. from the bucket URL query string;
-		// the bucket host must not carry a trailing slash before "?".
-		bucketURI = strings.TrimSuffix(bucketURI, "/") + "?" + query
-	}
+	// path/to/object as an object name. Any query string (e.g. use_path_style,
+	// region) is moved onto the bucket URL so gocloud's s3blob driver reads it.
+	bucketURI, objectName := bloburi.Split(config.URI, regS3)
 
 	interval, poller, err := newPoller(config)
 	if err != nil {

--- a/core/pkg/sync/internal/bloburi/bloburi.go
+++ b/core/pkg/sync/internal/bloburi/bloburi.go
@@ -1,0 +1,32 @@
+// Package bloburi splits and rejoins blob sync URIs (s3://, gs://, azblob://).
+package bloburi
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Split parses "scheme://bucket/key?opt=1" into bucket URL ("scheme://bucket?opt=1")
+// and object key ("key"). The query moves to the bucket URL because gocloud blob
+// drivers read driver options (e.g. s3blob use_path_style, region) from there.
+// schemeRegex must match through the first "/" after the scheme (e.g. "^s3://.+?/").
+func Split(uri string, schemeRegex *regexp.Regexp) (bucket, object string) {
+	raw, query, hasQuery := strings.Cut(uri, "?")
+	bucket = schemeRegex.FindString(raw)
+	object = schemeRegex.ReplaceAllString(raw, "")
+	if hasQuery && query != "" {
+		bucket = strings.TrimSuffix(bucket, "/") + "?" + query
+	}
+	return bucket, object
+}
+
+// Join is the inverse of Split. The reconstructed URI must match what was
+// registered in the store (see flagd#1971).
+func Join(bucket, object string) string {
+	i := strings.Index(bucket, "?")
+	if i < 0 {
+		return bucket + object
+	}
+	base := strings.TrimSuffix(bucket[:i], "/") + "/"
+	return base + object + bucket[i:]
+}

--- a/core/pkg/sync/internal/bloburi/bloburi_test.go
+++ b/core/pkg/sync/internal/bloburi/bloburi_test.go
@@ -1,0 +1,86 @@
+package bloburi
+
+import (
+	"regexp"
+	"testing"
+)
+
+var schemeRegexes = map[string]*regexp.Regexp{
+	"s3":     regexp.MustCompile("^s3://.+?/"),
+	"gs":     regexp.MustCompile("^gs://.+?/"),
+	"azblob": regexp.MustCompile("^azblob://.+?/"),
+}
+
+func TestSplit(t *testing.T) {
+	tests := map[string]struct {
+		uri    string
+		scheme string
+		bucket string
+		object string
+	}{
+		"s3 simple": {
+			uri:    "s3://my-bucket/flags.json",
+			scheme: "s3",
+			bucket: "s3://my-bucket/",
+			object: "flags.json",
+		},
+		"s3 with query (use_path_style)": {
+			uri:    "s3://my-bucket/example_flags.json?use_path_style=true&region=garage&endpoint=http://127.0.0.1:3900",
+			scheme: "s3",
+			bucket: "s3://my-bucket?use_path_style=true&region=garage&endpoint=http://127.0.0.1:3900",
+			object: "example_flags.json",
+		},
+		"gs simple": {
+			uri:    "gs://my-bucket/path/to/object",
+			scheme: "gs",
+			bucket: "gs://my-bucket/",
+			object: "path/to/object",
+		},
+		"azblob simple": {
+			uri:    "azblob://my-bucket/flags.yaml",
+			scheme: "azblob",
+			bucket: "azblob://my-bucket/",
+			object: "flags.yaml",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			bucket, object := Split(tt.uri, schemeRegexes[tt.scheme])
+			if bucket != tt.bucket {
+				t.Errorf("Split bucket = %q, want %q", bucket, tt.bucket)
+			}
+			if object != tt.object {
+				t.Errorf("Split object = %q, want %q", object, tt.object)
+			}
+		})
+	}
+}
+
+// TestSplitJoinInverse ensures that Join is the inverse of Split
+func TestSplitJoinInverse(t *testing.T) {
+	uris := []string{
+		"s3://b/o",
+		"s3://b/path/to/object",
+		"s3://b/o?use_path_style=true",
+		"s3://b/o?use_path_style=true&region=garage&endpoint=http://127.0.0.1:3900",
+		"s3://b/path/to/object?a=1&b=2",
+		"gs://b/o",
+		"gs://b/path/to/object",
+		"azblob://b/o",
+		"azblob://b/flags.yaml",
+	}
+	for _, uri := range uris {
+		t.Run(uri, func(t *testing.T) {
+			for _, reg := range schemeRegexes {
+				if !reg.MatchString(uri) {
+					continue
+				}
+				bucket, object := Split(uri, reg)
+				if got := Join(bucket, object); got != uri {
+					t.Errorf("Join(Split(%q)) = %q, want %q (bucket=%q object=%q)",
+						uri, got, uri, bucket, object)
+				}
+			}
+		})
+	}
+}

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -83,6 +83,9 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 
 	sources := []string{}
 
+	// URIs are registered verbatim (including any blob query string like
+	// s3://bucket/key?use_path_style=true); the sync implementation must
+	// emit DataSync.Source matching this exact string. See flagd#1973.
 	for _, provider := range config.SyncProviders {
 		sources = append(sources, provider.URI)
 	}


### PR DESCRIPTION
#1971 put the query string on the bucket URL (so gocloud reads it), but `blob.Sync` still emits `Source` as `Bucket + Object`, so it no longer matches the registered URI and `Store.Update` panics.

Pulled the split/join into `internal/bloburi` and rebuild the URI when emitting `DataSync.Source` so that things stay consistent if there's changes here - added a test for that as well to lock them as inverses.

Verified manually/locally against MinIO.

Closes #1973

FYI @mvanhorn