### PR TITLE
test(model): add unit tests for GetErrorMessage and Flag.MarshalJSON

### DIFF
--- a/core/pkg/model/model_test.go
+++ b/core/pkg/model/model_test.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "flag not found", code: FlagNotFoundErrorCode, want: "Flag not found"},
+		{name: "parse error", code: ParseErrorCode, want: "Error parsing input or configuration"},
+		{name: "type mismatch", code: TypeMismatchErrorCode, want: "Type mismatch error"},
+		{name: "general error", code: GeneralErrorCode, want: "General error"},
+		{name: "flag disabled", code: FlagDisabledErrorCode, want: "Flag is disabled"},
+		{name: "invalid context", code: InvalidContextCode, want: "Invalid context provided"},
+		{name: "unknown code", code: "NOT_A_CODE", want: "Unknown error code: NOT_A_CODE"},
+		{name: "empty code", code: "", want: "Unknown error code: "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetErrorMessage(tt.code))
+		})
+	}
+}
+
+func TestFlagMarshalJSON(t *testing.T) {
+	flag := Flag{
+		Key:            "my-flag",
+		FlagSetId:      "set-1",
+		Priority:       7,
+		State:          "ENABLED",
+		DefaultVariant: "on",
+		Variants:       map[string]any{"on": true, "off": false},
+		Targeting:      json.RawMessage(`{"if":[true,"on","off"]}`),
+		Source:         "file.json",
+		Metadata:       Metadata{"team": "platform"},
+	}
+
+	b, err := json.Marshal(flag)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	// MarshalJSON intentionally omits the key; locking this in so a refactor
+	// cannot silently start emitting it.
+	assert.NotContains(t, got, "key")
+	// FlagSetId and Priority are json:"-" and must never serialize.
+	assert.NotContains(t, got, "FlagSetId")
+	assert.NotContains(t, got, "Priority")
+
+	assert.Equal(t, "ENABLED", got["state"])
+	assert.Equal(t, "on", got["defaultVariant"])
+	assert.Equal(t, "file.json", got["source"])
+	assert.Contains(t, got, "variants")
+	assert.Contains(t, got, "targeting")
+	assert.Contains(t, got, "metadata")
+}
+
+func TestFlagMarshalJSON_OmitsEmptyOptionalFields(t *testing.T) {
+	b, err := json.Marshal(Flag{State: "ENABLED", DefaultVariant: "on", Source: "file.json"})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.NotContains(t, got, "key")
+	assert.NotContains(t, got, "targeting")
+	assert.NotContains(t, got, "metadata")
+}


### PR DESCRIPTION
core/pkg/model had no test coverage (0.0%) even though it is imported by 17 packages and holds the core Flag type. This adds table-driven tests for the two functions in the package that have real behaviour:

- `GetErrorMessage`: every known code maps to its readable message, and an unknown code falls through to `Unknown error code: <code>`.
- `Flag.MarshalJSON`: locks in the non-obvious behaviour where `key` is deliberately omitted from the serialized JSON, `FlagSetId`/`Priority` (`json:"-"`) never serialize, and `targeting`/`metadata` honour `omitempty`.

Test-only, no production change. Brings the package to 100% coverage.

Relates to #1773.

### Checklist
- [x] Unit tests included (CONTRIBUTING requires it)
- [x] `make test-core` / `go test -race -short ./pkg/model/` passes (100% cov)
- [x] `make lint` (golangci-lint v2.7.2) clean
- [x] DCO sign-off present, author == signoff
- [x] No markdown changes (markdownlint N/A)
