### PR TITLE
fix: readyz never true of multiple gRPC syncs are used

### DIFF
--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	msync "sync"
 	"time"
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
@@ -41,8 +40,6 @@ type FlagSyncServiceClient interface {
 type FlagSyncServiceClientResponse interface {
 	syncv1grpc.FlagSyncService_SyncFlagsClient
 }
-
-var once msync.Once
 
 type Sync struct {
 	GrpcDialOptionsOverride []grpc.DialOption
@@ -208,9 +205,7 @@ func (g *Sync) connectWithRetry(
 
 // handleFlagSync wraps the stream listening and push updates through dataSync channel
 func (g *Sync) handleFlagSync(stream syncv1grpc.FlagSyncService_SyncFlagsClient, dataSync chan<- sync.DataSync) error {
-	once.Do(func() {
-		g.ready = true
-	})
+	g.ready = true
 
 	for {
 		data, err := stream.Recv()

--- a/core/pkg/sync/grpc/grpc_sync_test.go
+++ b/core/pkg/sync/grpc/grpc_sync_test.go
@@ -338,6 +338,65 @@ func Test_StreamListener(t *testing.T) {
 	}
 }
 
+// Test_MultipleSyncsBecomeReady ensures readiness is tracked per Sync instance.
+// flagd builds a distinct *grpc.Sync per configured grpc source, and the runtime
+// only reports ready once every Sync.IsReady() is true. A shared, package-level
+// guard around g.ready would let only the first instance report ready, leaving any
+// flagd with 2+ grpc sources permanently NotReady. Both instances must become ready.
+func Test_MultipleSyncsBecomeReady(t *testing.T) {
+	const target = "localBufCon"
+
+	newReadySync := func() *Sync {
+		bufCon := bufconn.Listen(5)
+		bufServer := bufferedServer{
+			listener:      bufCon,
+			mockResponses: []serverPayload{{flags: "{\"flags\": {}}"}},
+		}
+		go serve(&bufServer)
+
+		dial, err := grpc.Dial(target,
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return bufCon.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		require.NoError(t, err)
+
+		return &Sync{
+			URI:    target,
+			Logger: logger.NewLogger(nil, false),
+			client: syncv1grpc.NewFlagSyncServiceClient(dial),
+		}
+	}
+
+	syncs := []*Sync{newReadySync(), newReadySync()}
+
+	for i, s := range syncs {
+		require.Falsef(t, s.IsReady(), "sync %d should not be ready before sync starts", i)
+	}
+
+	for i, s := range syncs {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		syncChan := make(chan sync.DataSync, 1)
+		go func() {
+			if err := s.Sync(ctx, syncChan); err != nil && err != io.EOF {
+				t.Errorf("sync %d returned error: %s", i, err.Error())
+			}
+		}()
+
+		// Receiving a payload establishes that handleFlagSync ran (and set ready)
+		// for this instance before we read IsReady, keeping the check race-free.
+		select {
+		case <-syncChan:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for sync %d to emit", i)
+		}
+
+		require.Truef(t, s.IsReady(), "sync %d should be ready after its stream connects", i)
+	}
+}
+
 // Test_ConnectWithRetry is an attempt to validate grpc.connectWithRetry behavior
 func Test_ConnectWithRetry(t *testing.T) {
 	target := "grpc://local"


### PR DESCRIPTION

```markdown
## This PR

The gRPC sync guards its one-shot readiness with a package-level `sync.Once`:

```go
var once msync.Once
// ...
func (g *Sync) handleFlagSync(...) error {
    once.Do(func() {
        g.ready = true
    })
    // ...
}
```

Because that `Once` is shared across every `grpc.Sync` in the process, only the
first instance whose stream connects runs the closure and sets its own `ready`
flag. Every other `grpc.Sync` instance stays not-ready forever, so its
`IsReady()` keeps returning false.

flagd builds a distinct `grpc.Sync` per configured grpc source
(`SyncBuilder.newGRPC` in `core/pkg/sync/builder/syncbuilder.go`), and the
runtime only reports ready once every sync is ready (`Runtime.isReady` in
`flagd/pkg/runtime/runtime.go` returns false if any `Syncs[].IsReady()` is
false). The net effect is that any flagd configured with two or more `grpc://`
sync sources never passes `/readyz`, even after all of its gRPC streams are
healthy, so the pod stays NotReady.

## The fix

Set `g.ready = true` directly in `handleFlagSync` and drop the package-level
`once` (and its now-unused `sync` import alias). The assignment is idempotent,
so this is a no-op for the single-source case and makes readiness per instance
for the multi-source case. This also matches the other sync implementations:
the blob, file, and http syncs already set a plain `ready bool` directly, and
kubernetes tracks it per instance with an `atomic.Bool`. The package-level
`Once` was the outlier.

The write still happens-before the update pushed onto the `dataSync` channel,
so no new concurrent read path is introduced and the change stays race-clean.

## Tests

Adds `Test_MultipleSyncsBecomeReady`, which starts two independent `grpc.Sync`
instances (each backed by its own bufconn server), drives each one, and asserts
both report `IsReady() == true`. The test synchronizes by receiving a payload
from the sync channel before reading `IsReady()`, so it establishes a
happens-before edge and is race-free by construction rather than by timing.

Before this change the test fails on the second instance
("sync 1 should be ready after its stream connects"); after it, both pass.
Readiness was previously untested in this file, so this also closes that
coverage gap.

Verified with:

- `go build ./...`
- `go test -race -covermode=atomic -cover -short ./pkg/sync/grpc/` (from `core/`)
- `golangci-lint run ./pkg/sync/grpc/...`
```

### Notes on the clean body
- No upstream issue exists for this bug, so the PR does not claim to close one.
  Before opening, do a final search for a matching readiness/`/readyz` issue; if
  none, file a short issue describing the multi-grpc-source NotReady symptom and
  link it, or open the PR as a standalone fix (both are acceptable here).
- Diff is 2 files, +60/-6 (source: -6, test: +59). Surgical.
