### PR TITLE
test(evaluator): exercise ResolveStringValue in concurrency test

### DIFF
--- a/core/pkg/evaluator/json_test.go
+++ b/core/pkg/evaluator/json_test.go
@@ -1462,7 +1462,7 @@ func TestFlagStateSafeForConcurrentReadWrites(t *testing.T) {
 		},
 		"Update_ResolveStringValue": {
 			flagResolution: func(evaluator *flagdEvaluator.JSON) error {
-				_, _, _, _, err := evaluator.ResolveBooleanValue(context.TODO(), "", StaticStringValue, nil)
+				_, _, _, _, err := evaluator.ResolveStringValue(context.TODO(), "", StaticStringFlag, nil)
 				return err
 			},
 		},


### PR DESCRIPTION

## This PR

In `TestFlagStateSafeForConcurrentReadWrites`
(`core/pkg/evaluator/json_test.go`), the `"Update_ResolveStringValue"` case
does not resolve a string flag. It calls `ResolveBooleanValue` and passes
`StaticStringValue` (a variant value, `"#CC0000"`) as the flag key, whereas
every sibling case calls its namesake resolver with the matching `*Flag` key
constant:

```go
"Add_ResolveBooleanValue":    ResolveBooleanValue(..., StaticBoolFlag, nil)
"Update_ResolveStringValue":  ResolveBooleanValue(..., StaticStringValue, nil)  // wrong resolver + value used as key
"Delete_ResolveIntValue":     ResolveIntValue(..., StaticIntFlag, nil)
"Add_ResolveFloatValue":      ResolveFloatValue(..., StaticFloatFlag, nil)
"Update_ResolveObjectValue":  ResolveObjectValue(..., StaticObjectFlag, nil)
```

The resolving goroutine discards the result (`_ = tt.flagResolution(...)`) and
only surfaces data races and panics, so the mismatch passes silently. The net
effect is that `ResolveStringValue` is never driven under concurrent
read/write (the path this case is named for gets zero race coverage), while
`ResolveBooleanValue` is exercised twice.

This is a **test-only** change; no production code is touched.

## What's changed

One line in the `"Update_ResolveStringValue"` case so it matches its name and
the sibling pattern:

```diff
- _, _, _, _, err := evaluator.ResolveBooleanValue(context.TODO(), "", StaticStringValue, nil)
+ _, _, _, _, err := evaluator.ResolveStringValue(context.TODO(), "", StaticStringFlag, nil)
```

`StaticStringFlag` (`"staticStringFlag"`) is a real `ENABLED` string flag in
the test's `flagConfig`, so the corrected call resolves an existing flag and
now genuinely covers the string-resolve path concurrently with `SetState`.

## Testing

```sh
cd core
go build ./...
go test -race -run '^TestFlagStateSafeForConcurrentReadWrites$' ./pkg/evaluator/...
go test -race -covermode=atomic -cover -short ./pkg/evaluator/...
```

All green under `-race`. `golangci-lint` (repo-pinned v2.7.2) reports 0 issues
on the package.
