### PR TITLE
fix(flagd-proxy): route management-port gRPC health by the correct content-type

### DIFF
--- a/flagd-proxy/pkg/service/server.go
+++ b/flagd-proxy/pkg/service/server.go
@@ -137,8 +137,8 @@ func (s *Server) startMetricsServer() error {
 	mux.Handle("/metrics", promhttp.Handler())
 
 	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		// if this is 'application/grpcServer' and HTTP2, handle with gRPC, otherwise HTTP.
-		if request.ProtoMajor == 2 && strings.HasPrefix(request.Header.Get("Content-Type"), "application/grpcServer") {
+		// if this is 'application/grpc' and HTTP2, handle with gRPC, otherwise HTTP.
+		if request.ProtoMajor == 2 && strings.HasPrefix(request.Header.Get("Content-Type"), "application/grpc") {
 			grpcServer.ServeHTTP(writer, request)
 		} else {
 			mux.ServeHTTP(writer, request)

--- a/flagd-proxy/pkg/service/server_test.go
+++ b/flagd-proxy/pkg/service/server_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"github.com/open-feature/flagd/core/pkg/service"
+	"github.com/open-feature/flagd/flagd-proxy/pkg/service/subscriptions"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// freePort reserves an ephemeral TCP port from the kernel and returns it after
+// closing the listener, so the server under test can bind to it.
+func freePort(t *testing.T) uint16 {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a free port: %v", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	if err := lis.Close(); err != nil {
+		t.Fatalf("failed to release reserved port: %v", err)
+	}
+	return uint16(port)
+}
+
+// waitForListener blocks until a TCP connection to addr succeeds or the
+// deadline elapses.
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server did not start listening on %s within the deadline", addr)
+}
+
+// TestMetricsServerRoutesGRPCHealth verifies that a real gRPC request (which
+// carries Content-Type "application/grpc") sent to the management port is
+// routed to the registered gRPC health server via h2c, instead of falling
+// through to the plain HTTP mux. With the Content-Type prefix typo the h2c
+// dispatcher never matched real gRPC traffic, so the health server was
+// unreachable on the management port.
+func TestMetricsServerRoutesGRPCHealth(t *testing.T) {
+	ctx := context.Background()
+
+	managementPort := freePort(t)
+	s := NewServer(ctx, logger.NewLogger(nil, false), subscriptions.NewManager(ctx, logger.NewLogger(nil, false)))
+	s.config = service.Configuration{
+		ManagementPort: managementPort,
+		ReadinessProbe: func() bool { return true },
+	}
+	s.metricServerReady = true
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- s.startMetricsServer() }()
+
+	managementAddr := fmt.Sprintf("127.0.0.1:%d", managementPort)
+	waitForListener(t, managementAddr)
+
+	// insecure transport credentials speak plaintext HTTP/2, which is what the
+	// server's h2c handler expects.
+	conn, err := grpc.NewClient(managementAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("failed to create gRPC client: %v", err)
+	}
+	defer conn.Close()
+
+	checkCtx, checkCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer checkCancel()
+
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(checkCtx, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("gRPC health check on the management port failed; the request was not routed to the gRPC health server: %v", err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		t.Errorf("expected health status %v, got %v", grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
+	}
+
+	if err := s.metricsServer.Shutdown(ctx); err != nil {
+		t.Errorf("failed to shut down metrics server: %v", err)
+	}
+	if err := <-serveErr; err != nil {
+		t.Errorf("startMetricsServer returned an unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION

```markdown
### This PR

Fixes the h2c content-type routing on the flagd-proxy management/metrics port so
that gRPC traffic reaches the registered gRPC health server.

`startMetricsServer` in `flagd-proxy/pkg/service/server.go` registers a
`grpc_health_v1` health server behind an h2c handler that dispatches HTTP/2
requests to gRPC based on the request `Content-Type`. The predicate matched the
prefix `application/grpcServer`:

```go
// if this is 'application/grpcServer' and HTTP2, handle with gRPC, otherwise HTTP.
if request.ProtoMajor == 2 && strings.HasPrefix(request.Header.Get("Content-Type"), "application/grpcServer") {
```

`application/grpcServer` is not a real media type. Per the gRPC-over-HTTP2
protocol, gRPC clients send `Content-Type: application/grpc` (optionally with a
`+proto` / `+json` suffix). Because no client sends `application/grpcServer`,
the `HasPrefix` check never matched real gRPC traffic: every gRPC request on the
management port fell through to the plain HTTP mux (which only serves
`/healthz`, `/readyz`, `/metrics`), so the registered gRPC health server on that
port was unreachable.

This changes the prefix (and its comment) to `application/grpc`, which makes the
dispatcher identical to the equivalent one in flagd's connect service
(`flagd/pkg/service/flag-evaluation/connect_service.go`), the authoritative
reference for the intended behavior. After this change, `application/grpcServer`
no longer appears anywhere in the repository.

### Regression test

Adds `flagd-proxy/pkg/service/server_test.go`
(`TestMetricsServerRoutesGRPCHealth`): it starts the management server on an
ephemeral port, dials a real gRPC client over plaintext HTTP/2 (h2c), and
asserts a `grpc_health_v1.Check` is routed to the health server and returns
`SERVING`.

- Before the fix, the check is served by the plain HTTP mux and fails
  (HTTP 404, `text/plain`, `code = Unimplemented`).
- After the fix, it returns `SERVING`.

The test uses only the standard library plus gRPC packages already used in the
module (`google.golang.org/grpc`, `.../health/grpc_health_v1`,
`.../credentials/insecure`); `go.mod` and `go.sum` are unchanged.

### Validation

- `cd flagd-proxy && go build ./...`, `go vet ./pkg/service/...`
- `go test -race -covermode=atomic -cover -short ./pkg/...` (all pass; new test
  run with `-race -count` shows no flake and no data race)
- `golangci-lint run ./...`

The h2c gRPC routing path on the management port was previously untested, so
this also closes a coverage gap.
```
