### PR TITLE
docs: fix result values in custom operation examples

### DIFF
--- a/docs/reference/custom-operations/semver-operation.md
+++ b/docs/reference/custom-operations/semver-operation.md
@@ -73,7 +73,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```json
-{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"red"}
+{"value":"#FF0000","reason":"TARGETING_MATCH","variant":"red"}
 ```
 
 Command:
@@ -85,5 +85,5 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```shell
-{"value":"#0000FF","reason":"TARGETING_MATCH","variant":"green"}
+{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"green"}
 ```

--- a/docs/reference/custom-operations/string-comparison-operation.md
+++ b/docs/reference/custom-operations/string-comparison-operation.md
@@ -62,7 +62,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```json
-{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"red"}
+{"value":"#FF0000","reason":"TARGETING_MATCH","variant":"red"}
 ```
 
 Command:
@@ -74,7 +74,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```json
-{"value":"#0000FF","reason":"TARGETING_MATCH","variant":"green"}
+{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"green"}
 ```
 
 ## EndsWith Operation Configuration
@@ -136,7 +136,7 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```json
-{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"red"}
+{"value":"#FF0000","reason":"TARGETING_MATCH","variant":"red"}
 ```
 
 Command:
@@ -148,5 +148,5 @@ curl -X POST "localhost:8013/flagd.evaluation.v1.Service/ResolveString" -d '{"fl
 Result:
 
 ```json
-{"value":"#0000FF","reason":"TARGETING_MATCH","variant":"green"}
+{"value":"#00FF00","reason":"TARGETING_MATCH","variant":"green"}
 ```


### PR DESCRIPTION
## This PR

Fixes the example "Result" JSON in the semver and starts-with/ends-with custom
operation docs, where the `value` did not match its own `variant`.

Each example flag defines the same variants map:

```json
"variants": { "red": "#FF0000", "blue": "#0000FF", "green": "#00FF00" }
```

with targeting `if(<operation>) then "red" else "green"`. So a result with
`"variant":"red"` must carry `"value":"#FF0000"` and `"variant":"green"` must
carry `"value":"#00FF00"`. The docs instead showed:

- `{"value":"#00FF00", ... ,"variant":"red"}`   (should be `#FF0000`)
- `{"value":"#0000FF", ... ,"variant":"green"}`  (should be `#00FF00`)

which flagd never actually returns, so anyone copy-running the examples sees a
mismatch. This corrects the six affected `value` fields (2 in
`semver-operation.md`, 4 in `string-comparison-operation.md`) to match each
variant. Only the hex value changes; `reason` (`TARGETING_MATCH`, correct on
both branches) and `variant` are left as-is.

## Verification

Built flagd and re-ran the exact commands from the docs against `ResolveString`:

- semver `>=1.0.0`: `1.0.1` -> `{"value":"#FF0000",...,"variant":"red"}`;
  `0.1.0` -> `{"value":"#00FF00",...,"variant":"green"}`
- startsWith `user@faas`: `user@faas.com` -> red/`#FF0000`;
  `foo@bar.com` -> green/`#00FF00`
- endsWith `faas.com`: `user@faas.com` -> red/`#FF0000`;
  `foo@bar.com` -> green/`#00FF00`

All six live outputs now match the corrected docs. `fractional-operation.md`
already agreed with its variants map, so it is left untouched.

Docs-only change; `make markdownlint` rules pass on both files.
