### PR TITLE
fix(sync): handle non-string YAML map keys in config parsing

### DIFF
--- a/core/pkg/utils/yaml.go
+++ b/core/pkg/utils/yaml.go
@@ -18,10 +18,39 @@ func YAMLToJSON(rawFile []byte) (string, error) {
 		return "", fmt.Errorf("error unmarshaling yaml: %w", err)
 	}
 
-	r, err := json.Marshal(ms)
+	r, err := json.Marshal(convertMapKeys(ms))
 	if err != nil {
 		return "", fmt.Errorf("error marshaling json: %w", err)
 	}
 
 	return string(r), err
+}
+
+// convertMapKeys recursively converts any map[interface{}]interface{} into
+// map[string]interface{} so it can be marshaled by encoding/json. gopkg.in/yaml.v3
+// decodes a nested mapping that has a non-string key (e.g. an unquoted numeric key
+// in an object variant) as map[interface{}]interface{}, which json.Marshal cannot
+// handle; stringifying the keys mirrors how YAML-to-JSON conversion is expected to
+// behave and preserves YAML 1.2 value semantics.
+func convertMapKeys(in interface{}) interface{} {
+	switch v := in.(type) {
+	case map[string]interface{}:
+		for key, val := range v {
+			v[key] = convertMapKeys(val)
+		}
+		return v
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for key, val := range v {
+			out[fmt.Sprintf("%v", key)] = convertMapKeys(val)
+		}
+		return out
+	case []interface{}:
+		for i, val := range v {
+			v[i] = convertMapKeys(val)
+		}
+		return v
+	default:
+		return in
+	}
 }

--- a/core/pkg/utils/yaml_test.go
+++ b/core/pkg/utils/yaml_test.go
@@ -37,6 +37,16 @@ func TestYAMLToJSON(t *testing.T) {
 			expected:      `{"arr":[1,2],"bool":true,"num":123,"obj":{"nested":"value"},"str":"hello"}`,
 			expectedError: false,
 		},
+		"nested non-string map keys": {
+			input:         []byte("flags:\n  myObjectFlag:\n    state: ENABLED\n    defaultVariant: config\n    variants:\n      config:\n        1: first\n        2: second"),
+			expected:      `{"flags":{"myObjectFlag":{"defaultVariant":"config","state":"ENABLED","variants":{"config":{"1":"first","2":"second"}}}}}`,
+			expectedError: false,
+		},
+		"unquoted boolean-like keys and values stay strings": {
+			input:         []byte("variants:\n  on: A\n  off: B\ncountry: NO\nflag: yes"),
+			expected:      `{"country":"NO","flag":"yes","variants":{"off":"B","on":"A"}}`,
+			expectedError: false,
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION

**What**

A YAML flag config that contains a nested mapping with a non-string key (for
example an unquoted numeric key inside an object variant, or under `metadata`)
currently fails to load entirely, and the whole file is rejected with a cryptic
internal error:

```
json: unsupported type: map[interface {}]interface {}
```

This affects every YAML sync source (`file`, `http`, `blob`), all of which route
through `utils.ConvertToJSON` -> `utils.YAMLToJSON`.

**Reproduction**

A minimal, realistic flag definition that uses an object variant with numeric
keys is enough to trigger it:

```yaml
flags:
  myObjectFlag:
    state: ENABLED
    defaultVariant: config
    variants:
      config:
        1: first
        2: second
```

Loading this config (via a `file:`, `http:`, or `blob:` sync) fails the entire
file rather than just that flag, with the `map[interface {}]interface {}` error
above.

**Root cause**

`YAMLToJSON` decodes the document into `map[string]interface{}` with
`gopkg.in/yaml.v3` and then `json.Marshal`s the result. yaml.v3 only forces
string keys for the *top-level* map (because the decode target type does).
Any *nested* mapping with a non-string key is decoded as
`map[interface{}]interface{}`, which `encoding/json` cannot marshal, so the
marshal step fails and the whole config is rejected.

**Fix**

Recursively convert nested `map[interface{}]interface{}` into
`map[string]interface{}` (stringifying the keys) before marshaling. yaml.v3 is
kept as the parser, so YAML 1.2 value semantics are unchanged:

- unquoted `on/off/yes/no/NO` still parse as strings (no "Norway problem"),
- timestamps keep their existing normalization,
- duplicate keys and top-level scalar inputs still error exactly as before.

The change is purely additive: configs that already loaded are unaffected, and
configs with nested non-string keys now load instead of failing. No dependency
change.

**Tests**

Adds two table cases to `core/pkg/utils/yaml_test.go`:

- `nested non-string map keys` - the object-variant config above now converts to
  JSON with stringified keys (`"1"`, `"2"`); red before this change, green after.
- `unquoted boolean-like keys and values stay strings` - pins YAML 1.2 value
  semantics so a future parser swap that reintroduced boolean coercion would be
  caught. Passes on `main` too.

`go test -race -covermode=atomic -cover -short ./pkg/utils/...` passes (97.2%
coverage); `golangci-lint` (v2.7.2) is clean; `go mod tidy` leaves go.mod/go.sum
unchanged.
