### PR TITLE
fix(sync): avoid send on closed channel in fileinfo watcher Close

### DIFF
--- a/core/pkg/sync/file/fileinfo_watcher.go
+++ b/core/pkg/sync/file/fileinfo_watcher.go
@@ -35,7 +35,7 @@ type fileInfoWatcher struct {
 	wg sync.WaitGroup
 }
 
-// NewFsNotifyWatcher returns a new fsNotifyWatcher
+// NewFileInfoWatcher returns a new fileInfoWatcher
 func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger) Watcher {
 	fiw := &fileInfoWatcher{
 		evChan:   make(chan fsnotify.Event, 32),
@@ -57,12 +57,13 @@ func (f *fileInfoWatcher) Close() error {
 	// signal the timer goroutine to stop and abort any in-flight send, then wait
 	// for it to exit before closing the channels it sends on. Closing before the
 	// goroutine has stopped would race with its sends -> send on closed channel.
+	// stopOnce guards the whole sequence so Close is idempotent.
 	f.stopOnce.Do(func() {
 		close(f.done)
+		f.wg.Wait()
+		close(f.evChan)
+		close(f.erChan)
 	})
-	f.wg.Wait()
-	close(f.evChan)
-	close(f.erChan)
 	return nil
 }
 

--- a/core/pkg/sync/file/fileinfo_watcher.go
+++ b/core/pkg/sync/file/fileinfo_watcher.go
@@ -26,6 +26,13 @@ type fileInfoWatcher struct {
 	// thread-safe interface to underlying files we are watching
 	mu      sync.RWMutex
 	watches map[string]fs.FileInfo // filename -> info
+	// done signals the timer goroutine to stop and aborts any in-flight send,
+	// so Close never closes evChan/erChan while the goroutine is still sending
+	done chan struct{}
+	// stopOnce guards done so Close is safe to call more than once
+	stopOnce sync.Once
+	// wg tracks the timer goroutine so Close can wait for it to exit
+	wg sync.WaitGroup
 }
 
 // NewFsNotifyWatcher returns a new fsNotifyWatcher
@@ -36,6 +43,7 @@ func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger) Watcher {
 		statFunc: getFileInfo,
 		logger:   logger,
 		watches:  make(map[string]fs.FileInfo),
+		done:     make(chan struct{}),
 	}
 	fiw.run(ctx, (1 * time.Second))
 	return fiw
@@ -44,9 +52,15 @@ func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger) Watcher {
 // fileInfoWatcher explicitly implements file.Watcher
 var _ Watcher = &fileInfoWatcher{}
 
-// Close calls close on the underlying fsnotify.Watcher
+// Close stops the timer goroutine and closes the event and error channels
 func (f *fileInfoWatcher) Close() error {
-	// close all channels and exit
+	// signal the timer goroutine to stop and abort any in-flight send, then wait
+	// for it to exit before closing the channels it sends on. Closing before the
+	// goroutine has stopped would race with its sends -> send on closed channel.
+	f.stopOnce.Do(func() {
+		close(f.done)
+	})
+	f.wg.Wait()
 	close(f.evChan)
 	close(f.erChan)
 	return nil
@@ -108,7 +122,9 @@ func (f *fileInfoWatcher) Errors() chan error {
 // run is a blocking function that starts the filewatcher's timer thread
 func (f *fileInfoWatcher) run(ctx context.Context, s time.Duration) {
 	// timer thread
+	f.wg.Add(1)
 	go func() {
+		defer f.wg.Done()
 		// execute update on the configured interval of time
 		ticker := time.NewTicker(s)
 		defer ticker.Stop()
@@ -117,9 +133,14 @@ func (f *fileInfoWatcher) run(ctx context.Context, s time.Duration) {
 			select {
 			case <-ctx.Done():
 				return
+			case <-f.done:
+				return
 			case <-ticker.C:
 				if err := f.update(); err != nil {
-					f.erChan <- err
+					select {
+					case f.erChan <- err:
+					case <-f.done:
+					}
 					return
 				}
 			}
@@ -137,9 +158,13 @@ func (f *fileInfoWatcher) update() error {
 			// if the file isn't there, it must have been removed
 			// fire off a remove event and remove it from the watches
 			if errors.Is(err, os.ErrNotExist) {
-				f.evChan <- fsnotify.Event{
+				select {
+				case f.evChan <- fsnotify.Event{
 					Name: path,
 					Op:   fsnotify.Remove,
+				}:
+				case <-f.done:
+					return nil
 				}
 				delete(f.watches, path)
 				continue
@@ -151,7 +176,11 @@ func (f *fileInfoWatcher) update() error {
 		if info != newInfo {
 			event := f.generateEvent(path, newInfo)
 			if event != nil {
-				f.evChan <- *event
+				select {
+				case f.evChan <- *event:
+				case <-f.done:
+					return nil
+				}
 			}
 			f.watches[path] = newInfo
 		}

--- a/core/pkg/sync/file/fileinfo_watcher_test.go
+++ b/core/pkg/sync/file/fileinfo_watcher_test.go
@@ -70,9 +70,9 @@ func Test_fileInfoWatcher_Close_racesWithTimer(t *testing.T) {
 		t.Errorf("second fileInfoWatcher.Close() error = %v", err)
 	}
 
-	// Close must have stopped the timer goroutine and closed both channels;
-	// draining the events chan blocks forever unless it is closed
 	for range watcher.Events() {
+	    // Close must have stopped the timer goroutine and closed both channels;
+	    // draining the (buffered) events chan blocks forever unless it is closed
 	}
 	if _, ok := <-watcher.Errors(); ok {
 		t.Error("fileInfoWatcher.Close() failed to close error chan")

--- a/core/pkg/sync/file/fileinfo_watcher_test.go
+++ b/core/pkg/sync/file/fileinfo_watcher_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -35,6 +36,37 @@ func Test_fileInfoWatcher_Close(t *testing.T) {
 				t.Error("fileInfoWatcher.Close() failed to close events chan")
 			}
 		})
+	}
+}
+
+// Test_fileInfoWatcher_Close_racesWithTimer ensures Close does not panic with
+// "send on closed channel" when the timer goroutine is actively emitting events.
+// Close must stop that goroutine before closing the channels it sends on.
+func Test_fileInfoWatcher_Close_racesWithTimer(t *testing.T) {
+	watcher := makeTestWatcher(t, map[string]fs.FileInfo{
+		"foo": &mockFileInfo{name: "foo", modTime: time.Now()},
+	})
+	// every stat reports a newer modtime, so update() emits a Write event on
+	// every tick, keeping the timer goroutine busy sending on evChan
+	watcher.statFunc = func(_ string) (fs.FileInfo, error) {
+		return &mockFileInfo{name: "foo", modTime: time.Now().Add(time.Hour)}, nil
+	}
+
+	// nothing reads Events()/Errors(), so the buffer fills and the goroutine ends
+	// up blocked mid-send, which is exactly when the unguarded Close() panicked
+	watcher.run(context.Background(), time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+
+	if err := watcher.Close(); err != nil {
+		t.Errorf("fileInfoWatcher.Close() error = %v", err)
+	}
+
+	// Close must have stopped the timer goroutine and closed both channels;
+	// draining the (buffered) events chan blocks forever unless it is closed
+	for range watcher.Events() {
+	}
+	if _, ok := <-watcher.Errors(); ok {
+		t.Error("fileInfoWatcher.Close() failed to close error chan")
 	}
 }
 
@@ -200,6 +232,7 @@ func makeTestWatcher(t *testing.T, watches map[string]fs.FileInfo) *fileInfoWatc
 		evChan:  make(chan fsnotify.Event, 512),
 		erChan:  make(chan error, 512),
 		watches: watches,
+		done:    make(chan struct{}),
 	}
 }
 

--- a/core/pkg/sync/file/fileinfo_watcher_test.go
+++ b/core/pkg/sync/file/fileinfo_watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,23 +47,31 @@ func Test_fileInfoWatcher_Close_racesWithTimer(t *testing.T) {
 	watcher := makeTestWatcher(t, map[string]fs.FileInfo{
 		"foo": &mockFileInfo{name: "foo", modTime: time.Now()},
 	})
-	// every stat reports a newer modtime, so update() emits a Write event on
-	// every tick, keeping the timer goroutine busy sending on evChan
+	// an unbuffered event chan with no reader forces the timer goroutine to block
+	// mid-send, which is exactly when the unguarded Close() panicked
+	watcher.evChan = make(chan fsnotify.Event)
+	statCalled := make(chan struct{})
+	var statOnce sync.Once
+	// every stat reports a newer modtime, so update() emits a Write event and
+	// blocks on the send; statCalled signals the goroutine has reached update()
 	watcher.statFunc = func(_ string) (fs.FileInfo, error) {
+		statOnce.Do(func() { close(statCalled) })
 		return &mockFileInfo{name: "foo", modTime: time.Now().Add(time.Hour)}, nil
 	}
 
-	// nothing reads Events()/Errors(), so the buffer fills and the goroutine ends
-	// up blocked mid-send, which is exactly when the unguarded Close() panicked
 	watcher.run(context.Background(), time.Millisecond)
-	time.Sleep(20 * time.Millisecond)
+	<-statCalled
 
 	if err := watcher.Close(); err != nil {
 		t.Errorf("fileInfoWatcher.Close() error = %v", err)
 	}
+	// Close is idempotent: a second call must not panic on a re-closed channel
+	if err := watcher.Close(); err != nil {
+		t.Errorf("second fileInfoWatcher.Close() error = %v", err)
+	}
 
 	// Close must have stopped the timer goroutine and closed both channels;
-	// draining the (buffered) events chan blocks forever unless it is closed
+	// draining the events chan blocks forever unless it is closed
 	for range watcher.Events() {
 	}
 	if _, ok := <-watcher.Errors(); ok {


### PR DESCRIPTION

The `FILEINFO` file watcher (`core/pkg/sync/file/fileinfo_watcher.go`) can crash flagd with `panic: send on closed channel` at shutdown.

The watcher's timer goroutine is the sole sender on `evChan` and `erChan`, but `Close()` closed both channels without coordinating with that goroutine. If the ticker fires while `Close()` runs, the goroutine can be mid-send on `evChan` and hit the panic. The realistic trigger is `filepath` `Sync()` returning on context cancel: its `defer fs.watcher.Close()` runs while the same context is stopping the timer goroutine, so a send can still be in flight exactly as the channel is closed.

This only affects the non-default `fileinfo` watcher (selected by `watchType == "fileinfo"`); the default `fsnotify` watcher is unaffected. The window is narrow, but the panic is unrecovered and takes the process down.

### Fix

`Close()` now stops the timer goroutine before it closes the channels the goroutine sends on:

- Add a `done` channel (closed once, guarded by a `sync.Once`) and a `sync.WaitGroup` to `fileInfoWatcher`.
- `Close()` signals `done`, waits for the goroutine to exit (`wg.Wait()`), and only then closes `evChan`/`erChan`, so no send can race with the close.
- `done` is also added to the timer goroutine's `select` and to every send in `update()`, so an in-flight send is aborted promptly and shutdown cannot deadlock on a full, unread buffer.

No happy-path behavior changes.

### Changes

- `core/pkg/sync/file/fileinfo_watcher.go`: add `done`/`stopOnce`/`wg`; make `Close()` stop-then-close; make the timer goroutine and the three sends (`erChan` in `run`, both `evChan` sends in `update`) abortable on `done`.
- `core/pkg/sync/file/fileinfo_watcher_test.go`: add `Test_fileInfoWatcher_Close_racesWithTimer`, which drives the timer at a fast tick with a stat func that emits an event every tick, then calls `Close()` with no reader draining the channels. It panics before this change and passes after. `makeTestWatcher` gains the `done` field so the existing close test keeps compiling.

### Notes

- `make test-core` (`-race`), `golangci-lint` v2.7.2, and `gofmt` all pass locally; `core/pkg/sync/file` coverage is ~69.9% and the full `core/pkg/...` `-race` suite has no regressions.
- The new test is red -> green: reverting only the `Close`/`run`/`update` coordination (keeping the field so it compiles) reproduces the exact `panic: send on closed channel`; with the fix it is race-clean across repeated runs.
