### PR TITLE
fix(eventing): prevent send on closed channel in EmitToAll

### DIFF
--- a/flagd/pkg/service/flag-evaluation/connect_service.go
+++ b/flagd/pkg/service/flag-evaluation/connect_service.go
@@ -81,7 +81,7 @@ func NewConnectService(
 		eval:    evaluator,
 		metrics: &telemetry.NoopMetricsRecorder{},
 		eventingConfiguration: &eventingConfiguration{
-			subs:   make(map[interface{}]chan service.Notification),
+			subs:   make(map[interface{}]*subscription),
 			mu:     &sync.RWMutex{},
 			store:  store,
 			logger: logger,

--- a/flagd/pkg/service/flag-evaluation/connect_service_test.go
+++ b/flagd/pkg/service/flag-evaluation/connect_service_test.go
@@ -237,7 +237,7 @@ func TestConnectServiceWatcher(t *testing.T) {
 		store:  s,
 		logger: log,
 		mu:     &sync.RWMutex{},
-		subs:   make(map[any]chan iservice.Notification),
+		subs:   make(map[any]*subscription),
 	}
 
 	// subscribe and wait for for the sub to be active

--- a/flagd/pkg/service/flag-evaluation/eventing.go
+++ b/flagd/pkg/service/flag-evaluation/eventing.go
@@ -45,6 +45,13 @@ func (s *subscription) send(n iservice.Notification) {
 		return
 	}
 
+	// if the subscription is already stopped, deliver nothing;
+	select {
+	case <-s.done:
+		return
+	default:
+	}
+
 	select {
 	case s.notifier <- n:
 	case <-s.done:

--- a/flagd/pkg/service/flag-evaluation/eventing.go
+++ b/flagd/pkg/service/flag-evaluation/eventing.go
@@ -24,14 +24,53 @@ var _ IEvents = &eventingConfiguration{}
 // eventingConfiguration is a wrapper for notification subscriptions
 type eventingConfiguration struct {
 	mu     *sync.RWMutex
-	subs   map[any]chan iservice.Notification
+	subs   map[any]*subscription
 	store  store.IStore
 	logger *logger.Logger
+}
+
+type subscription struct {
+	mu       sync.Mutex
+	notifier chan iservice.Notification
+	done     chan struct{}
+	stopOnce sync.Once
+	closed   bool
+}
+
+func (s *subscription) send(n iservice.Notification) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return
+	}
+
+	select {
+	case s.notifier <- n:
+	case <-s.done:
+	}
+}
+
+func (s *subscription) close() {
+	s.stop()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.closed {
+		close(s.notifier)
+		s.closed = true
+	}
+}
+
+func (s *subscription) stop() {
+	s.stopOnce.Do(func() { close(s.done) })
 }
 
 func (eventing *eventingConfiguration) Subscribe(ctx context.Context, id any, selector *store.Selector, notifier chan iservice.Notification) {
 	eventing.mu.Lock()
 	defer eventing.mu.Unlock()
+	sub := &subscription{notifier: notifier, done: make(chan struct{})}
 
 	// proxy events from our store watcher to the notify channel, so that RPC mode event streams
 	watcher := make(chan store.FlagQueryResult, 1)
@@ -53,37 +92,50 @@ func (eventing *eventingConfiguration) Subscribe(ctx context.Context, id any, se
 					oldFlags = newFlags
 					continue
 				}
-				notifier <- iservice.Notification{
+				sub.send(iservice.Notification{
 					Type: iservice.ConfigurationChange,
 					Data: map[string]interface{}{
 						// don't use our custom type or it cannot be serialized, convert to map
 						"flags": map[string]interface{}(notifications),
 					},
-				}
+				})
 			}
 			oldFlags = newFlags
 		}
 
 		eventing.logger.Debug(fmt.Sprintf("closing notify channel for id %v", id))
-		close(notifier)
+		eventing.mu.Lock()
+		if eventing.subs[id] == sub {
+			delete(eventing.subs, id)
+		}
+		eventing.mu.Unlock()
+		sub.close()
 	}()
 
 	eventing.store.Watch(ctx, selector, watcher)
-	eventing.subs[id] = notifier
+	eventing.subs[id] = sub
 }
 
 func (eventing *eventingConfiguration) EmitToAll(n iservice.Notification) {
 	eventing.mu.RLock()
-	defer eventing.mu.RUnlock()
+	subs := make([]*subscription, 0, len(eventing.subs))
+	for _, sub := range eventing.subs {
+		subs = append(subs, sub)
+	}
+	eventing.mu.RUnlock()
 
-	for _, send := range eventing.subs {
-		send <- n
+	for _, sub := range subs {
+		sub.send(n)
 	}
 }
 
 func (eventing *eventingConfiguration) Unsubscribe(id any) {
 	eventing.mu.Lock()
-	defer eventing.mu.Unlock()
-
+	sub := eventing.subs[id]
 	delete(eventing.subs, id)
+	eventing.mu.Unlock()
+
+	if sub != nil {
+		sub.stop()
+	}
 }

--- a/flagd/pkg/service/flag-evaluation/eventing_test.go
+++ b/flagd/pkg/service/flag-evaluation/eventing_test.go
@@ -137,72 +137,44 @@ func TestNoNotificationWhenFlagsUnchanged(t *testing.T) {
 	}
 }
 
-// TestEmitToAllVsSubscriberCancel is a regression test for a data race between
-// EmitToAll and the per-subscription goroutine that closes the notifier channel
-// on context cancellation. The subscription goroutine closes the notifier when
-// its store watcher stops (the store closes the watcher on ctx cancel), but that
-// close is independent of Unsubscribe. If the notifier is closed while it is
-// still present in subs, a concurrent EmitToAll sends on a closed channel and
-// panics ("send on closed channel"), which crashes the whole flagd process.
-// This is the exact interleaving ConnectService.Shutdown forces: it broadcasts a
-// Shutdown notification via EmitToAll precisely as the shared context is being
-// cancelled and every subscription is tearing down. Run with -race.
+// TestEmitToAllVsSubscriberCancel checks EmitToAll racing subscriber
+// cancellation (which closes notifiers) never sends on a closed channel.
 func TestEmitToAllVsSubscriberCancel(t *testing.T) {
-	eventing, _ := newTestEventingConfig(t, []string{"source1", "source2"})
+	// cancelling subscribers while hammering EmitToAll must not panic.
+	eventing, _ := newTestEventingConfig(t, []string{"source1"})
 
-	const subscribers = 50
-	cancels := make([]context.CancelFunc, 0, subscribers)
-	var drainers sync.WaitGroup
-
-	for i := 0; i < subscribers; i++ {
+	var drain, work sync.WaitGroup
+	cancels := make([]context.CancelFunc, 0, 50)
+	for i := 0; i < 50; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancels = append(cancels, cancel)
-
-		notifier := make(chan iservice.Notification, 1)
-		eventing.Subscribe(ctx, i, nil, notifier)
-
-		// Drain the notifier so EmitToAll never blocks on a full buffer, and so
-		// the range exits when the subscription goroutine closes the channel.
-		drainers.Add(1)
+		ch := make(chan iservice.Notification, 1)
+		eventing.Subscribe(ctx, i, nil, ch)
+		drain.Add(1)
 		go func() {
-			defer drainers.Done()
-			for range notifier {
-				// Drain until cancellation closes the notifier.
+			defer drain.Done()
+			for range ch { //nolint:revive // drain so EmitToAll never blocks on a full buffer
 			}
 		}()
 	}
+	time.Sleep(50 * time.Millisecond) // let subscription goroutines start watching
 
-	// Let the subscription goroutines start watching before we cancel them.
-	time.Sleep(50 * time.Millisecond)
-
-	var workers sync.WaitGroup
-
-	// Cancel every subscriber context: each cancel makes the store close the
-	// watcher, which makes the subscription goroutine close its notifier.
-	workers.Add(1)
+	work.Add(2)
 	go func() {
-		defer workers.Done()
-		for _, cancel := range cancels {
-			cancel()
+		defer work.Done()
+		for _, c := range cancels {
+			c() // cancel -> store closes watcher -> goroutine closes notifier
 		}
 	}()
-
-	// Concurrently hammer EmitToAll. Before the fix this reproducibly panics
-	// with "send on closed channel" when it sends to a notifier that the
-	// subscription goroutine has already closed but not removed from subs.
-	workers.Add(1)
 	go func() {
-		defer workers.Done()
+		defer work.Done()
 		for i := 0; i < 200; i++ {
+			// hammer EmitToAll into the teardown; panics before the fix
 			eventing.EmitToAll(iservice.Notification{Type: iservice.Shutdown})
 		}
 	}()
-
-	workers.Wait()
-
-	// Cancelling the contexts closes every notifier; wait for the drainers so
-	// the test does not leak goroutines and the race detector sees clean exits.
-	drainers.Wait()
+	work.Wait()
+	drain.Wait()
 }
 
 func TestBlockedSubscriberDoesNotBlockCleanup(t *testing.T) {
@@ -251,5 +223,29 @@ func TestBlockedSubscriberDoesNotBlockCleanup(t *testing.T) {
 	case <-emitDone:
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for EmitToAll to stop after cancellation")
+	}
+}
+
+func TestNoDeliveryAfterUnsubscribe(t *testing.T) {
+	// nothing should be delivered after Unsubscribe returns.
+	// looped because the unfixed select only leaks ~50% of the time.
+	for i := 0; i < 50; i++ {
+		eventing, _ := newTestEventingConfig(t, []string{"source1"})
+		ch := make(chan iservice.Notification, 1)
+		eventing.Subscribe(context.Background(), "id", nil, ch)
+		sub := eventing.subs["id"]
+
+		sub.mu.Lock() // park EmitToAll's send after it snapshots this sub
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			eventing.EmitToAll(iservice.Notification{Type: iservice.ConfigurationChange})
+		}()
+		time.Sleep(20 * time.Millisecond)
+		eventing.Unsubscribe("id") // closes done while the send is parked
+		sub.mu.Unlock()
+
+		<-done
+		require.Empty(t, ch, "notification delivered after Unsubscribe returned")
 	}
 }

--- a/flagd/pkg/service/flag-evaluation/eventing_test.go
+++ b/flagd/pkg/service/flag-evaluation/eventing_test.go
@@ -21,7 +21,7 @@ func newTestEventingConfig(t *testing.T, sources []string) (*eventingConfigurati
 	s, err := store.NewStore(log, sources)
 	require.NoError(t, err)
 	return &eventingConfiguration{
-		subs:   make(map[interface{}]chan iservice.Notification),
+		subs:   make(map[interface{}]*subscription),
 		mu:     &sync.RWMutex{},
 		store:  s,
 		logger: log,
@@ -43,8 +43,8 @@ func TestSubscribe(t *testing.T) {
 	eventing.Subscribe(context.Background(), idB, nil, chanB)
 
 	// then
-	require.Equal(t, chanA, eventing.subs[idA], "incorrect subscription association")
-	require.Equal(t, chanB, eventing.subs[idB], "incorrect subscription association")
+	require.Equal(t, chanA, eventing.subs[idA].notifier, "incorrect subscription association")
+	require.Equal(t, chanB, eventing.subs[idB].notifier, "incorrect subscription association")
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -65,7 +65,7 @@ func TestUnsubscribe(t *testing.T) {
 	// then
 	require.Empty(t, eventing.subs[idA],
 		"expected subscription cleared, but value present: %v", eventing.subs[idA])
-	require.Equal(t, chanB, eventing.subs[idB], "incorrect subscription association")
+	require.Equal(t, chanB, eventing.subs[idB].notifier, "incorrect subscription association")
 }
 
 // TestNotificationCompatibleWithStructpb verifies that notification data from
@@ -134,5 +134,122 @@ func TestNoNotificationWhenFlagsUnchanged(t *testing.T) {
 		t.Fatalf("unexpected notification received: %v", n)
 	case <-time.After(500 * time.Millisecond):
 		// expected: no notification sent
+	}
+}
+
+// TestEmitToAllVsSubscriberCancel is a regression test for a data race between
+// EmitToAll and the per-subscription goroutine that closes the notifier channel
+// on context cancellation. The subscription goroutine closes the notifier when
+// its store watcher stops (the store closes the watcher on ctx cancel), but that
+// close is independent of Unsubscribe. If the notifier is closed while it is
+// still present in subs, a concurrent EmitToAll sends on a closed channel and
+// panics ("send on closed channel"), which crashes the whole flagd process.
+// This is the exact interleaving ConnectService.Shutdown forces: it broadcasts a
+// Shutdown notification via EmitToAll precisely as the shared context is being
+// cancelled and every subscription is tearing down. Run with -race.
+func TestEmitToAllVsSubscriberCancel(t *testing.T) {
+	eventing, _ := newTestEventingConfig(t, []string{"source1", "source2"})
+
+	const subscribers = 50
+	cancels := make([]context.CancelFunc, 0, subscribers)
+	var drainers sync.WaitGroup
+
+	for i := 0; i < subscribers; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels = append(cancels, cancel)
+
+		notifier := make(chan iservice.Notification, 1)
+		eventing.Subscribe(ctx, i, nil, notifier)
+
+		// Drain the notifier so EmitToAll never blocks on a full buffer, and so
+		// the range exits when the subscription goroutine closes the channel.
+		drainers.Add(1)
+		go func() {
+			defer drainers.Done()
+			for range notifier {
+				// Drain until cancellation closes the notifier.
+			}
+		}()
+	}
+
+	// Let the subscription goroutines start watching before we cancel them.
+	time.Sleep(50 * time.Millisecond)
+
+	var workers sync.WaitGroup
+
+	// Cancel every subscriber context: each cancel makes the store close the
+	// watcher, which makes the subscription goroutine close its notifier.
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}()
+
+	// Concurrently hammer EmitToAll. Before the fix this reproducibly panics
+	// with "send on closed channel" when it sends to a notifier that the
+	// subscription goroutine has already closed but not removed from subs.
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		for i := 0; i < 200; i++ {
+			eventing.EmitToAll(iservice.Notification{Type: iservice.Shutdown})
+		}
+	}()
+
+	workers.Wait()
+
+	// Cancelling the contexts closes every notifier; wait for the drainers so
+	// the test does not leak goroutines and the race detector sees clean exits.
+	drainers.Wait()
+}
+
+func TestBlockedSubscriberDoesNotBlockCleanup(t *testing.T) {
+	eventing, _ := newTestEventingConfig(t, []string{"source1"})
+
+	stalledCtx, cancelStalled := context.WithCancel(context.Background())
+	stalledNotifier := make(chan iservice.Notification)
+	eventing.Subscribe(stalledCtx, "stalled", nil, stalledNotifier)
+	stalledSub := eventing.subs["stalled"]
+
+	emitDone := make(chan struct{})
+	go func() {
+		defer close(emitDone)
+		eventing.EmitToAll(iservice.Notification{Type: iservice.Shutdown})
+	}()
+
+	require.Eventually(t, func() bool {
+		if stalledSub.mu.TryLock() {
+			stalledSub.mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond, "EmitToAll did not block on the stalled subscriber")
+
+	otherCtx, cancelOther := context.WithCancel(context.Background())
+	otherNotifier := make(chan iservice.Notification, 1)
+	eventing.Subscribe(otherCtx, "other", nil, otherNotifier)
+	cancelOther()
+
+	require.Eventually(t, func() bool {
+		eventing.mu.RLock()
+		defer eventing.mu.RUnlock()
+		_, ok := eventing.subs["other"]
+		return !ok
+	}, time.Second, time.Millisecond, "other subscriber cleanup was blocked")
+
+	select {
+	case _, ok := <-otherNotifier:
+		require.False(t, ok, "other subscriber notifier was not closed")
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for other subscriber notifier to close")
+	}
+
+	cancelStalled()
+	select {
+	case <-emitDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for EmitToAll to stop after cancellation")
 	}
 }


### PR DESCRIPTION
### this pr

fixes a lifecycle race in rpc eventing that can panic with `send on closed channel` when subscriber cancellation overlaps `EmitToAll`.

### the fix

- keep each notifier and its lifecycle state in a subscription object
- serialize sends with notifier closure so a closed channel is never selected for a send
- snapshot subscriptions under the map lock, then release it before potentially blocking sends
- let unsubscribe interrupt a blocked send, preserving blocking delivery for active subscribers without allowing one stalled subscriber to block unrelated cleanup
- avoid deleting a newer subscription if an id is reused

### testing

adds regression coverage for cancellation racing with repeated broadcasts and for one stalled subscriber not blocking another subscriber's cleanup.

- `make test`
- `go test -race ./flagd/pkg/service/flag-evaluation/...`
- `gofmt` on changed files
- `make lint` (changed files clean; existing staticcheck findings remain in untouched files)
