### PR TITLE
fix(certreloader): re-check reload condition under write lock

### DIFF
--- a/core/pkg/certreloader/certreloader.go
+++ b/core/pkg/certreloader/certreloader.go
@@ -48,19 +48,28 @@ func (r *CertReloader) GetCertificate() (*tls.Certificate, error) {
 		// Need to release the read lock, otherwise we deadlock
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		cert, err := r.loadCertificate()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load TLS cert and key: %w", err)
+		// Re-check the condition now that we hold the write lock: a concurrent
+		// caller may have already reloaded while we were blocked, in which case
+		// we skip the redundant reload (double-checked locking).
+		if r.ReloadInterval != 0 && r.nextReload.Before(now) {
+			cert, err := r.loadCertificate()
+			if err != nil {
+				return nil, fmt.Errorf("failed to load TLS cert and key: %w", err)
+			}
+			r.cert = &cert
+			r.nextReload = now.Add(r.ReloadInterval)
 		}
-		r.cert = &cert
-		r.nextReload = now.Add(r.ReloadInterval)
 		return r.cert, nil
 	}
 	return r.cert, nil
 }
 
+// loadX509KeyPair loads a certificate/key pair from disk. It is a package
+// variable so tests can observe reloads; production always uses the stdlib.
+var loadX509KeyPair = tls.LoadX509KeyPair
+
 func (r *CertReloader) loadCertificate() (tls.Certificate, error) {
-	newCert, err := tls.LoadX509KeyPair(r.CertPath, r.KeyPath)
+	newCert, err := loadX509KeyPair(r.CertPath, r.KeyPath)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("failed to load key pair: %w", err)
 	}

--- a/core/pkg/certreloader/certreloader.go
+++ b/core/pkg/certreloader/certreloader.go
@@ -48,9 +48,7 @@ func (r *CertReloader) GetCertificate() (*tls.Certificate, error) {
 		// Need to release the read lock, otherwise we deadlock
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		// Re-check the condition now that we hold the write lock: a concurrent
-		// caller may have already reloaded while we were blocked, in which case
-		// we skip the redundant reload (double-checked locking).
+		// re-check under the write lock; a concurrent caller may have already reloaded
 		if r.ReloadInterval != 0 && r.nextReload.Before(now) {
 			cert, err := r.loadCertificate()
 			if err != nil {
@@ -64,8 +62,7 @@ func (r *CertReloader) GetCertificate() (*tls.Certificate, error) {
 	return r.cert, nil
 }
 
-// loadX509KeyPair loads a certificate/key pair from disk. It is a package
-// variable so tests can observe reloads; production always uses the stdlib.
+// loadX509KeyPair is a package var so tests can observe reloads; prod uses the stdlib
 var loadX509KeyPair = tls.LoadX509KeyPair
 
 func (r *CertReloader) loadCertificate() (tls.Certificate, error) {

--- a/core/pkg/certreloader/certreloader_test.go
+++ b/core/pkg/certreloader/certreloader_test.go
@@ -13,6 +13,8 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -147,6 +149,66 @@ func TestCertificateReload(t *testing.T) {
 				t.Fatalf("expected certificate was not returned by GetCertificate. expectedCert: %v, actualCert: %v", expectedCertParsed.DNSNames[0], actualCertParsed.DNSNames[0])
 			}
 		})
+	}
+}
+
+// TestConcurrentCertificateReload verifies that when many goroutines call
+// GetCertificate concurrently after the reload interval has elapsed, the
+// certificate is reloaded from disk exactly once. GetCertificate is wired as
+// tls.Config.GetCertificate and is invoked in parallel per handshake, so a
+// missing second check under the write lock makes every racing caller reload
+// (a thundering herd of redundant disk reads), which this test guards against.
+func TestConcurrentCertificateReload(t *testing.T) {
+	cert, key, cleanup := generateValidCertificateFiles(t)
+	defer cleanup()
+
+	reloader, err := NewCertReloader(Config{
+		CertPath:       cert,
+		KeyPath:        key,
+		ReloadInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var reloads int32
+	original := loadX509KeyPair
+	loadX509KeyPair = func(certFile, keyFile string) (tls.Certificate, error) {
+		atomic.AddInt32(&reloads, 1)
+		return original(certFile, keyFile)
+	}
+	defer func() { loadX509KeyPair = original }()
+
+	// Hold the write lock so every caller parks on the read lock inside
+	// GetCertificate. Releasing it lets them all evaluate the reload condition
+	// together (readers run concurrently), reproducing the case where several
+	// callers see a reload is due within the same interval window.
+	reloader.mu.Lock()
+	reloader.nextReload = time.Now().Add(-time.Hour)
+
+	const callers = 50
+	var started, wg sync.WaitGroup
+	started.Add(callers)
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			started.Done()
+			if _, err := reloader.GetCertificate(); err != nil {
+				t.Errorf("GetCertificate returned error: %s", err)
+			}
+		}()
+	}
+
+	// Wait for every goroutine to be running, then give them a moment to block
+	// on the read lock before releasing it.
+	started.Wait()
+	time.Sleep(50 * time.Millisecond)
+	reloader.mu.Unlock()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&reloads); got != 1 {
+		t.Fatalf("expected exactly 1 reload for %d concurrent callers past the interval, got %d", callers, got)
 	}
 }
 

--- a/core/pkg/certreloader/certreloader_test.go
+++ b/core/pkg/certreloader/certreloader_test.go
@@ -152,12 +152,8 @@ func TestCertificateReload(t *testing.T) {
 	}
 }
 
-// TestConcurrentCertificateReload verifies that when many goroutines call
-// GetCertificate concurrently after the reload interval has elapsed, the
-// certificate is reloaded from disk exactly once. GetCertificate is wired as
-// tls.Config.GetCertificate and is invoked in parallel per handshake, so a
-// missing second check under the write lock makes every racing caller reload
-// (a thundering herd of redundant disk reads), which this test guards against.
+// TestConcurrentCertificateReload verifies that many concurrent callers past the
+// reload interval reload the cert from disk exactly once, not once per caller.
 func TestConcurrentCertificateReload(t *testing.T) {
 	cert, key, cleanup := generateValidCertificateFiles(t)
 	defer cleanup()
@@ -179,10 +175,8 @@ func TestConcurrentCertificateReload(t *testing.T) {
 	}
 	defer func() { loadX509KeyPair = original }()
 
-	// Hold the write lock so every caller parks on the read lock inside
-	// GetCertificate. Releasing it lets them all evaluate the reload condition
-	// together (readers run concurrently), reproducing the case where several
-	// callers see a reload is due within the same interval window.
+	// hold the write lock so all callers park on the read lock, then release to
+	// let them evaluate the reload condition together
 	reloader.mu.Lock()
 	reloader.nextReload = time.Now().Add(-time.Hour)
 
@@ -200,8 +194,7 @@ func TestConcurrentCertificateReload(t *testing.T) {
 		}()
 	}
 
-	// Wait for every goroutine to be running, then give them a moment to block
-	// on the read lock before releasing it.
+	// wait for all goroutines to run, then let them block on the read lock before releasing
 	started.Wait()
 	time.Sleep(50 * time.Millisecond)
 	reloader.mu.Unlock()


### PR DESCRIPTION

## This PR

`GetCertificate` in `core/pkg/certreloader/certreloader.go` uses a
double-checked-locking pattern, but the second check is missing. It reads the
reload condition under the read lock, releases it, takes the write lock, and then
reloads the key pair from disk **unconditionally**:

```go
r.mu.RLock()
shouldReload := r.ReloadInterval != 0 && r.nextReload.Before(now)
r.mu.RUnlock()
if shouldReload {
    r.mu.Lock()
    defer r.mu.Unlock()
    cert, err := r.loadCertificate() // always runs, even if another caller just reloaded
    ...
    r.cert = &cert
    r.nextReload = now.Add(r.ReloadInterval)
    return r.cert, nil
}
```

The function's own comment states the intended behavior:

> If a reload is in progress this will block and we will skip reloading in the
> current call once we can continue

but nothing skips: after blocking on `r.mu.Lock()`, every caller that passed the
read-lock check calls `loadCertificate()` again.

`GetCertificate` is wired as `tls.Config.GetCertificate`, which the standard
library invokes per handshake and can run in parallel. So once `ReloadInterval`
has elapsed, a burst of concurrent handshakes all pass the read-lock check, then
each grabs the write lock in turn and re-reads and re-parses the cert/key pair
from disk, even though the first caller already reloaded and advanced
`nextReload`. That is a thundering herd of redundant disk reads at every reload
boundary on a busy TLS listener.

This is not a correctness/crash bug: access is serialized by the lock and the
served certificate is always valid. It defeats the single-reload optimization the
code is clearly trying to implement.

## The fix

Add the missing second check inside the write-locked critical section, so only
the first caller past the interval reloads and the rest return the
already-loaded certificate:

```go
r.mu.Lock()
defer r.mu.Unlock()
if r.ReloadInterval != 0 && r.nextReload.Before(now) {
    cert, err := r.loadCertificate()
    ...
    r.cert = &cert
    r.nextReload = now.Add(r.ReloadInterval)
}
return r.cert, nil
```

The re-check reuses `now` captured at the top of the function. The first caller
sets `nextReload = now.Add(ReloadInterval)`; any caller that was blocked on the
write lock observes a `now` no earlier than the first caller's, so for any real
interval its re-check is false and it correctly skips. Production behavior is
otherwise unchanged: a single caller past the interval still reloads exactly as
before.

To make the behavior testable, `tls.LoadX509KeyPair` is called through a
package-level variable (`var loadX509KeyPair = tls.LoadX509KeyPair`) so a test
can count reloads. Production always uses the stdlib function; this is a one-line
seam plus one changed call site, and the runtime path is byte-identical.

## Testing

Adds `TestConcurrentCertificateReload`, which fires 50 concurrent
`GetCertificate` calls past the interval and asserts the cert is reloaded from
disk exactly once. It parks all callers on the read lock, releases them together
so they evaluate the reload condition concurrently, and counts reloads via the
seam.

```
cd core
go build ./...
go test -race -covermode=atomic -cover -short ./pkg/certreloader/...
```

All green under `-race` (stable over repeated runs). Package coverage for
`core/pkg/certreloader` is 92.6%. `golangci-lint` (repo-pinned v2.7.2) reports 0
issues on the package.

Red/green: with only the new write-lock re-check reverted, the test reports 50
reloads for 50 concurrent callers and fails; with the fix it reports exactly 1.
