### PR TITLE
feat(sync): configurable gRPC keepalive enforcement on sync server

### DIFF
--- a/docs/architecture-decisions/sync-server-keepalive-enforcement.md
+++ b/docs/architecture-decisions/sync-server-keepalive-enforcement.md
@@ -1,0 +1,127 @@
+---
+# Valid statuses: draft | proposed | rejected | accepted | superseded
+status: proposed
+author: Jason Benedicic (@jabenedicic)
+created: 2026-07-14
+updated: 2026-07-14
+---
+# gRPC keepalive enforcement on the flag-sync server
+
+The flag-sync gRPC server currently sets no keepalive enforcement policy, so it
+inherits grpc-go's defaults, which are tuned for generic request/response RPC
+rather than a long-lived streaming sync. Clients that ping to keep the sync
+stream alive can be disconnected with `GOAWAY ENHANCE_YOUR_CALM`. This ADR
+proposes setting a streaming-appropriate enforcement policy on the server, with
+sane defaults and operator-facing overrides.
+Tracking issue: [#1998](https://github.com/open-feature/flagd/issues/1998).
+
+## Background
+
+flagd's in-process mode has providers consume a long-lived `SyncFlags` gRPC
+stream from the flag-sync server. gRPC clients keep such streams healthy by
+sending periodic keepalive pings, especially during idle periods when no flag
+changes are flowing.
+
+gRPC servers enforce a *keepalive enforcement policy* that decides how often a
+client is allowed to ping. grpc-go's default is `MinTime: 5m` with
+`PermitWithoutStream: false`: a client may ping at most once every five minutes,
+and only while it has an active stream. A client that exceeds this — pings more
+often, or pings during a gap with no active RPC — accrues "ping strikes", and
+after a small number the server sends `GOAWAY` with `ENHANCE_YOUR_CALM` /
+`too_many_pings` and closes the connection. Those defaults suit short unary RPC
+traffic; they are a poor fit for a service whose primary job is a long-lived,
+often-idle stream.
+
+The flag-sync server is constructed with a bare `grpc.NewServer(...)` and no
+enforcement policy, so it inherits those defaults. Provider SDKs choose their
+own keepalive cadence, and several ping far more frequently than every five
+minutes to detect dead connections quickly. The Go provider is the clearest
+example — it pings every 30s with `PermitWithoutStream: true` and exposes no
+override — so it is disconnected roughly every 60–90s and must reconnect. This
+is not specific to one provider: any client, in any language, whose keepalive
+interval is shorter than five minutes is exposed to the same teardown, and there
+is no server-side setting today to widen the tolerance.
+
+## Requirements
+
+* The flag-sync server must tolerate the keepalive cadences that provider SDKs
+  use in practice, without emitting `GOAWAY ENHANCE_YOUR_CALM`.
+* The fix must apply to every client language, not one provider.
+* The policy must be operator-configurable (CLI flag and environment variable),
+  so deployments can tune it without a code change.
+* The default must not regress any client that works against flagd today.
+
+## Considered Options
+
+* Set a fixed, streaming-appropriate enforcement policy on the server, exposed
+  via CLI flags / environment variables (chosen).
+* Set a fixed enforcement policy on the server with no configuration surface.
+* Change each language provider's client keepalive settings instead of the
+  server.
+* Leave the server on grpc-go's defaults (status quo).
+
+## Proposal
+
+Set a `KeepaliveEnforcementPolicy` on the flag-sync gRPC server, configurable
+through two new options with defaults chosen to match how providers actually
+keep the stream alive:
+
+* `--keep-alive-min-time` (env `FLAGD_KEEP_ALIVE_MIN_TIME`, duration, default
+  `30s`) — the minimum interval the server permits between client keepalive
+  pings.
+* `--keep-alive-permit-without-stream` (env
+  `FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM`, bool, default `true`) — whether the
+  server permits pings while the client holds no active stream.
+
+The `30s` default matches the tightest keepalive cadence a shipped provider uses
+today; because a ping sent every 30s arrives at the server `30s + RTT` apart, it
+clears a 30s minimum with margin. `PermitWithoutStream: true` is required
+because providers ping during idle gaps when, transiently, no stream is active.
+Both defaults are strictly more permissive than grpc-go's `5m` /
+`PermitWithoutStream: false`, so any client that works against flagd today
+continues to work; clients that were being disconnected stop being disconnected.
+
+Choosing the server as the point of control is deliberate. Keepalive enforcement
+is a property of the server — it is the party that decides how often a client
+may ping — so the server is the correct and complete place to fix a
+too-aggressive default. The alternative, changing keepalive in each provider,
+would require coordinated releases across every provider repository, would not
+help third-party or future clients, and would leave the server rejecting
+reasonable keepalives out of the box. One server-side change covers every client
+in every language.
+
+### API changes
+
+Two new CLI flags on `flagd start`, with matching `FLAGD_`-prefixed environment
+variables, documented in the auto-generated CLI reference. No changes to the
+gRPC or flag-configuration APIs. No wire-format or schema changes.
+
+### Consequences
+
+* Good, because a single server-side change resolves `ENHANCE_YOUR_CALM`
+  disconnects for every provider language at once, at the layer that owns the
+  policy.
+* Good, because the defaults are more permissive than grpc-go's, so no
+  currently-working client regresses.
+* Good, because deployments — including operator-managed flagd — can tune the
+  policy through environment variables or arguments on the flagd container,
+  giving estate-wide, cross-language keepalive tuning from one place, without
+  editing any gRPC client in any workload.
+* Bad, because it adds two configuration options to the flagd surface that
+  operators may need to understand.
+* Bad, because a misconfigured very-low `--keep-alive-min-time` could let a
+  misbehaving client ping more aggressively than intended; the default is
+  conservative and this is opt-in.
+
+### Open questions
+
+* Should the OpenFeature Operator expose these as first-class `Flagd` CRD fields,
+  or is passing them through container env/args sufficient? (Follow-up; out of
+  scope for this change.)
+
+## More Information
+
+* grpc-go keepalive documentation:
+  <https://github.com/grpc/grpc-go/blob/master/Documentation/keepalive.md>
+* Keepalive enforcement and `ENHANCE_YOUR_CALM`:
+  <https://github.com/grpc/grpc/blob/master/doc/keepalive.md>

--- a/docs/reference/flagd-cli/flagd_start.md
+++ b/docs/reference/flagd-cli/flagd_start.md
@@ -16,6 +16,8 @@ flagd start [flags]
   -C, --cors-origin strings                  CORS allowed origins, * will allow all origins
       --disable-sync-metadata                Disables the getMetadata endpoint of the sync service. Defaults to false, but will default to true in later versions.
   -h, --help                                 help for start
+      --keep-alive-min-time duration         Minimum interval the flag sync gRPC server permits between client keepalive pings. Pings arriving more frequently than this are rejected with GOAWAY (ENHANCE_YOUR_CALM). Defaults to 30s. (default 30s)
+      --keep-alive-permit-without-stream     Permit clients of the flag sync gRPC server to send keepalive pings even when there is no active stream. Defaults to true. (default true)
   -z, --log-format string                    Set the logging format, e.g. console or json (default "console")
   -m, --management-port int32                Port for management operations (default 8014)
   -B, --max-request-body int                 Maximum allowed request body size in bytes. Requests exceeding this are rejected with HTTP 413 (OFREP) or 429 (connect). Set to 0 to disable. WARNING: disabling this limit may allow memory exhaustion from oversized requests. (default 1000000)

--- a/flagd/cmd/start.go
+++ b/flagd/cmd/start.go
@@ -42,6 +42,9 @@ const (
 	streamDeadlineFlagName     = "stream-deadline"
 	maxRequestBodyFlagName     = "max-request-body"
 	maxRequestHeaderFlagName   = "max-request-header"
+
+	keepAliveMinTimeFlagName             = "keep-alive-min-time"
+	keepAlivePermitWithoutStreamFlagName = "keep-alive-permit-without-stream"
 )
 
 func init() {
@@ -96,6 +99,8 @@ func init() {
 	flags.Bool(disableSyncMetadata, false, "Disables the getMetadata endpoint of the sync service. Defaults to false, but will default to true in later versions.")
 	flags.Int64P(maxRequestBodyFlagName, "B", 1_000_000, "Maximum allowed request body size in bytes. Requests exceeding this are rejected with HTTP 413 (OFREP) or 429 (connect). Set to 0 to disable. WARNING: disabling this limit may allow memory exhaustion from oversized requests.")
 	flags.Int64P(maxRequestHeaderFlagName, "R", 1_000_000, "Maximum allowed request header size in bytes. Requests exceeding this are rejected with HTTP 431. Set to 0 to use Go's built-in default (1 MiB). WARNING: setting a very large or zero value may allow memory exhaustion from oversized headers.")
+	flags.Duration(keepAliveMinTimeFlagName, 30*time.Second, "Minimum interval the flag sync gRPC server permits between client keepalive pings. Pings arriving more frequently than this are rejected with GOAWAY (ENHANCE_YOUR_CALM). Defaults to 30s.")
+	flags.Bool(keepAlivePermitWithoutStreamFlagName, true, "Permit clients of the flag sync gRPC server to send keepalive pings even when there is no active stream. Defaults to true.")
 
 	bindFlags(flags)
 }
@@ -124,6 +129,8 @@ func bindFlags(flags *pflag.FlagSet) {
 	_ = viper.BindPFlag(disableSyncMetadata, flags.Lookup(disableSyncMetadata))
 	_ = viper.BindPFlag(maxRequestBodyFlagName, flags.Lookup(maxRequestBodyFlagName))
 	_ = viper.BindPFlag(maxRequestHeaderFlagName, flags.Lookup(maxRequestHeaderFlagName))
+	_ = viper.BindPFlag(keepAliveMinTimeFlagName, flags.Lookup(keepAliveMinTimeFlagName))
+	_ = viper.BindPFlag(keepAlivePermitWithoutStreamFlagName, flags.Lookup(keepAlivePermitWithoutStreamFlagName))
 }
 
 // startCmd represents the start command
@@ -190,28 +197,30 @@ var startCmd = &cobra.Command{
 
 		// Build Runtime -----------------------------------------------------------
 		rt, err := runtime.FromConfig(logger, Version, runtime.Config{
-			CORS:                       viper.GetStringSlice(corsFlagName),
-			MetricExporter:             viper.GetString(metricsExporter),
-			ManagementPort:             viper.GetUint16(managementPortFlagName),
-			OfrepServicePort:           viper.GetUint16(ofrepPortFlagName),
-			OtelCollectorURI:           viper.GetString(otelCollectorURI),
-			OtelCertPath:               viper.GetString(otelCertPathFlagName),
-			OtelKeyPath:                viper.GetString(otelKeyPathFlagName),
-			OtelReloadInterval:         viper.GetDuration(otelReloadIntervalFlagName),
-			OtelCAPath:                 viper.GetString(otelCAPathFlagName),
-			ServiceCertPath:            viper.GetString(serverCertPathFlagName),
-			ServiceKeyPath:             viper.GetString(serverKeyPathFlagName),
-			ServicePort:                viper.GetUint16(portFlagName),
-			ServiceSocketPath:          viper.GetString(socketPathFlagName),
-			SyncServicePort:            viper.GetUint16(syncPortFlagName),
-			SyncServiceSocketPath:      viper.GetString(syncSocketPathFlagName),
-			StreamDeadline:             viper.GetDuration(streamDeadlineFlagName),
-			DisableSyncMetadata:        viper.GetBool(disableSyncMetadata),
-			SyncProviders:              syncProviders,
-			ContextValues:              contextValuesToMap,
-			HeaderToContextKeyMappings: headerToContextKeyMappings,
-			MaxRequestBodyBytes:        maxRequestBodyBytes,
-			MaxRequestHeaderBytes:      maxRequestHeaderBytes,
+			CORS:                         viper.GetStringSlice(corsFlagName),
+			MetricExporter:               viper.GetString(metricsExporter),
+			ManagementPort:               viper.GetUint16(managementPortFlagName),
+			OfrepServicePort:             viper.GetUint16(ofrepPortFlagName),
+			OtelCollectorURI:             viper.GetString(otelCollectorURI),
+			OtelCertPath:                 viper.GetString(otelCertPathFlagName),
+			OtelKeyPath:                  viper.GetString(otelKeyPathFlagName),
+			OtelReloadInterval:           viper.GetDuration(otelReloadIntervalFlagName),
+			OtelCAPath:                   viper.GetString(otelCAPathFlagName),
+			ServiceCertPath:              viper.GetString(serverCertPathFlagName),
+			ServiceKeyPath:               viper.GetString(serverKeyPathFlagName),
+			ServicePort:                  viper.GetUint16(portFlagName),
+			ServiceSocketPath:            viper.GetString(socketPathFlagName),
+			SyncServicePort:              viper.GetUint16(syncPortFlagName),
+			SyncServiceSocketPath:        viper.GetString(syncSocketPathFlagName),
+			StreamDeadline:               viper.GetDuration(streamDeadlineFlagName),
+			DisableSyncMetadata:          viper.GetBool(disableSyncMetadata),
+			KeepAliveMinTime:             viper.GetDuration(keepAliveMinTimeFlagName),
+			KeepAlivePermitWithoutStream: viper.GetBool(keepAlivePermitWithoutStreamFlagName),
+			SyncProviders:                syncProviders,
+			ContextValues:                contextValuesToMap,
+			HeaderToContextKeyMappings:   headerToContextKeyMappings,
+			MaxRequestBodyBytes:          maxRequestBodyBytes,
+			MaxRequestHeaderBytes:        maxRequestHeaderBytes,
 		})
 		if err != nil {
 			rtLogger.Fatal(err.Error())

--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -41,6 +41,9 @@ type Config struct {
 	StreamDeadline        time.Duration
 	DisableSyncMetadata   bool
 
+	KeepAliveMinTime             time.Duration
+	KeepAlivePermitWithoutStream bool
+
 	SyncProviders []sync.SourceConfig
 	CORS          []string
 
@@ -137,6 +140,9 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 		StreamDeadline:      config.StreamDeadline,
 		DisableSyncMetadata: config.DisableSyncMetadata,
 		MetricsRecorder:     recorder,
+
+		KeepAliveMinTime:             config.KeepAliveMinTime,
+		KeepAlivePermitWithoutStream: config.KeepAlivePermitWithoutStream,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating sync service: %w", err)

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 type ISyncService interface {
@@ -27,17 +28,19 @@ type ISyncService interface {
 }
 
 type SvcConfigurations struct {
-	Logger              *logger.Logger
-	Port                uint16
-	Sources             []string
-	Store               store.IStore
-	ContextValues       map[string]any
-	CertPath            string
-	KeyPath             string
-	SocketPath          string
-	StreamDeadline      time.Duration
-	DisableSyncMetadata bool
-	MetricsRecorder     telemetry.IMetricsRecorder
+	Logger                       *logger.Logger
+	Port                         uint16
+	Sources                      []string
+	Store                        store.IStore
+	ContextValues                map[string]any
+	CertPath                     string
+	KeyPath                      string
+	SocketPath                   string
+	StreamDeadline               time.Duration
+	DisableSyncMetadata          bool
+	MetricsRecorder              telemetry.IMetricsRecorder
+	KeepAliveMinTime             time.Duration
+	KeepAlivePermitWithoutStream bool
 }
 
 type Service struct {
@@ -65,25 +68,37 @@ func loadTLSCredentials(certPath string, keyPath string) (credentials.TransportC
 	return credentials.NewTLS(config), nil
 }
 
+// keepAliveEnforcementPolicy derives the gRPC keepalive enforcement policy for
+// the sync server from the service configuration. The sync server serves a
+// long-lived SyncFlags stream that in-process providers keep alive with
+// periodic keepalive pings, so the defaults deliberately widen grpc-go's
+// generic-RPC enforcement (MinTime 5m, PermitWithoutStream false) to tolerate
+// those pings instead of responding with GOAWAY ENHANCE_YOUR_CALM.
+func keepAliveEnforcementPolicy(cfg SvcConfigurations) keepalive.EnforcementPolicy {
+	return keepalive.EnforcementPolicy{
+		MinTime:             cfg.KeepAliveMinTime,
+		PermitWithoutStream: cfg.KeepAlivePermitWithoutStream,
+	}
+}
+
 func NewSyncService(cfg SvcConfigurations) (*Service, error) {
 	var err error
 	l := cfg.Logger
 
-	var server *grpc.Server
+	serverOpts := []grpc.ServerOption{
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.KeepaliveEnforcementPolicy(keepAliveEnforcementPolicy(cfg)),
+	}
+
 	if cfg.CertPath != "" && cfg.KeyPath != "" {
 		tlsCredentials, err := loadTLSCredentials(cfg.CertPath, cfg.KeyPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load TLS cert and key: %w", err)
 		}
-		server = grpc.NewServer(
-			grpc.Creds(tlsCredentials),
-			grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		)
-	} else {
-		server = grpc.NewServer(
-			grpc.StatsHandler(otelgrpc.NewServerHandler()),
-		)
+		serverOpts = append(serverOpts, grpc.Creds(tlsCredentials))
 	}
+
+	server := grpc.NewServer(serverOpts...)
 
 	metricsRecorder := cfg.MetricsRecorder
 	if metricsRecorder == nil {

--- a/flagd/pkg/service/flag-sync/sync_service.go
+++ b/flagd/pkg/service/flag-sync/sync_service.go
@@ -68,12 +68,9 @@ func loadTLSCredentials(certPath string, keyPath string) (credentials.TransportC
 	return credentials.NewTLS(config), nil
 }
 
-// keepAliveEnforcementPolicy derives the gRPC keepalive enforcement policy for
-// the sync server from the service configuration. The sync server serves a
-// long-lived SyncFlags stream that in-process providers keep alive with
-// periodic keepalive pings, so the defaults deliberately widen grpc-go's
-// generic-RPC enforcement (MinTime 5m, PermitWithoutStream false) to tolerate
-// those pings instead of responding with GOAWAY ENHANCE_YOUR_CALM.
+// keepAliveEnforcementPolicy builds the gRPC keepalive enforcement policy so
+// provider keepalive pings on the long-lived SyncFlags stream aren't rejected
+// with GOAWAY ENHANCE_YOUR_CALM.
 func keepAliveEnforcementPolicy(cfg SvcConfigurations) keepalive.EnforcementPolicy {
 	return keepalive.EnforcementPolicy{
 		MinTime:             cfg.KeepAliveMinTime,

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -311,7 +311,6 @@ func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
 			flagStore, sources := getSimpleFlagStore(t)
 
 			ctx, cancelFunc := context.WithCancel(context.Background())
-			defer cancelFunc()
 
 			service, err := NewSyncService(SvcConfigurations{
 				Logger:                       logger.NewLogger(nil, false),
@@ -323,10 +322,18 @@ func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			serverDone := make(chan struct{})
 			go func() {
 				// error ignored, the assertions below fail if start does not succeed
 				_ = service.Start(ctx)
+				close(serverDone)
 			}()
+			// stop the server and wait for the listener to be released before the
+			// next subtest reuses the port
+			t.Cleanup(func() {
+				cancelFunc()
+				<-serverDone
+			})
 			for _, source := range sources {
 				service.Emit(source)
 			}
@@ -344,21 +351,10 @@ func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
 func floodKeepalivePings(t *testing.T, addr string) bool {
 	t.Helper()
 
-	var conn net.Conn
-	var err error
-	// the listener is created in NewSyncService but Serve is delayed until the
-	// startup tracker completes, so retry the dial briefly
-	for i := 0; i < 50; i++ {
-		conn, err = net.Dial("tcp", addr)
-		if err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	require.NoError(t, err)
+	conn := dialWithRetry(t, addr)
 	defer conn.Close()
 
-	_, err = io.WriteString(conn, http2.ClientPreface)
+	_, err := io.WriteString(conn, http2.ClientPreface)
 	require.NoError(t, err)
 
 	framer := http2.NewFramer(conn, conn)
@@ -373,24 +369,7 @@ func floodKeepalivePings(t *testing.T, addr string) bool {
 	// client connection preface must be followed by a SETTINGS frame
 	write(func() error { return framer.WriteSettings() })
 
-	enhanceYourCalm := make(chan bool, 1)
-	go func() {
-		for {
-			frame, err := framer.ReadFrame()
-			if err != nil {
-				return
-			}
-			switch f := frame.(type) {
-			case *http2.SettingsFrame:
-				if !f.IsAck() {
-					write(func() error { return framer.WriteSettingsAck() })
-				}
-			case *http2.GoAwayFrame:
-				enhanceYourCalm <- f.ErrCode == http2.ErrCodeEnhanceYourCalm
-				return
-			}
-		}
-	}()
+	enhanceYourCalm := watchForGoAway(framer, write)
 
 	// flood pings faster than any strict MinTime; grpc-go GOAWAYs after more
 	// than two "ping strikes", so a handful of rapid pings is enough
@@ -410,6 +389,49 @@ func floodKeepalivePings(t *testing.T, addr string) bool {
 	case <-time.After(2 * time.Second):
 		return false
 	}
+}
+
+// dialWithRetry dials addr, retrying briefly because the listener is created in
+// NewSyncService but Serve is delayed until the startup tracker completes.
+func dialWithRetry(t *testing.T, addr string) net.Conn {
+	t.Helper()
+
+	var conn net.Conn
+	var err error
+	for i := 0; i < 50; i++ {
+		conn, err = net.Dial("tcp", addr)
+		if err == nil {
+			return conn
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	return conn
+}
+
+// watchForGoAway reads frames from the framer in the background, acking server
+// SETTINGS, and reports on the returned channel whether the first GOAWAY carries
+// the ENHANCE_YOUR_CALM code.
+func watchForGoAway(framer *http2.Framer, write func(func() error)) <-chan bool {
+	enhanceYourCalm := make(chan bool, 1)
+	go func() {
+		for {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch f := frame.(type) {
+			case *http2.SettingsFrame:
+				if !f.IsAck() {
+					write(func() error { return framer.WriteSettingsAck() })
+				}
+			case *http2.GoAwayFrame:
+				enhanceYourCalm <- f.ErrCode == http2.ErrCodeEnhanceYourCalm
+				return
+			}
+		}
+	}()
+	return enhanceYourCalm
 }
 
 func createAndStartSyncService(

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -3,13 +3,18 @@ package sync
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/open-feature/flagd/core/pkg/model"
 	"github.com/open-feature/flagd/core/pkg/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -239,6 +244,171 @@ func TestSyncServiceDeadlineEndToEnd(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestKeepAliveEnforcementPolicy(t *testing.T) {
+	tests := []struct {
+		name                string
+		minTime             time.Duration
+		permitWithoutStream bool
+	}{
+		{name: "flag defaults", minTime: 30 * time.Second, permitWithoutStream: true},
+		{name: "custom min time", minTime: 10 * time.Second, permitWithoutStream: true},
+		{name: "permit without stream disabled", minTime: 30 * time.Second, permitWithoutStream: false},
+		{name: "zero min time passed through unchanged", minTime: 0, permitWithoutStream: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := keepAliveEnforcementPolicy(SvcConfigurations{
+				KeepAliveMinTime:             tt.minTime,
+				KeepAlivePermitWithoutStream: tt.permitWithoutStream,
+			})
+
+			assert.Equal(t, tt.minTime, policy.MinTime)
+			assert.Equal(t, tt.permitWithoutStream, policy.PermitWithoutStream)
+		})
+	}
+}
+
+// TestSyncServiceKeepAliveEnforcement proves the enforcement policy is applied
+// to the sync gRPC server. The Go gRPC client clamps its keepalive interval to a
+// 10s minimum, so we drive the HTTP/2 connection directly with a raw framer to
+// flood keepalive pings and observe how the server's configured policy reacts:
+// a permissive policy tolerates the pings, while a strict one tears the
+// connection down with GOAWAY ENHANCE_YOUR_CALM.
+func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
+	tests := []struct {
+		name                string
+		minTime             time.Duration
+		permitWithoutStream bool
+		wantEnhanceYourCalm bool
+	}{
+		{
+			name:                "permissive policy tolerates frequent pings",
+			minTime:             time.Millisecond,
+			permitWithoutStream: true,
+			wantEnhanceYourCalm: false,
+		},
+		{
+			name:                "strict min time rejects frequent pings with GOAWAY",
+			minTime:             time.Hour,
+			permitWithoutStream: true,
+			wantEnhanceYourCalm: true,
+		},
+		{
+			name:                "pings without an active stream are rejected when not permitted",
+			minTime:             time.Millisecond,
+			permitWithoutStream: false,
+			wantEnhanceYourCalm: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := 18017
+			flagStore, sources := getSimpleFlagStore(t)
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			defer cancelFunc()
+
+			service, err := NewSyncService(SvcConfigurations{
+				Logger:                       logger.NewLogger(nil, false),
+				Port:                         uint16(port),
+				Sources:                      sources,
+				Store:                        flagStore,
+				KeepAliveMinTime:             tt.minTime,
+				KeepAlivePermitWithoutStream: tt.permitWithoutStream,
+			})
+			require.NoError(t, err)
+
+			go func() {
+				// error ignored, the assertions below fail if start does not succeed
+				_ = service.Start(ctx)
+			}()
+			for _, source := range sources {
+				service.Emit(source)
+			}
+
+			gotEnhanceYourCalm := floodKeepalivePings(t, fmt.Sprintf("localhost:%d", port))
+			assert.Equal(t, tt.wantEnhanceYourCalm, gotEnhanceYourCalm)
+		})
+	}
+}
+
+// floodKeepalivePings opens a raw HTTP/2 (h2c) connection to the sync server and
+// sends keepalive PING frames in rapid succession without opening a stream. It
+// returns true if the server responds with GOAWAY ENHANCE_YOUR_CALM within a
+// short window, and false if the connection is left healthy.
+func floodKeepalivePings(t *testing.T, addr string) bool {
+	t.Helper()
+
+	var conn net.Conn
+	var err error
+	// the listener is created in NewSyncService but Serve is delayed until the
+	// startup tracker completes, so retry the dial briefly
+	for i := 0; i < 50; i++ {
+		conn, err = net.Dial("tcp", addr)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = io.WriteString(conn, http2.ClientPreface)
+	require.NoError(t, err)
+
+	framer := http2.NewFramer(conn, conn)
+
+	var writeMu sync.Mutex
+	write := func(fn func() error) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		_ = fn()
+	}
+
+	// client connection preface must be followed by a SETTINGS frame
+	write(func() error { return framer.WriteSettings() })
+
+	enhanceYourCalm := make(chan bool, 1)
+	go func() {
+		for {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch f := frame.(type) {
+			case *http2.SettingsFrame:
+				if !f.IsAck() {
+					write(func() error { return framer.WriteSettingsAck() })
+				}
+			case *http2.GoAwayFrame:
+				enhanceYourCalm <- f.ErrCode == http2.ErrCodeEnhanceYourCalm
+				return
+			}
+		}
+	}()
+
+	// flood pings faster than any strict MinTime; grpc-go GOAWAYs after more
+	// than two "ping strikes", so a handful of rapid pings is enough
+	var pingData [8]byte
+	for i := 0; i < 8; i++ {
+		write(func() error { return framer.WritePing(false, pingData) })
+		select {
+		case got := <-enhanceYourCalm:
+			return got
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	select {
+	case got := <-enhanceYourCalm:
+		return got
+	case <-time.After(2 * time.Second):
+		return false
 	}
 }
 

--- a/flagd/pkg/service/flag-sync/sync_service_test.go
+++ b/flagd/pkg/service/flag-sync/sync_service_test.go
@@ -311,6 +311,7 @@ func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
 			flagStore, sources := getSimpleFlagStore(t)
 
 			ctx, cancelFunc := context.WithCancel(context.Background())
+			defer cancelFunc()
 
 			service, err := NewSyncService(SvcConfigurations{
 				Logger:                       logger.NewLogger(nil, false),
@@ -328,10 +329,9 @@ func TestSyncServiceKeepAliveEnforcement(t *testing.T) {
 				_ = service.Start(ctx)
 				close(serverDone)
 			}()
-			// stop the server and wait for the listener to be released before the
-			// next subtest reuses the port
+			// defer cancelFunc above stops the server; wait for the listener to be
+			// released before the next subtest reuses the port
 			t.Cleanup(func() {
-				cancelFunc()
 				<-serverDone
 			})
 			for _, source := range sources {


### PR DESCRIPTION
## This PR

Sets a streaming-appropriate gRPC keepalive **enforcement policy** on the flag-sync server, configurable via two new flags, so in-process providers stop being disconnected with `GOAWAY ENHANCE_YOUR_CALM` (`too_many_pings`).

Closes #1998.

## Problem

The flag-sync service exposes a long-lived `SyncFlags` gRPC stream that in-process providers keep alive with periodic keepalive pings. The sync server is created with a bare `grpc.NewServer(...)` and no `KeepaliveEnforcementPolicy`, so it inherits grpc-go's defaults — `MinTime: 5m`, `PermitWithoutStream: false` — which are tuned for short unary RPC, not a long-lived, often-idle stream.

Any client pinging more often than every 5 minutes (or pinging during an idle gap with no active stream) accrues ping strikes, and the server responds with `GOAWAY ENHANCE_YOUR_CALM` and closes the connection. Provider SDKs choose their own cadence; the Go provider's in-process resolver pings every 30s with `PermitWithoutStream: true` and no override, so it is disconnected roughly every 60–90s. This is a server-side default mismatch that affects every client language, and there is no server-side setting to correct it today.

## Why fix it on the server

Keepalive *enforcement* is the server's contract — the server decides how often a client may ping. Adjusting each provider's client keepalive instead would need coordinated releases across every provider repo, wouldn't help third-party or future clients, and would leave the server rejecting reasonable keepalives by default. One server-side change fixes every client, in every language, at the correct layer.

## Change

New flags on `flagd start` (env vars auto-derived), applied to the flag-sync gRPC server:

| Flag | Env | Type | Default |
|---|---|---|---|
| `--keep-alive-min-time` | `FLAGD_KEEP_ALIVE_MIN_TIME` | duration | `30s` |
| `--keep-alive-permit-without-stream` | `FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM` | bool | `true` |

The defaults are strictly **more permissive** than grpc-go's, so no client that works against flagd today regresses; clients that were being disconnected stop being disconnected. Because these are flags/env vars, deployments (including operator-managed flagd via container env/args) can tune keepalive tolerance for every consumer from one place, without editing any gRPC client.

An ADR is included at `docs/architecture-decisions/sync-server-keepalive-enforcement.md`.

## Validation

Reproduced end to end with an in-process provider (Go provider `v0.6.0`, default 30s keepalive) against two builds of the sync server on `:8015`, identical in every other respect:

- **Before** (this repo's `main`): server logs `got too many pings from the client`; client receives `GoAway ... ENHANCE_YOUR_CALM ... "too_many_pings"` at ~105s and the sync stream is torn down and retried.
- **After** (this branch, default `MinTime 30s`): 0 GOAWAYs, 0 sync errors, stream stable for the full 4-minute window (2.4× past the point where `main` failed).

## Test plan

- `make workspace-init && make test` — passes (added a unit test for the config→policy mapping and a raw-HTTP/2 behavioural test that drives the server's enforcement directly: strict policy → `GOAWAY ENHANCE_YOUR_CALM`, permissive policy → healthy, pings-without-stream rejected when not permitted).
- `make lint` — clean on the changed packages.
- `make generate-docs` — regenerated CLI reference is committed.
- `make markdownlint` — clean.
