### PR TITLE
fix(sync): re-establish file watch after delete and restore

### DIFF
--- a/core/pkg/sync/file/filepath_sync.go
+++ b/core/pkg/sync/file/filepath_sync.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	msync "sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -18,6 +19,17 @@ import (
 const (
 	FSNOTIFY = "fsnotify"
 	FILEINFO = "fileinfo"
+)
+
+const (
+	// reAddMaxAttempts bounds how many times we try to re-establish the watch
+	// after a remove event before giving up. A delete followed by a quick
+	// restore (e.g. an editor's atomic save, or a manual delete + undo) can
+	// leave the file momentarily absent when the first Add is attempted, so a
+	// single attempt is not enough to recover the watch.
+	reAddMaxAttempts = 5
+	// reAddBackoff is the delay between re-add attempts.
+	reAddBackoff = 100 * time.Millisecond
 )
 
 type Watcher interface {
@@ -114,7 +126,10 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 			case event.Has(fsnotify.Remove):
 				// K8s exposes config maps as symlinks.
 				// Updates cause a remove event, we need to re-add the watcher in this case.
-				err := fs.watcher.Add(fs.URI)
+				// A delete quickly followed by a restore can leave the file
+				// momentarily absent, so retry the re-add for a short window
+				// rather than giving up after a single failed attempt.
+				err := fs.reAddWatcher(ctx)
 				if err != nil {
 					// the watcher could not be re-added, so the file must have been deleted
 					fs.Logger.Error(fmt.Sprintf("error restoring watcher, file may have been deleted: %s", err.Error()))
@@ -147,6 +162,29 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 			return nil
 		}
 	}
+}
+
+// reAddWatcher re-establishes the watch on fs.URI after a remove event. It
+// retries fs.watcher.Add a bounded number of times with a short backoff so a
+// file that is deleted and quickly restored is picked back up instead of
+// silently losing its watch. It returns the last Add error if every attempt
+// fails, or ctx.Err() if the context is cancelled while backing off.
+func (fs *Sync) reAddWatcher(ctx context.Context) error {
+	var err error
+	for attempt := 0; attempt < reAddMaxAttempts; attempt++ {
+		if err = fs.watcher.Add(fs.URI); err == nil {
+			return nil
+		}
+		if attempt == reAddMaxAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(reAddBackoff):
+		}
+	}
+	return err
 }
 
 func (fs *Sync) sendDataSync(ctx context.Context, dataSync chan<- sync.DataSync) {

--- a/core/pkg/sync/file/filepath_sync.go
+++ b/core/pkg/sync/file/filepath_sync.go
@@ -22,14 +22,10 @@ const (
 )
 
 const (
-	// reAddMaxAttempts bounds how many times we try to re-establish the watch
-	// after a remove event before giving up. A delete followed by a quick
-	// restore (e.g. an editor's atomic save, or a manual delete + undo) can
-	// leave the file momentarily absent when the first Add is attempted, so a
-	// single attempt is not enough to recover the watch.
-	reAddMaxAttempts = 5
-	// reAddBackoff is the delay between re-add attempts.
-	reAddBackoff = 100 * time.Millisecond
+	// bounded re-add attempts after a remove event; 6 x 200ms backoff = ~1s window to survive a non-atomic replace (delete then recreate)
+	reAddMaxAttempts = 6
+	// delay between re-add attempts
+	reAddBackoff = 200 * time.Millisecond
 )
 
 type Watcher interface {
@@ -126,9 +122,7 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 			case event.Has(fsnotify.Remove):
 				// K8s exposes config maps as symlinks.
 				// Updates cause a remove event, we need to re-add the watcher in this case.
-				// A delete quickly followed by a restore can leave the file
-				// momentarily absent, so retry the re-add for a short window
-				// rather than giving up after a single failed attempt.
+				// a non-atomic replace (delete then recreate) leaves the file briefly absent; retry so we don't drop the watch
 				err := fs.reAddWatcher(ctx)
 				if err != nil {
 					// the watcher could not be re-added, so the file must have been deleted
@@ -164,11 +158,7 @@ func (fs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 	}
 }
 
-// reAddWatcher re-establishes the watch on fs.URI after a remove event. It
-// retries fs.watcher.Add a bounded number of times with a short backoff so a
-// file that is deleted and quickly restored is picked back up instead of
-// silently losing its watch. It returns the last Add error if every attempt
-// fails, or ctx.Err() if the context is cancelled while backing off.
+// reAddWatcher retries watcher.Add with backoff; returns the last Add error, or ctx.Err() if cancelled
 func (fs *Sync) reAddWatcher(ctx context.Context) error {
 	var err error
 	for attempt := 0; attempt < reAddMaxAttempts; attempt++ {

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/sync"
 )
@@ -298,5 +300,100 @@ func writeToFile(t *testing.T, fetchDirName, fileContents string) {
 	_, err = file.WriteAt([]byte(fileContents), 0)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// reAddMockWatcher is a minimal file.Watcher used to exercise reAddWatcher's
+// retry behavior without touching the real filesystem. Its Add fails the first
+// addFailUntil calls, then succeeds and records the watched name.
+type reAddMockWatcher struct {
+	addFailUntil int
+	addErr       error
+	addCalls     int
+	watchList    []string
+}
+
+func (m *reAddMockWatcher) Close() error { return nil }
+
+func (m *reAddMockWatcher) Add(name string) error {
+	m.addCalls++
+	if m.addCalls <= m.addFailUntil {
+		return m.addErr
+	}
+	m.watchList = append(m.watchList, name)
+	return nil
+}
+
+func (m *reAddMockWatcher) Remove(string) error         { return nil }
+func (m *reAddMockWatcher) WatchList() []string         { return m.watchList }
+func (m *reAddMockWatcher) Events() chan fsnotify.Event { return make(chan fsnotify.Event) }
+func (m *reAddMockWatcher) Errors() chan error          { return make(chan error) }
+
+func newReAddSync(w Watcher) *Sync {
+	return &Sync{
+		URI:     "/tmp/does-not-matter/flags.json",
+		Logger:  logger.NewLogger(nil, false),
+		watcher: w,
+		Mux:     &msync.RWMutex{},
+	}
+}
+
+// Happy path: the file is momentarily absent (Add fails once) then restored, so
+// the retry re-establishes the watch.
+func TestReAddWatcher_RetriesUntilSuccess(t *testing.T) {
+	mw := &reAddMockWatcher{addFailUntil: 1, addErr: errors.New("no such file or directory")}
+	fs := newReAddSync(mw)
+
+	if err := fs.reAddWatcher(context.Background()); err != nil {
+		t.Fatalf("expected watch to be re-established after a transient failure, got error: %v", err)
+	}
+	if mw.addCalls != 2 {
+		t.Errorf("expected 2 Add attempts (1 fail + 1 success), got %d", mw.addCalls)
+	}
+	if len(mw.watchList) != 1 || mw.watchList[0] != fs.URI {
+		t.Errorf("expected watch list to contain %q, got %v", fs.URI, mw.watchList)
+	}
+}
+
+// Edge case: the file is truly deleted, so every Add fails and the retry gives
+// up after the bounded number of attempts, returning the last error.
+func TestReAddWatcher_ExhaustsAttempts(t *testing.T) {
+	wantErr := errors.New("no such file or directory")
+	mw := &reAddMockWatcher{addFailUntil: reAddMaxAttempts + 1, addErr: wantErr}
+	fs := newReAddSync(mw)
+
+	err := fs.reAddWatcher(context.Background())
+	if err == nil {
+		t.Fatal("expected an error after exhausting all re-add attempts, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected the last Add error, got %v", err)
+	}
+	if mw.addCalls != reAddMaxAttempts {
+		t.Errorf("expected exactly %d Add attempts, got %d", reAddMaxAttempts, mw.addCalls)
+	}
+}
+
+// Cancellation: a context cancelled during the backoff aborts the retry
+// promptly instead of running out the full attempt budget.
+func TestReAddWatcher_ContextCancelled(t *testing.T) {
+	mw := &reAddMockWatcher{addFailUntil: reAddMaxAttempts + 1, addErr: errors.New("no such file or directory")}
+	fs := newReAddSync(mw)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the first backoff completes
+
+	start := time.Now()
+	err := fs.reAddWatcher(ctx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if mw.addCalls >= reAddMaxAttempts {
+		t.Errorf("expected retry to abort early, but it made %d attempts", mw.addCalls)
+	}
+	if elapsed >= reAddMaxAttempts*reAddBackoff {
+		t.Errorf("expected prompt return on cancellation, took %s", elapsed)
 	}
 }

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -303,9 +303,7 @@ func writeToFile(t *testing.T, fetchDirName, fileContents string) {
 	}
 }
 
-// reAddMockWatcher is a minimal file.Watcher used to exercise reAddWatcher's
-// retry behavior without touching the real filesystem. Its Add fails the first
-// addFailUntil calls, then succeeds and records the watched name.
+// reAddMockWatcher is a file.Watcher whose Add fails the first addFailUntil calls, then succeeds
 type reAddMockWatcher struct {
 	addFailUntil int
 	addErr       error
@@ -338,8 +336,7 @@ func newReAddSync(w Watcher) *Sync {
 	}
 }
 
-// Happy path: the file is momentarily absent (Add fails once) then restored, so
-// the retry re-establishes the watch.
+// Happy path: file briefly absent (Add fails once) then restored -> watch re-established
 func TestReAddWatcher_RetriesUntilSuccess(t *testing.T) {
 	mw := &reAddMockWatcher{addFailUntil: 1, addErr: errors.New("no such file or directory")}
 	fs := newReAddSync(mw)
@@ -355,8 +352,7 @@ func TestReAddWatcher_RetriesUntilSuccess(t *testing.T) {
 	}
 }
 
-// Edge case: the file is truly deleted, so every Add fails and the retry gives
-// up after the bounded number of attempts, returning the last error.
+// Edge case: file truly deleted -> every Add fails, retry gives up and returns the last error
 func TestReAddWatcher_ExhaustsAttempts(t *testing.T) {
 	wantErr := errors.New("no such file or directory")
 	mw := &reAddMockWatcher{addFailUntil: reAddMaxAttempts + 1, addErr: wantErr}
@@ -374,8 +370,7 @@ func TestReAddWatcher_ExhaustsAttempts(t *testing.T) {
 	}
 }
 
-// Cancellation: a context cancelled during the backoff aborts the retry
-// promptly instead of running out the full attempt budget.
+// Cancellation: a cancelled context aborts the retry promptly
 func TestReAddWatcher_ContextCancelled(t *testing.T) {
 	mw := &reAddMockWatcher{addFailUntil: reAddMaxAttempts + 1, addErr: errors.New("no such file or directory")}
 	fs := newReAddSync(mw)


### PR DESCRIPTION
## Summary

flagd now recovers its file watch when a watched flag-definition file is deleted and quickly restored, instead of silently going stale.

## Why this matters

The reporter of #1876 hit this on Windows by deleting the flag file and immediately undoing (ctrl+z): after the restore, `/ofrep/v1/evaluate/flags` kept returning stale data and later edits to the file were never picked up. A maintainer confirmed the report, labeled it `bug` / `help wanted`, and left it open.

The cause is in `core/pkg/sync/file/filepath_sync.go`. On a `Remove` event the sync loop re-added the watcher with a single `fs.watcher.Add(fs.URI)` call (originally there to handle Kubernetes ConfigMap symlink swaps). During a delete+restore race the file can be momentarily absent at that instant, so `Add` fails, the code logs "error restoring watcher" and gives up. The watch is then lost permanently even though the file exists again a moment later.

## Changes

- Extracted the re-add into a bounded-retry helper, `reAddWatcher(ctx)`, that retries `Add` a few times with a short backoff and aborts early on `ctx` cancellation. A file that returns within the retry window is re-watched. The retry is watcher-agnostic, so it fixes both the `fsnotify` and `fileinfo` paths. The retry bound and backoff are package constants (`reAddMaxAttempts`, `reAddBackoff`).

## Testing

`go test ./pkg/sync/file/` (including `-race`). Added three unit tests against a mock `Watcher`:

- transient failure then success (delete + restore) re-establishes the watch,
- a truly deleted file exhausts the bounded attempts and returns the error (existing default-state behavior preserved),
- a context cancelled during backoff returns promptly instead of running out the attempt budget.

The existing `TestSimpleSync` delete/update cases (real `fsnotify` over a temp dir) stay green, confirming single-delete and ordinary-write behavior is unchanged.

Fixes #1876
