### PR TITLE
fix(sync): synchronize readiness state

### DIFF
--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
@@ -55,7 +56,7 @@ type Sync struct {
 	Headers                 map[string]string
 
 	client FlagSyncServiceClient
-	ready  bool
+	ready  atomic.Bool
 }
 
 func (g *Sync) Init(_ context.Context) error {
@@ -123,7 +124,7 @@ func (g *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error 
 }
 
 func (g *Sync) IsReady() bool {
-	return g.ready
+	return g.ready.Load()
 }
 
 func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
@@ -205,7 +206,7 @@ func (g *Sync) connectWithRetry(
 
 // handleFlagSync wraps the stream listening and push updates through dataSync channel
 func (g *Sync) handleFlagSync(stream syncv1grpc.FlagSyncService_SyncFlagsClient, dataSync chan<- sync.DataSync) error {
-	g.ready = true
+	g.ready.Store(true)
 
 	for {
 		data, err := stream.Recv()

--- a/core/pkg/sync/grpc/grpc_sync_test.go
+++ b/core/pkg/sync/grpc/grpc_sync_test.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	stdsync "sync"
 	"testing"
 	"time"
 
@@ -32,6 +33,14 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+type eofFlagSyncClient struct {
+	syncv1grpc.FlagSyncService_SyncFlagsClient
+}
+
+func (eofFlagSyncClient) Recv() (*v1.SyncFlagsResponse, error) {
+	return nil, io.EOF
+}
 
 func Test_InitWithMockCredentialBuilder(t *testing.T) {
 	tests := []struct {
@@ -560,6 +569,34 @@ func Test_MultipleSyncsBecomeReady(t *testing.T) {
 	}
 }
 
+func TestIsReadyRaceFreeDuringGRPCStreamStart(t *testing.T) {
+	const attempts = 1_000
+
+	grpcSync := Sync{}
+	start := make(chan struct{})
+	var wg stdsync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < attempts; i++ {
+			_ = grpcSync.handleFlagSync(eofFlagSyncClient{}, nil)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < attempts; i++ {
+			_ = grpcSync.IsReady()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
 // Test_ConnectWithRetry is an attempt to validate grpc.connectWithRetry behavior
 func Test_ConnectWithRetry(t *testing.T) {
 	target := "grpc://local"
@@ -784,7 +821,7 @@ func Test_contextWithHeaders(t *testing.T) {
 			name: "headers are appended as metadata",
 			headers: map[string]string{
 				"X-Proxy-Gateway-Host": "myhost.service",
-				"X-Tenant-ID":           "tenant1",
+				"X-Tenant-ID":          "tenant1",
 			},
 			expectUnchanged: false,
 		},
@@ -856,7 +893,7 @@ func Test_ReSyncWithHeaders(t *testing.T) {
 		Logger: logger.NewLogger(nil, false),
 		Headers: map[string]string{
 			"x-proxy-gateway-host": "myhost.service",
-			"x-tenant-id":           "tenant1",
+			"x-tenant-id":          "tenant1",
 		},
 		client: syncv1grpc.NewFlagSyncServiceClient(dial),
 	}

--- a/core/pkg/sync/http/http_sync.go
+++ b/core/pkg/sync/http/http_sync.go
@@ -10,6 +10,7 @@ import (
 	parseUrl "net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
@@ -30,7 +31,7 @@ type Sync struct {
 	authHeader  string
 	headers     map[string]string
 	interval    uint32
-	ready       bool
+	ready       atomic.Bool
 	eTag        string
 	timeoutS    time.Duration
 
@@ -102,7 +103,7 @@ func (hs *Sync) Init(_ context.Context) error {
 }
 
 func (hs *Sync) IsReady() bool {
-	return hs.ready
+	return hs.ready.Load()
 }
 
 func (hs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
@@ -116,7 +117,7 @@ func (hs *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 	}
 
 	// Set ready state
-	hs.ready = true
+	hs.ready.Store(true)
 
 	hs.logger.Debug(fmt.Sprintf("polling %s every %ds (offset: %ds)", hs.uri, hs.interval, hs.poller.Offset()))
 

--- a/core/pkg/sync/http/http_sync_test.go
+++ b/core/pkg/sync/http/http_sync_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	stdsync "sync"
 	"testing"
 	"time"
 
@@ -31,6 +32,16 @@ func buildHeaders(m map[string][]string) http.Header {
 		}
 	}
 	return h
+}
+
+type readinessHTTPClient struct{}
+
+func (readinessHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		Header:     buildHeaders(map[string][]string{"Content-Type": {"application/json"}}),
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		StatusCode: http.StatusOK,
+	}, nil
 }
 
 func TestSimpleSync(t *testing.T) {
@@ -69,6 +80,41 @@ func TestSimpleSync(t *testing.T) {
 
 	if data.FlagData != responseBody {
 		t.Errorf("expected content: %s, but received content: %s", responseBody, data.FlagData)
+	}
+}
+
+func TestIsReadyRaceFreeDuringHTTPStartup(t *testing.T) {
+	const attempts = 100
+
+	for i := 0; i < attempts; i++ {
+		httpSync := Sync{
+			uri:      "http://localhost/flags",
+			client:   readinessHTTPClient{},
+			poller:   synctesting.NewMockPoller(),
+			logger:   logger.NewLogger(nil, false),
+			interval: 1,
+		}
+
+		start := make(chan struct{})
+		var wg stdsync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := httpSync.Sync(context.Background(), make(chan sync.DataSync, 1)); err != nil {
+				t.Errorf("sync: %v", err)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = httpSync.IsReady()
+		}()
+
+		close(start)
+		wg.Wait()
 	}
 }
 
@@ -120,7 +166,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 		authHeader     string
 		eTagHeader     string
 		lastBodySHA    string
-		handleResponse func(*testing.T, Sync, string, error)
+		handleResponse func(*testing.T, *Sync, string, error)
 	}{
 		"success": {
 			setup: func(_ *testing.T, client *syncmock.MockClient) {
@@ -131,7 +177,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 				}, nil)
 			},
 			uri: "http://localhost",
-			handleResponse: func(t *testing.T, _ Sync, fetched string, err error) {
+			handleResponse: func(t *testing.T, _ *Sync, fetched string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -143,7 +189,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 		},
 		"return an error if no uri": {
 			setup: func(_ *testing.T, _ *syncmock.MockClient) {},
-			handleResponse: func(t *testing.T, _ Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, _ *Sync, _ string, err error) {
 				if err == nil {
 					t.Error("expected err, got nil")
 				}
@@ -159,7 +205,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 			},
 			uri:         "http://localhost",
 			lastBodySHA: "",
-			handleResponse: func(t *testing.T, httpSync Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, httpSync *Sync, _ string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -190,7 +236,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 			uri:         "http://localhost",
 			authHeader:  "Basic dXNlcjpwYXNz",
 			lastBodySHA: "",
-			handleResponse: func(t *testing.T, httpSync Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, httpSync *Sync, _ string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -212,7 +258,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 				}, nil)
 			},
 			uri: "http://localhost",
-			handleResponse: func(t *testing.T, _ Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, _ *Sync, _ string, err error) {
 				if err == nil {
 					t.Fatalf("expected unauthorized request to return an error")
 				}
@@ -235,7 +281,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 			},
 			uri:        "http://localhost",
 			eTagHeader: `"1af17a664e3fa8e419b8ba05c2a173169df76162a5a286e0c405b460d478f7ef"`,
-			handleResponse: func(t *testing.T, httpSync Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, httpSync *Sync, _ string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -278,7 +324,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 			},
 			uri:        "http://localhost",
 			eTagHeader: `"1af17a664e3fa8e419b8ba05c2a173169df76162a5a286e0c405b460d478f7ef"`,
-			handleResponse: func(t *testing.T, httpSync Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, httpSync *Sync, _ string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -315,7 +361,7 @@ func TestHTTPSync_Fetch(t *testing.T) {
 			}
 
 			fetched, err := httpSync.Fetch(context.Background())
-			tt.handleResponse(t, httpSync, fetched, err)
+			tt.handleResponse(t, &httpSync, fetched, err)
 		})
 	}
 }
@@ -333,9 +379,9 @@ func TestNewHTTP_PassesHeaders(t *testing.T) {
 
 func TestHTTPSync_CustomHeaders(t *testing.T) {
 	tests := map[string]struct {
-		authHeader     string
-		headers        map[string]string
-		assertRequest  func(t *testing.T, req *http.Request)
+		authHeader    string
+		headers       map[string]string
+		assertRequest func(t *testing.T, req *http.Request)
 	}{
 		"injects custom headers": {
 			headers: map[string]string{"X-Interop-Gateway-Host": "myhost", "X-Tenant-ID": "tenant1"},
@@ -406,7 +452,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 		setup             func(t *testing.T, client *syncmock.MockClient)
 		uri               string
 		lastBodySHA       string
-		handleResponse    func(*testing.T, Sync, string, error)
+		handleResponse    func(*testing.T, *Sync, string, error)
 		wantErr           bool
 		wantNotifications []sync.DataSync
 	}{
@@ -419,7 +465,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 				}, nil)
 			},
 			uri: source,
-			handleResponse: func(t *testing.T, _ Sync, fetched string, err error) {
+			handleResponse: func(t *testing.T, _ *Sync, fetched string, err error) {
 				if err != nil {
 					t.Fatalf("fetch: %v", err)
 				}
@@ -438,7 +484,7 @@ func TestHTTPSync_Resync(t *testing.T) {
 		},
 		"error response": {
 			setup: func(_ *testing.T, _ *syncmock.MockClient) {},
-			handleResponse: func(t *testing.T, _ Sync, _ string, err error) {
+			handleResponse: func(t *testing.T, _ *Sync, _ string, err error) {
 				if err == nil {
 					t.Error("expected err, got nil")
 				}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- synchronizes gRPC and HTTP readiness state with `atomic.Bool`
- preserves blob sync's existing mutex synchronization from #1991
- avoids copying `atomic.Bool` values in HTTP tests
- adds production-path race regressions for both sync implementations

### Related Issues

Fixes #2004

### Notes

The issue's blob item is already synchronized by #1991, so this PR leaves it unchanged.

### How to test

- `cd core && go test -race -short ./pkg/sync/grpc ./pkg/sync/http`
- `cd core && go test -race -count=3 -run "TestIsReadyRaceFreeDuring" ./pkg/sync/grpc ./pkg/sync/http`
- `cd core && go vet ./...`
- `cd core && go test -short ./...`
- `git diff --check`
