### PR TITLE
feat: http sync: check if recevied body is valid json if received content-type is not suppoted

### DIFF
--- a/core/pkg/utils/convert_to_json.go
+++ b/core/pkg/utils/convert_to_json.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"mime"
 	"regexp"
@@ -37,6 +38,9 @@ func ConvertToJSON(data []byte, fileExtension string, mediaType string) (string,
 	case "json", "application/json":
 		return string(data), nil
 	default:
-		return "", fmt.Errorf("unsupported file format: '%s'", detectedType)
+		if !json.Valid(data) {
+			return "", fmt.Errorf("received invalid json with unsupported file format: %q", detectedType)
+		}
+		return string(data), nil
 	}
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Allows flagd to work with http syncs that do not set content-type to json even if returning valid json (such as Gitlab's Repository API).

### Related Issues

I haven't opened any.

### Notes

No notes.

### Follow-up Tasks

No follow-up tasks.

### How to test

Spin up an nginx server that serves a valid feature flag definition file but sets content-type to text/plain. Before this PR, flagd would have crashed due to the content-type being unsupported. After this PR, it will crash only if the content-type is unsupported **and** the response body is not valid json.

