### PR TITLE
fix: record OFREP evaluation metrics

### DIFF
--- a/flagd/pkg/service/flag-evaluation/ofrep/handler.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/handler.go
@@ -34,6 +34,7 @@ type handler struct {
 	evaluator                  evaluator.IEvaluator
 	contextValues              map[string]any
 	headerToContextKeyMappings map[string]string
+	metricsRecorder            telemetry.IMetricsRecorder
 	tracer                     trace.Tracer
 }
 
@@ -50,6 +51,7 @@ func NewOfrepHandler(
 		evaluator:                  evaluator,
 		contextValues:              contextValues,
 		headerToContextKeyMappings: headerToContextKeyMappings,
+		metricsRecorder:            metricsRecorder,
 		tracer:                     otel.Tracer("flagd.ofrep.v1"),
 	}
 
@@ -109,6 +111,9 @@ func (h *handler) HandleFlagEvaluation(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), store.SelectorContextKey{}, selector)
 
 	evaluation := h.evaluator.ResolveAsAnyValue(ctx, requestID, flagKey, evaluationContext)
+	if h.metricsRecorder != nil {
+		h.metricsRecorder.RecordEvaluation(ctx, evaluation.Error, evaluation.Reason, evaluation.Variant, evaluation.FlagKey)
+	}
 	if evaluation.Error != nil {
 		status, evaluationError := ofrep.EvaluationErrorResponseFrom(evaluation)
 		h.writeJSONToResponse(status, evaluationError, w)
@@ -139,6 +144,11 @@ func (h *handler) HandleBulkEvaluation(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), store.SelectorContextKey{}, selector)
 
 	evaluations, metadata, err := h.evaluator.ResolveAllValues(ctx, requestID, evaluationContext)
+	if h.metricsRecorder != nil {
+		for _, evaluation := range evaluations {
+			h.metricsRecorder.RecordEvaluation(ctx, evaluation.Error, evaluation.Reason, evaluation.Variant, evaluation.FlagKey)
+		}
+	}
 	if err != nil {
 		h.Logger.WarnWithID(requestID, fmt.Sprintf("error from resolver: %v", err))
 

--- a/flagd/pkg/service/flag-evaluation/ofrep/handler_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/handler_test.go
@@ -2,6 +2,7 @@ package ofrep
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
 	"github.com/open-feature/flagd/core/pkg/service/ofrep"
+	"github.com/open-feature/flagd/core/pkg/telemetry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -41,6 +43,31 @@ var genericErrorValue = evaluator.AnyValue{
 	Reason:  model.ErrorReason,
 	FlagKey: flagKey,
 	Error:   errors.New(model.GeneralErrorCode),
+}
+
+type recordedEvaluation struct {
+	errorText string
+	reason    string
+	variant   string
+	flagKey   string
+}
+
+type recordingMetricsRecorder struct {
+	telemetry.NoopMetricsRecorder
+	evaluations []recordedEvaluation
+}
+
+func (r *recordingMetricsRecorder) RecordEvaluation(_ context.Context, err error, reason, variant, flagKey string) {
+	errorText := ""
+	if err != nil {
+		errorText = err.Error()
+	}
+	r.evaluations = append(r.evaluations, recordedEvaluation{
+		errorText: errorText,
+		reason:    reason,
+		variant:   variant,
+		flagKey:   flagKey,
+	})
 }
 
 func Test_handler_HandleFlagEvaluation(t *testing.T) {
@@ -409,4 +436,83 @@ func TestInvalidSelector_OFREPHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
+}
+
+func TestHandlerRecordsSingleEvaluationMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		evaluation evaluator.AnyValue
+		expected   recordedEvaluation
+	}{
+		{
+			name:       "successful evaluation",
+			evaluation: successValue,
+			expected: recordedEvaluation{
+				reason:  successValue.Reason,
+				variant: successValue.Variant,
+				flagKey: successValue.FlagKey,
+			},
+		},
+		{
+			name:       "failed evaluation",
+			evaluation: genericErrorValue,
+			expected: recordedEvaluation{
+				errorText: genericErrorValue.Error.Error(),
+				reason:    genericErrorValue.Reason,
+				variant:   genericErrorValue.Variant,
+				flagKey:   genericErrorValue.FlagKey,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metrics := &recordingMetricsRecorder{}
+			eval := mock.NewMockIEvaluator(gomock.NewController(t))
+			eval.EXPECT().
+				ResolveAsAnyValue(gomock.Any(), gomock.Any(), flagKey, gomock.Any()).
+				Return(test.evaluation)
+			handler := NewOfrepHandler(logger.NewLogger(nil, false), eval, nil, nil, metrics, "flagd")
+
+			request := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags/"+flagKey, nil)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			require.Len(t, metrics.evaluations, 1)
+			require.Equal(t, test.expected, metrics.evaluations[0])
+		})
+	}
+}
+
+func TestHandlerRecordsEachBulkEvaluationMetric(t *testing.T) {
+	metrics := &recordingMetricsRecorder{}
+	evaluations := []evaluator.AnyValue{successValue, genericErrorValue, flagNotFoundValue}
+	eval := mock.NewMockIEvaluator(gomock.NewController(t))
+	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(evaluations, model.Metadata{}, nil)
+	handler := NewOfrepHandler(logger.NewLogger(nil, false), eval, nil, nil, metrics, "flagd")
+
+	request := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	require.Equal(t, []recordedEvaluation{
+		{
+			reason:  successValue.Reason,
+			variant: successValue.Variant,
+			flagKey: successValue.FlagKey,
+		},
+		{
+			errorText: genericErrorValue.Error.Error(),
+			reason:    genericErrorValue.Reason,
+			variant:   genericErrorValue.Variant,
+			flagKey:   genericErrorValue.FlagKey,
+		},
+		{
+			errorText: flagNotFoundValue.Error.Error(),
+			reason:    flagNotFoundValue.Reason,
+			variant:   flagNotFoundValue.Variant,
+			flagKey:   flagNotFoundValue.FlagKey,
+		},
+	}, metrics.evaluations)
 }


### PR DESCRIPTION
## This PR

- Records evaluation metrics for each flag resolved through the OFREP single and bulk endpoints.
- Uses each bulk result's own error, reason, variant, and key so per-flag metrics remain accurate.

### Related Issues

Fixes #2015

### Notes

The full flagd lint command reports four existing staticcheck findings in `flag_evaluator_v1.go` and `ofrep_service.go`; the same findings reproduce on `origin/main`. The changed code introduces no new lint findings.

### How to test

- `go test -race -count=1 ./flagd/pkg/service/flag-evaluation/ofrep`
- `make test`
- `make build-flagd`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2 run --new-from-rev=origin/main ./flagd/...`
