### PR TITLE
fix: do not log an error per evaluation for an absent string comparison property

### DIFF
--- a/core/pkg/evaluator/string_comparison.go
+++ b/core/pkg/evaluator/string_comparison.go
@@ -13,6 +13,14 @@ const (
 	EndsWithEvaluationName   = "ends_with"
 )
 
+// errPropertyAbsent signals that the property operand resolved to nil, meaning
+// the evaluation context simply did not carry the attribute. Targeting rules
+// routinely reference optional attributes, so this is an ordinary condition
+// rather than a misconfiguration, and is reported separately from a genuine
+// type error so the two can be logged differently.
+var errPropertyAbsent = errors.New(
+	"[start/end]s_with evaluation: property is absent from the evaluation context")
+
 type StringComparisonEvaluator struct {
 	Logger *logger.Logger
 }
@@ -41,12 +49,32 @@ func NewStringComparisonEvaluator(log *logger.Logger) *StringComparisonEvaluator
 // Note that the 'starts_with' evaluation rule must contain exactly two items, which both resolve to a
 // string value
 func (sce *StringComparisonEvaluator) StartsWithEvaluation(values, _ interface{}) interface{} {
+	return sce.evaluate(StartsWithEvaluationName, values, strings.HasPrefix)
+}
+
+// evaluate applies cmp to the parsed operands, returning nil -- which jsonLogic
+// treats as falsy -- when they cannot be used.
+//
+// The logging severity here is deliberate. This runs on every evaluation of a
+// rule, so its volume tracks request rate rather than the number of bad rules,
+// and error level additionally attaches a stack trace to each occurrence. A rule
+// referencing an attribute that a client did not send would therefore emit tens
+// of log lines per evaluation, for a condition that is entirely normal. An
+// absent property is logged at debug; a genuinely malformed rule is logged at
+// warn, which still surfaces it but without the stack trace.
+func (sce *StringComparisonEvaluator) evaluate(
+	name string, values interface{}, cmp func(string, string) bool,
+) interface{} {
 	propertyValue, target, err := parseStringComparisonEvaluationData(values)
 	if err != nil {
-		sce.Logger.Error(fmt.Sprintf("parse starts_with evaluation data: %v", err))
+		if errors.Is(err, errPropertyAbsent) {
+			sce.Logger.Debug(fmt.Sprintf("%s: %v", name, err))
+		} else {
+			sce.Logger.Warn(fmt.Sprintf("parse %s evaluation data: %v", name, err))
+		}
 		return nil
 	}
-	return strings.HasPrefix(propertyValue, target)
+	return cmp(propertyValue, target)
 }
 
 // EndsWithEvaluation checks if the given property ends with a certain prefix.
@@ -69,12 +97,7 @@ func (sce *StringComparisonEvaluator) StartsWithEvaluation(values, _ interface{}
 // Note that the 'ends_with'  evaluation rule must contain exactly two items, which both resolve to a
 // string value
 func (sce *StringComparisonEvaluator) EndsWithEvaluation(values, _ interface{}) interface{} {
-	propertyValue, target, err := parseStringComparisonEvaluationData(values)
-	if err != nil {
-		sce.Logger.Error(fmt.Sprintf("parse ends_with evaluation data: %v", err))
-		return nil
-	}
-	return strings.HasSuffix(propertyValue, target)
+	return sce.evaluate(EndsWithEvaluationName, values, strings.HasSuffix)
 }
 
 // parseStringComparisonEvaluationData tries to parse the input for the starts_with/ends_with evaluation.
@@ -109,6 +132,12 @@ func parseStringComparisonEvaluationData(values interface{}) (string, string, er
 
 	if len(parsed) != 2 {
 		return "", "", errors.New("[start/end]s_with evaluation must contain a value and a comparison target")
+	}
+
+	// jsonLogic resolves a `var` referencing a missing attribute to nil, so this
+	// distinguishes "the context did not carry it" from "it was the wrong type".
+	if parsed[0] == nil {
+		return "", "", errPropertyAbsent
 	}
 
 	property, ok := parsed[0].(string)

--- a/core/pkg/evaluator/string_comparison_test.go
+++ b/core/pkg/evaluator/string_comparison_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -371,4 +372,40 @@ func TestStringComparisonEvaluation_ErrorFallbackWhenUsedDirectly(t *testing.T) 
 	}
 
 	runErrorFallbackTests(t, ctx, source, "string-op-error-fallback", tests)
+}
+
+// A targeting rule routinely references an optional attribute that a given
+// client did not send. jsonLogic resolves that to nil, which must be
+// distinguishable from an attribute of the wrong type so the two can be
+// reported at different severities.
+func Test_parseStringComparisonEvaluationData_absentProperty(t *testing.T) {
+	_, _, err := parseStringComparisonEvaluationData([]interface{}{nil, "prefix"})
+
+	assert.ErrorIs(t, err, errPropertyAbsent)
+}
+
+func Test_parseStringComparisonEvaluationData_wrongTypeIsNotAbsent(t *testing.T) {
+	_, _, err := parseStringComparisonEvaluationData([]interface{}{1, "prefix"})
+
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, errPropertyAbsent,
+		"a wrong-typed property is a misconfiguration and must not be treated as an absent one")
+}
+
+// Whatever the operands, the rule must simply fail to match rather than error
+// the evaluation.
+func TestStringComparisonEvaluation_absentPropertyDoesNotMatch(t *testing.T) {
+	sce := NewStringComparisonEvaluator(logger.NewLogger(nil, false))
+
+	assert.Nil(t, sce.StartsWithEvaluation([]interface{}{nil, "prefix"}, nil))
+	assert.Nil(t, sce.EndsWithEvaluation([]interface{}{nil, "suffix"}, nil))
+}
+
+func TestStringComparisonEvaluation_comparesStrings(t *testing.T) {
+	sce := NewStringComparisonEvaluator(logger.NewLogger(nil, false))
+
+	assert.Equal(t, true, sce.StartsWithEvaluation([]interface{}{"user@faas.com", "user@"}, nil))
+	assert.Equal(t, false, sce.StartsWithEvaluation([]interface{}{"user@faas.com", "admin@"}, nil))
+	assert.Equal(t, true, sce.EndsWithEvaluation([]interface{}{"user@faas.com", ".com"}, nil))
+	assert.Equal(t, false, sce.EndsWithEvaluation([]interface{}{"user@faas.com", ".org"}, nil))
 }


### PR DESCRIPTION
Fixes #2018. Opening as a draft since #2018 proposes a direction and I'd rather confirm it before you spend review time — happy to change the severities, the sentinel, or the shared-helper refactor.

## The problem

A `starts_with` / `ends_with` rule referencing a context attribute the client did not send logs at **error** level, with a stack trace, on **every evaluation**. jsonLogic resolves a missing `var` to `nil`, and `parseStringComparisonEvaluationData` could not tell that apart from a wrong-typed operand, so both took the same error path.

Two properties of that path make it expensive:

- it runs **per evaluation**, so volume tracks request rate rather than the number of bad rules
- `zap.Config.Build()` attaches a stack trace at error level, turning each occurrence into ~40 log lines

A rule that ORs several version prefixes multiplies again — one of ours had eight `starts_with` calls, so a single bulk OFREP evaluation produced several hundred lines. That exhausted our organisation's daily log-index quota in about nine minutes and stopped log indexing for **every service we run** until the quota reset. The flag resolved correctly throughout; the entire cost was log volume.

## The change

`parseStringComparisonEvaluationData` returns a distinct sentinel when the property operand is `nil`, which lets the two cases be reported differently:

| Case | Before | After |
|---|---|---|
| property absent from context | `error` + stack trace, per evaluation | `debug` |
| property present, wrong type | `error` + stack trace, per evaluation | `warn`, no stack trace |

Rationale: referencing an optional attribute is ordinary and the rule simply does not match, so it isn't an error condition at all. A wrong-typed operand *is* a real misconfiguration and stays visible — but at a level that doesn't attach a stack trace, since the volume is still driven by request rate.

Both continue to return `nil` to jsonLogic, so **evaluation results are unchanged**. The two evaluators now share the comparison and logging path, keeping that policy in one place.

## Testing

New cases cover the absent/wrong-type distinction, that a wrong-typed operand is *not* treated as absent, that neither errors the evaluation, and that ordinary string comparison still works. Full `core` and `flagd` suites pass.

Verified against the reproduction in #2018 — evaluation output byte-identical, log output transformed:

```
A. absent key:  {"value":false,"reason":"TARGETING_MATCH","variant":"off"}
B. matching:    {"value":true, "reason":"TARGETING_MATCH","variant":"on"}
C. non-string:  {"value":false,"reason":"TARGETING_MATCH","variant":"off"}

error lines:       0     (was 1 per evaluation)
stack frame lines: 0     (was ~40 per evaluation)
warn lines:        1     (the wrong-type case, still surfaced)
```

## Open questions

- **Severity for the wrong-type case.** I chose `warn` to keep it visible without the stack trace. If you'd rather keep `error` there, a log-once/deduplicated variant would be needed to stop the volume tracking request rate — happy to add that instead.
- **The `TARGETING_MATCH` reason.** As noted in #2018, all three cases above report `TARGETING_MATCH` with no `errorCode`, so an operator error is indistinguishable from a legitimate else-branch match to SDKs and to validation tooling. That's a behaviour change rather than a logging fix, so I've deliberately left it out of this PR and am happy to follow up separately if you want to pursue it.
