### PR TITLE
fix(flagd-proxy): set gRPC keepalive enforcement policy on the sync server

### DIFF
--- a/core/pkg/service/iservice.go
+++ b/core/pkg/service/iservice.go
@@ -39,14 +39,9 @@ type Configuration struct {
 	MaxRequestHeaderBytes      int64
 	MaxRequestBodyBytes        int64
 
-	// KeepAliveMinTime is the minimum interval the gRPC server permits between
-	// client keepalive pings. Pings arriving more frequently are rejected with
-	// GOAWAY (ENHANCE_YOUR_CALM). Honoured by services exposing a gRPC sync
-	// server; ignored by the connect-based flag evaluation service.
+	// min interval the gRPC sync server permits between client keepalive pings; ignored by the connect eval service
 	KeepAliveMinTime time.Duration
-	// KeepAlivePermitWithoutStream allows clients to send keepalive pings even
-	// when there is no active stream. Honoured by the same services as
-	// KeepAliveMinTime.
+	// permit keepalive pings with no active stream; honoured by the same services as KeepAliveMinTime
 	KeepAlivePermitWithoutStream bool
 }
 

--- a/core/pkg/service/iservice.go
+++ b/core/pkg/service/iservice.go
@@ -38,6 +38,16 @@ type Configuration struct {
 	StreamDeadline             time.Duration
 	MaxRequestHeaderBytes      int64
 	MaxRequestBodyBytes        int64
+
+	// KeepAliveMinTime is the minimum interval the gRPC server permits between
+	// client keepalive pings. Pings arriving more frequently are rejected with
+	// GOAWAY (ENHANCE_YOUR_CALM). Honoured by services exposing a gRPC sync
+	// server; ignored by the connect-based flag evaluation service.
+	KeepAliveMinTime time.Duration
+	// KeepAlivePermitWithoutStream allows clients to send keepalive pings even
+	// when there is no active stream. Honoured by the same services as
+	// KeepAliveMinTime.
+	KeepAlivePermitWithoutStream bool
 }
 
 /*

--- a/flagd-proxy/cmd/start.go
+++ b/flagd-proxy/cmd/start.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	iService "github.com/open-feature/flagd/core/pkg/service"
@@ -22,9 +23,11 @@ import (
 // start
 
 const (
-	logFormatFlagName      = "log-format"
-	managementPortFlagName = "management-port"
-	portFlagName           = "port"
+	logFormatFlagName                    = "log-format"
+	managementPortFlagName               = "management-port"
+	portFlagName                         = "port"
+	keepAliveMinTimeFlagName             = "keep-alive-min-time"
+	keepAlivePermitWithoutStreamFlagName = "keep-alive-permit-without-stream"
 )
 
 func init() {
@@ -34,10 +37,14 @@ func init() {
 	flags.Int32P(portFlagName, "p", 8015, "Port to listen on")
 	flags.Int32P(managementPortFlagName, "m", 8016, "Management port")
 	flags.StringP(logFormatFlagName, "z", "console", "Set the logging format, e.g. console or json")
+	flags.Duration(keepAliveMinTimeFlagName, 30*time.Second, "Minimum interval the flag sync gRPC server permits between client keepalive pings. Pings arriving more frequently than this are rejected with GOAWAY (ENHANCE_YOUR_CALM). Defaults to 30s.")
+	flags.Bool(keepAlivePermitWithoutStreamFlagName, true, "Permit clients of the flag sync gRPC server to send keepalive pings even when there is no active stream. Defaults to true.")
 
 	_ = viper.BindPFlag(logFormatFlagName, flags.Lookup(logFormatFlagName))
 	_ = viper.BindPFlag(managementPortFlagName, flags.Lookup(managementPortFlagName))
 	_ = viper.BindPFlag(portFlagName, flags.Lookup(portFlagName))
+	_ = viper.BindPFlag(keepAliveMinTimeFlagName, flags.Lookup(keepAliveMinTimeFlagName))
+	_ = viper.BindPFlag(keepAlivePermitWithoutStreamFlagName, flags.Lookup(keepAlivePermitWithoutStreamFlagName))
 }
 
 // startCmd represents the start command
@@ -69,6 +76,9 @@ var startCmd = &cobra.Command{
 			ReadinessProbe: func() bool { return true },
 			Port:           viper.GetUint16(portFlagName),
 			ManagementPort: viper.GetUint16(managementPortFlagName),
+
+			KeepAliveMinTime:             viper.GetDuration(keepAliveMinTimeFlagName),
+			KeepAlivePermitWithoutStream: viper.GetBool(keepAlivePermitWithoutStreamFlagName),
 		}
 
 		errChan := make(chan error, 1)

--- a/flagd-proxy/pkg/service/server.go
+++ b/flagd-proxy/pkg/service/server.go
@@ -96,9 +96,7 @@ func (s *Server) Shutdown() {
 	s.grpcServer.GracefulStop()
 }
 
-// keepAliveEnforcementPolicy builds the gRPC keepalive enforcement policy so
-// provider keepalive pings on the long-lived SyncFlags stream aren't rejected
-// with GOAWAY ENHANCE_YOUR_CALM.
+// keepalive policy so provider pings on the long-lived SyncFlags stream aren't rejected with GOAWAY ENHANCE_YOUR_CALM
 func keepAliveEnforcementPolicy(cfg service.Configuration) keepalive.EnforcementPolicy {
 	return keepalive.EnforcementPolicy{
 		MinTime:             cfg.KeepAliveMinTime,

--- a/flagd-proxy/pkg/service/server.go
+++ b/flagd-proxy/pkg/service/server.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 )
 
 type Server struct {
@@ -95,6 +96,16 @@ func (s *Server) Shutdown() {
 	s.grpcServer.GracefulStop()
 }
 
+// keepAliveEnforcementPolicy builds the gRPC keepalive enforcement policy so
+// provider keepalive pings on the long-lived SyncFlags stream aren't rejected
+// with GOAWAY ENHANCE_YOUR_CALM.
+func keepAliveEnforcementPolicy(cfg service.Configuration) keepalive.EnforcementPolicy {
+	return keepalive.EnforcementPolicy{
+		MinTime:             cfg.KeepAliveMinTime,
+		PermitWithoutStream: cfg.KeepAlivePermitWithoutStream,
+	}
+}
+
 func (s *Server) startServer() error {
 	var lis net.Listener
 	var err error
@@ -104,7 +115,9 @@ func (s *Server) startServer() error {
 		return fmt.Errorf("error setting up listener for address %s: %w", address, err)
 	}
 
-	s.grpcServer = grpc.NewServer()
+	s.grpcServer = grpc.NewServer(
+		grpc.KeepaliveEnforcementPolicy(keepAliveEnforcementPolicy(s.config)),
+	)
 	rpc.RegisterFlagSyncServiceServer(s.grpcServer, s.oldHandler)
 	syncv1.RegisterFlagSyncServiceServer(s.grpcServer, s.handler)
 

--- a/flagd-proxy/pkg/service/server_test.go
+++ b/flagd-proxy/pkg/service/server_test.go
@@ -3,13 +3,16 @@ package service
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/open-feature/flagd/core/pkg/logger"
 	"github.com/open-feature/flagd/core/pkg/service"
 	"github.com/open-feature/flagd/flagd-proxy/pkg/service/subscriptions"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -94,4 +97,187 @@ func TestMetricsServerRoutesGRPCHealth(t *testing.T) {
 	if err := <-serveErr; err != nil {
 		t.Errorf("startMetricsServer returned an unexpected error: %v", err)
 	}
+}
+
+// keepAliveConfig builds a Configuration carrying only the keepalive settings,
+// so the tests below can name scenarios without restating the field mapping.
+func keepAliveConfig(minTime time.Duration, permitWithoutStream bool) service.Configuration {
+	return service.Configuration{
+		KeepAliveMinTime:             minTime,
+		KeepAlivePermitWithoutStream: permitWithoutStream,
+	}
+}
+
+func TestKeepAliveEnforcementPolicy(t *testing.T) {
+	for name, cfg := range map[string]service.Configuration{
+		"flag defaults":                  keepAliveConfig(30*time.Second, true),
+		"custom min time":                keepAliveConfig(10*time.Second, true),
+		"permit without stream disabled": keepAliveConfig(30*time.Second, false),
+		"zero min time deferred to grpc": keepAliveConfig(0, false),
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy := keepAliveEnforcementPolicy(cfg)
+
+			if policy.MinTime != cfg.KeepAliveMinTime {
+				t.Errorf("expected MinTime %v, got %v", cfg.KeepAliveMinTime, policy.MinTime)
+			}
+			if policy.PermitWithoutStream != cfg.KeepAlivePermitWithoutStream {
+				t.Errorf("expected PermitWithoutStream %v, got %v", cfg.KeepAlivePermitWithoutStream, policy.PermitWithoutStream)
+			}
+		})
+	}
+}
+
+// TestServerKeepAliveEnforcement proves the enforcement policy is applied to the
+// sync gRPC server. The Go gRPC client clamps its keepalive interval to a 10s
+// minimum, so we drive the HTTP/2 connection directly with a raw framer to flood
+// keepalive pings and observe how the server's configured policy reacts: a
+// permissive policy tolerates the pings, while a strict one tears the connection
+// down with GOAWAY ENHANCE_YOUR_CALM. Without the policy the server falls back to
+// gRPC's defaults (MinTime 5m, PermitWithoutStream false), which is what severed
+// the providers' sync streams roughly every 90 seconds.
+func TestServerKeepAliveEnforcement(t *testing.T) {
+	tests := []struct {
+		name                string
+		cfg                 service.Configuration
+		wantEnhanceYourCalm bool
+	}{
+		{"permissive policy tolerates frequent pings", keepAliveConfig(time.Millisecond, true), false},
+		{"strict min time rejects frequent pings with GOAWAY", keepAliveConfig(time.Hour, true), true},
+		{"pings without an active stream are rejected when not permitted", keepAliveConfig(time.Millisecond, false), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			port := freePort(t)
+			s := NewServer(ctx, logger.NewLogger(nil, false), subscriptions.NewManager(ctx, logger.NewLogger(nil, false)))
+			s.config = tt.cfg
+			s.config.Port = port
+			s.config.ReadinessProbe = func() bool { return true }
+
+			serveErr := make(chan error, 1)
+			go func() { serveErr <- s.startServer() }()
+
+			addr := fmt.Sprintf("127.0.0.1:%d", port)
+			waitForListener(t, addr)
+			t.Cleanup(func() {
+				// s.grpcServer is only assigned once startServer's listener is
+				// up. freePort releases the port before the server rebinds it,
+				// so a competing bind leaves the field nil while waitForListener
+				// still succeeds against the competitor — stopping it
+				// unconditionally would panic and bury the real listen error.
+				if s.grpcServer != nil {
+					s.grpcServer.Stop()
+				}
+				if err := <-serveErr; err != nil {
+					t.Errorf("startServer returned an unexpected error: %v", err)
+				}
+			})
+
+			if got := floodKeepalivePings(t, addr); got != tt.wantEnhanceYourCalm {
+				t.Errorf("expected GOAWAY ENHANCE_YOUR_CALM %v, got %v", tt.wantEnhanceYourCalm, got)
+			}
+		})
+	}
+}
+
+// floodKeepalivePings opens a raw HTTP/2 connection to the sync server and sends
+// keepalive PING frames in rapid succession without opening a stream. It returns
+// true if the server responds with GOAWAY ENHANCE_YOUR_CALM within a short
+// window, and false if the connection is left healthy.
+func floodKeepalivePings(t *testing.T, addr string) bool {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("failed to dial %s: %v", addr, err)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, http2.ClientPreface); err != nil {
+		t.Fatalf("failed to write the HTTP/2 client preface: %v", err)
+	}
+
+	framer := http2.NewFramer(conn, conn)
+
+	var writeMu sync.Mutex
+	write := func(fn func() error) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		_ = fn()
+	}
+
+	// the client connection preface must be followed by a SETTINGS frame
+	write(func() error { return framer.WriteSettings() })
+
+	serverReady, enhanceYourCalm := watchForGoAway(framer, write)
+
+	// Wait for the server's own SETTINGS frame before flooding. A successful dial
+	// only means the kernel accepted the connection into the listen backlog, which
+	// happens before startServer builds the gRPC server; pings sent in that window
+	// would be buffered and then read back-to-back, registering as a MinTime
+	// violation no matter how permissive the policy is. The server's SETTINGS
+	// frame proves the HTTP/2 transport exists and its reader is live, so the
+	// pings below are paced by this loop rather than by the backlog.
+	select {
+	case <-serverReady:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not send its SETTINGS frame within the deadline")
+	}
+
+	// flood pings faster than any strict MinTime; grpc-go sends GOAWAY after more
+	// than two "ping strikes", so a handful of rapid pings is enough
+	var pingData [8]byte
+	for i := 0; i < 8; i++ {
+		write(func() error { return framer.WritePing(false, pingData) })
+		select {
+		case got := <-enhanceYourCalm:
+			return got
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	select {
+	case got := <-enhanceYourCalm:
+		return got
+	case <-time.After(2 * time.Second):
+		return false
+	}
+}
+
+// watchForGoAway reads frames from the framer in the background, acking server
+// SETTINGS. It returns two channels: serverReady is closed once the server's
+// SETTINGS frame has been seen — deliberately never closed on any other path,
+// so a server that fails to come up trips the caller's timeout rather than
+// letting it flood a dead connection — and enhanceYourCalm reports whether the
+// first GOAWAY carries the ENHANCE_YOUR_CALM code.
+func watchForGoAway(framer *http2.Framer, write func(func() error)) (<-chan struct{}, <-chan bool) {
+	serverReady := make(chan struct{})
+	// a server may legitimately send more than one non-ACK SETTINGS frame
+	var readyOnce sync.Once
+	markReady := func() { readyOnce.Do(func() { close(serverReady) }) }
+
+	enhanceYourCalm := make(chan bool, 1)
+	go func() {
+		for {
+			frame, err := framer.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch f := frame.(type) {
+			case *http2.SettingsFrame:
+				if !f.IsAck() {
+					write(func() error { return framer.WriteSettingsAck() })
+					markReady()
+				}
+			case *http2.GoAwayFrame:
+				enhanceYourCalm <- f.ErrCode == http2.ErrCodeEnhanceYourCalm
+				return
+			}
+		}
+	}()
+	return serverReady, enhanceYourCalm
 }

--- a/flagd-proxy/pkg/service/server_test.go
+++ b/flagd-proxy/pkg/service/server_test.go
@@ -99,8 +99,7 @@ func TestMetricsServerRoutesGRPCHealth(t *testing.T) {
 	}
 }
 
-// keepAliveConfig builds a Configuration carrying only the keepalive settings,
-// so the tests below can name scenarios without restating the field mapping.
+// Configuration with only the keepalive fields set, for table tests
 func keepAliveConfig(minTime time.Duration, permitWithoutStream bool) service.Configuration {
 	return service.Configuration{
 		KeepAliveMinTime:             minTime,
@@ -128,14 +127,8 @@ func TestKeepAliveEnforcementPolicy(t *testing.T) {
 	}
 }
 
-// TestServerKeepAliveEnforcement proves the enforcement policy is applied to the
-// sync gRPC server. The Go gRPC client clamps its keepalive interval to a 10s
-// minimum, so we drive the HTTP/2 connection directly with a raw framer to flood
-// keepalive pings and observe how the server's configured policy reacts: a
-// permissive policy tolerates the pings, while a strict one tears the connection
-// down with GOAWAY ENHANCE_YOUR_CALM. Without the policy the server falls back to
-// gRPC's defaults (MinTime 5m, PermitWithoutStream false), which is what severed
-// the providers' sync streams roughly every 90 seconds.
+// proves the policy reaches the sync server; grpc-go clamps client keepalive to 10s so we flood
+// pings via a raw HTTP/2 framer (strict policy -> GOAWAY ENHANCE_YOUR_CALM; default 5m severed streams)
 func TestServerKeepAliveEnforcement(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -164,11 +157,7 @@ func TestServerKeepAliveEnforcement(t *testing.T) {
 			addr := fmt.Sprintf("127.0.0.1:%d", port)
 			waitForListener(t, addr)
 			t.Cleanup(func() {
-				// s.grpcServer is only assigned once startServer's listener is
-				// up. freePort releases the port before the server rebinds it,
-				// so a competing bind leaves the field nil while waitForListener
-				// still succeeds against the competitor — stopping it
-				// unconditionally would panic and bury the real listen error.
+				// grpcServer may be nil if a competing bind won the freed port; guard so we don't panic and bury the listen error
 				if s.grpcServer != nil {
 					s.grpcServer.Stop()
 				}
@@ -184,10 +173,7 @@ func TestServerKeepAliveEnforcement(t *testing.T) {
 	}
 }
 
-// floodKeepalivePings opens a raw HTTP/2 connection to the sync server and sends
-// keepalive PING frames in rapid succession without opening a stream. It returns
-// true if the server responds with GOAWAY ENHANCE_YOUR_CALM within a short
-// window, and false if the connection is left healthy.
+// floods keepalive PINGs over a raw HTTP/2 conn (no stream); returns true if the server sends GOAWAY ENHANCE_YOUR_CALM
 func floodKeepalivePings(t *testing.T, addr string) bool {
 	t.Helper()
 
@@ -215,21 +201,15 @@ func floodKeepalivePings(t *testing.T, addr string) bool {
 
 	serverReady, enhanceYourCalm := watchForGoAway(framer, write)
 
-	// Wait for the server's own SETTINGS frame before flooding. A successful dial
-	// only means the kernel accepted the connection into the listen backlog, which
-	// happens before startServer builds the gRPC server; pings sent in that window
-	// would be buffered and then read back-to-back, registering as a MinTime
-	// violation no matter how permissive the policy is. The server's SETTINGS
-	// frame proves the HTTP/2 transport exists and its reader is live, so the
-	// pings below are paced by this loop rather than by the backlog.
+	// wait for the server's SETTINGS frame first; a dial only reaches the listen backlog (pre-server),
+	// so pings sent then get buffered and read back-to-back, tripping MinTime even under a permissive policy
 	select {
 	case <-serverReady:
 	case <-time.After(3 * time.Second):
 		t.Fatal("server did not send its SETTINGS frame within the deadline")
 	}
 
-	// flood pings faster than any strict MinTime; grpc-go sends GOAWAY after more
-	// than two "ping strikes", so a handful of rapid pings is enough
+	// flood faster than any strict MinTime; grpc-go sends GOAWAY after >2 ping strikes
 	var pingData [8]byte
 	for i := 0; i < 8; i++ {
 		write(func() error { return framer.WritePing(false, pingData) })
@@ -248,12 +228,9 @@ func floodKeepalivePings(t *testing.T, addr string) bool {
 	}
 }
 
-// watchForGoAway reads frames from the framer in the background, acking server
-// SETTINGS. It returns two channels: serverReady is closed once the server's
-// SETTINGS frame has been seen — deliberately never closed on any other path,
-// so a server that fails to come up trips the caller's timeout rather than
-// letting it flood a dead connection — and enhanceYourCalm reports whether the
-// first GOAWAY carries the ENHANCE_YOUR_CALM code.
+// reads frames in the background, acking server SETTINGS. returns serverReady (closed only when the
+// server's SETTINGS is seen, so a dead server trips the caller's timeout) and enhanceYourCalm (true if
+// the first GOAWAY carries ENHANCE_YOUR_CALM)
 func watchForGoAway(framer *http2.Framer, write func(func() error)) (<-chan struct{}, <-chan bool) {
 	serverReady := make(chan struct{})
 	// a server may legitimately send more than one non-ACK SETTINGS frame


### PR DESCRIPTION
### What

Adds `grpc.KeepaliveEnforcementPolicy` to flagd-proxy's sync gRPC server, plus
`--keep-alive-min-time` / `--keep-alive-permit-without-stream` flags, mirroring
what `flagd` already does in `flagd/pkg/service/flag-sync/sync_service.go`.

Fixes #2021.

### Why

flagd-proxy serves the same `FlagSyncService` to the same providers as flagd, but
built its server with a bare `grpc.NewServer()`. gRPC's default enforcement policy
(`MinTime: 5m`, `PermitWithoutStream: false`) rejects the providers' 30s keepalive
pings, so the server sends `GOAWAY ENHANCE_YOUR_CALM ("too_many_pings")` and drops
the sync stream about every 90 seconds. flagd fixed this in #1998; flagd-proxy was
missed.

Defaults are chosen to match `flagd` — and therefore the providers — so the fix
applies without anyone having to set a flag.

### Change

Four files, +223 / −4 (186 of those lines are tests).

`core/pkg/service/iservice.go` — two fields on the shared `Configuration`,
mirroring flagd's `SvcConfigurations`:

```go
// KeepAliveMinTime is the minimum interval the gRPC server permits between
// client keepalive pings. Pings arriving more frequently are rejected with
// GOAWAY (ENHANCE_YOUR_CALM). Honoured by services exposing a gRPC sync
// server; ignored by the connect-based flag evaluation service.
KeepAliveMinTime time.Duration
// KeepAlivePermitWithoutStream allows clients to send keepalive pings even
// when there is no active stream. Honoured by the same services as
// KeepAliveMinTime.
KeepAlivePermitWithoutStream bool
```

`flagd-proxy/pkg/service/server.go` — a `keepAliveEnforcementPolicy` helper
matching flagd's, applied in `startServer`:

```go
s.grpcServer = grpc.NewServer(
	grpc.KeepaliveEnforcementPolicy(keepAliveEnforcementPolicy(s.config)),
)
```

`flagd-proxy/cmd/start.go` — the two flags, viper bindings and config assignment.
Flag names, defaults and help text are copied verbatim from `flagd/cmd/start.go`
so the two binaries stay consistent.

### Testing

Two tests in `flagd-proxy/pkg/service/server_test.go`. They cover the same ground
as the ones that shipped with #1998 in
`flagd/pkg/service/flag-sync/sync_service_test.go`, but are deliberately not
copies of them: written as mirrors, SonarCloud flagged 19.4% duplication on new
code against a 3% gate, so the case tables here are expressed as
`service.Configuration` values instead. Same assertions, 0.9% duplication.

- `TestKeepAliveEnforcementPolicy` — table-driven check that the config maps onto
  `keepalive.EnforcementPolicy`.
- `TestServerKeepAliveEnforcement` — drives the HTTP/2 connection with a raw
  framer (grpc-go's client clamps its keepalive interval to a 10s minimum) and
  floods keepalive pings, asserting that a permissive policy tolerates them while
  a strict one tears the connection down with `GOAWAY ENHANCE_YOUR_CALM`.

Verified against `main` (`5c74b83`): all three modules build; `go test -race`
passes for `./flagd-proxy/...` and `./flagd/...`; `golangci-lint` reports nothing
new (the two `SA1019` hits in `handler.go` are pre-existing). Reverting the
`KeepaliveEnforcementPolicy` option makes `TestServerKeepAliveEnforcement` fail
with exactly the reported symptom, and the test was run 10× under `-race` to
check it isn't timing-sensitive.

Those tests build `Configuration` directly, so they say nothing about the
flag → viper → `Configuration` path. That gap matters here, because if the
binding silently failed, `MinTime` would be `0`, grpc-go would substitute its
5-minute default (`internal/transport/http2_server.go:250`), and the bug would be
back with every test still green. So I also drove the built binary with a raw
HTTP/2 client, pinging on a provider-like cadence:

| flagd-proxy started with | ping interval | result |
|---|---|---|
| *(no flags — shipped defaults)* | 31s | alive for the full 110s window |
| `--keep-alive-min-time=5m` (= the pre-fix gRPC default) | 31s | `GOAWAY ENHANCE_YOUR_CALM` at 93.0s |

The second row reproduces this issue at real timescales; the first shows the
shipped defaults resolve it. Two faster runs pin the individual flags:
`--keep-alive-min-time=1ms --keep-alive-permit-without-stream=true` survives 150
pings at 20ms intervals, and flipping only the boolean to `false` produces
`GOAWAY` immediately.

### Notes for reviewers

- **`startMetricsServer` is deliberately left on a bare `grpc.NewServer()`, and
  setting the policy there would have no effect anyway.** That server is
  dispatched via `grpcServer.ServeHTTP(...)` under h2c, so it runs on grpc-go's
  `serverHandlerTransport` (`internal/transport/handler_server.go`), which
  implements no ping-strike enforcement at all — `pingStrikes` and the keepalive
  policy live only in `http2_server.go`. `grpc.KeepaliveEnforcementPolicy` would
  be inert on that path. It also only serves short-lived health-check RPCs and
  isn't reachable by providers' sync clients, and the flags' help text says "the
  flag sync gRPC server", which would stop being accurate. Happy to revisit if
  you see it differently.
- **These flags are CLI-only on flagd-proxy, unlike on flagd.** `flagd-proxy/cmd`
  never calls `viper.SetEnvPrefix` / `SetEnvKeyReplacer` (there's a dangling
  `// allows environment variables to use _ instead of -` comment in `start.go`
  with no code behind it), so `FLAGD_KEEP_ALIVE_MIN_TIME` will not be picked up.
  This is pre-existing and affects `log-format` and `management-port` identically,
  so fixing it here felt like scope creep — but the ADR advertises env-var
  configurability, so I wanted to flag it. Happy to open a follow-up issue, or to
  fix it in this PR if you'd rather.
- **The ADR** (`docs/architecture-decisions/sync-server-keepalive-enforcement.md`,
  still `status: proposed`) is written entirely in terms of flagd's flag-sync
  server. I didn't edit it since it's authored by someone else and under review —
  say the word and I'll add a note that flagd-proxy carries the same two flags.
- No new dependencies.
