### PR TITLE
fix(core): register the OFO scheme at package init, not inside Sync.Init

### DIFF
--- a/core/pkg/sync/kubernetes/kubernetes_sync.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,6 +31,14 @@ var (
 )
 
 const invalidAPIVersionMsg = "invalid api version %s, expected %s"
+
+// Registering into the global client-go scheme has to happen once, before
+// anything can use it concurrently: runtime.Scheme is documented as "only
+// threadsafe after registration is complete". Doing it from Sync.Init instead
+// races on its unguarded maps, see https://github.com/open-feature/flagd/issues/2023.
+func init() {
+	utilruntime.Must(v1beta1.AddToScheme(scheme.Scheme))
+}
 
 type SyncOption func(s *Sync)
 
@@ -71,10 +80,6 @@ func (k *Sync) Init(_ context.Context) error {
 	k.namespace, k.crdName, err = parseURI(k.URI)
 	if err != nil {
 		return fmt.Errorf("unable to parse uri %s: %w", k.URI, err)
-	}
-
-	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
-		return fmt.Errorf("unable to v1beta1 types to scheme: %w", err)
 	}
 
 	// The created informer will not do resyncs if the given defaultEventHandlerResyncPeriod is zero.

--- a/core/pkg/sync/kubernetes/kubernetes_sync.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync.go
@@ -32,10 +32,7 @@ var (
 
 const invalidAPIVersionMsg = "invalid api version %s, expected %s"
 
-// Registering into the global client-go scheme has to happen once, before
-// anything can use it concurrently: runtime.Scheme is documented as "only
-// threadsafe after registration is complete". Doing it from Sync.Init instead
-// races on its unguarded maps, see https://github.com/open-feature/flagd/issues/2023.
+// register into the global client-go scheme once at init; doing it in Sync.Init races the scheme's maps (#2023)
 func init() {
 	utilruntime.Must(v1beta1.AddToScheme(scheme.Scheme))
 }

--- a/core/pkg/sync/kubernetes/kubernetes_sync_test.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync_test.go
@@ -582,18 +582,14 @@ func TestSync_watcher(t *testing.T) {
 	}
 }
 
-// Captured from init() rather than read inside the test: Sync.Init registers
-// these types as a side effect, so once TestInit has run the scheme looks
-// populated either way. A package-level variable initialiser would be too early
-// — Go initialises all package variables before running any init function.
+// capture in init(), not a package var (too early) nor in-test (Sync.Init would mask it)
 var schemeRegisteredAtPackageInit bool
 
 func init() {
 	schemeRegisteredAtPackageInit = scheme.Scheme.Recognizes(v1beta1.GroupVersion.WithKind("FeatureFlag"))
 }
 
-// TestSchemeRegisteredAtPackageInit pins the fix without needing -race, which
-// complements TestConcurrentInit below.
+// pins the fix without needing -race
 func TestSchemeRegisteredAtPackageInit(t *testing.T) {
 	if !schemeRegisteredAtPackageInit {
 		t.Error("expected the FeatureFlag type to be registered in the global scheme by package init; " +
@@ -601,10 +597,7 @@ func TestSchemeRegisteredAtPackageInit(t *testing.T) {
 	}
 }
 
-// TestConcurrentInit reproduces the reported crash: flagd-proxy calls Init from
-// one goroutine per sync target, so registering into the global scheme there
-// races on its unguarded maps. Run under -race, which the Makefile's test target
-// uses.
+// reproduces #2023: concurrent Sync.Init races the global scheme (run under -race)
 func TestConcurrentInit(t *testing.T) {
 	var wg stdsync.WaitGroup
 	for i := 0; i < 16; i++ {
@@ -761,7 +754,7 @@ func TestNotify(t *testing.T) {
 	// only delivers events via the watch stream, not via the initial List/Replace.
 	// Pre-populating causes the object to silently land in the store without
 	// triggering AddFunc, so later UpdateStatus calls are seen as updates on an
-	// object the informer has never "added" — leaving the test waiting forever.
+	// object the informer has never "added", leaving the test waiting forever.
 	fc := fake.NewSimpleDynamicClient(scheme.Scheme)
 	l, err := logger.NewZapLogger(zapcore.FatalLevel, "console")
 	if err != nil {

--- a/core/pkg/sync/kubernetes/kubernetes_sync_test.go
+++ b/core/pkg/sync/kubernetes/kubernetes_sync_test.go
@@ -582,6 +582,47 @@ func TestSync_watcher(t *testing.T) {
 	}
 }
 
+// Captured from init() rather than read inside the test: Sync.Init registers
+// these types as a side effect, so once TestInit has run the scheme looks
+// populated either way. A package-level variable initialiser would be too early
+// — Go initialises all package variables before running any init function.
+var schemeRegisteredAtPackageInit bool
+
+func init() {
+	schemeRegisteredAtPackageInit = scheme.Scheme.Recognizes(v1beta1.GroupVersion.WithKind("FeatureFlag"))
+}
+
+// TestSchemeRegisteredAtPackageInit pins the fix without needing -race, which
+// complements TestConcurrentInit below.
+func TestSchemeRegisteredAtPackageInit(t *testing.T) {
+	if !schemeRegisteredAtPackageInit {
+		t.Error("expected the FeatureFlag type to be registered in the global scheme by package init; " +
+			"registering it from Sync.Init instead races on the scheme's unguarded maps")
+	}
+}
+
+// TestConcurrentInit reproduces the reported crash: flagd-proxy calls Init from
+// one goroutine per sync target, so registering into the global scheme there
+// races on its unguarded maps. Run under -race, which the Makefile's test target
+// uses.
+func TestConcurrentInit(t *testing.T) {
+	var wg stdsync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s := &Sync{
+				URI:           "myNS/myFF",
+				dynamicClient: fake.NewSimpleDynamicClient(runtime.NewScheme()),
+			}
+			if err := s.Init(context.Background()); err != nil {
+				t.Errorf("unexpected error from Init: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestInit(t *testing.T) {
 	t.Run("expect error with wrong URI format", func(t *testing.T) {
 		k := Sync{URI: ""}
@@ -721,9 +762,6 @@ func TestNotify(t *testing.T) {
 	// Pre-populating causes the object to silently land in the store without
 	// triggering AddFunc, so later UpdateStatus calls are seen as updates on an
 	// object the informer has never "added" — leaving the test waiting forever.
-	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("failed to add v1beta1 to scheme: %v", err)
-	}
 	fc := fake.NewSimpleDynamicClient(scheme.Scheme)
 	l, err := logger.NewZapLogger(zapcore.FatalLevel, "console")
 	if err != nil {


### PR DESCRIPTION
### What

Moves `v1beta1.AddToScheme(scheme.Scheme)` out of `kubernetes.Sync.Init` and into
the package's `init()`, so the global client-go scheme is mutated once, on a single
goroutine, before anything can use it concurrently.

Fixes #2023.

### Why

`runtime.Scheme` holds plain maps and carries no lock. apimachinery states the
contract on the type itself:

```go
// Schemes are not expected to change at runtime and are only threadsafe after
// registration is complete.
type Scheme struct {
	gvkToType map[schema.GroupVersionKind]reflect.Type
	...
```

`Sync.Init` violates that by writing to the **global** `scheme.Scheme` at runtime.
That is harmless in flagd, which calls `Init` in a serial startup loop
(`flagd/pkg/runtime/runtime.go:60`), but flagd-proxy calls it from one goroutine
per sync target at arbitrary times (`flagd-proxy/pkg/service/subscriptions/manager.go:128`
→ `:201`), so two targets registering close together race on those maps and the Go
runtime kills the process:

```
fatal error: concurrent map read and map write

goroutine 2695 [running]:
k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName(...)
	k8s.io/apimachinery@v0.33.2/pkg/runtime/scheme.go:180
...
github.com/open-feature/flagd/core/pkg/sync/kubernetes.(*Sync).Init(...)
	/src/core/pkg/sync/kubernetes/kubernetes_sync.go:72
github.com/open-feature/flagd/flagd-proxy/pkg/service/subscriptions.(*Coordinator).watchResource(...)
	/src/flagd-proxy/pkg/service/subscriptions/manager.go:201
created by ...(*Coordinator).RegisterSubscription in goroutine 2694
	/src/flagd-proxy/pkg/service/subscriptions/manager.go:128
```

We see this roughly once an hour in a test cluster with four sync targets. Two
distinct targets registering close in time are enough — a second subscriber to an
*existing* target reuses the multiplexer and never calls `Init`. In practice it is
self-reinforcing: the crash makes every client reconnect at once, which is exactly
the condition that triggers it.

Registering at package init matches what the type documents and costs nothing: the
work was already idempotent, so doing it once instead of per-`Init` is strictly
less work. `utilruntime.Must` is the conventional Kubernetes idiom here — the call
only touches in-memory maps, so a failure would mean conflicting type definitions,
which is worth failing at startup for.

### Change

All of `core/pkg/sync/kubernetes/kubernetes_sync.go`:

```diff
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,6 +32,14 @@ var (
 
 const invalidAPIVersionMsg = "invalid api version %s, expected %s"
 
+// Registering into the global client-go scheme has to happen once, before
+// anything can use it concurrently: runtime.Scheme is documented as "only
+// threadsafe after registration is complete". Doing it from Sync.Init instead
+// races on its unguarded maps, see https://github.com/open-feature/flagd/issues/2023.
+func init() {
+	utilruntime.Must(v1beta1.AddToScheme(scheme.Scheme))
+}
+
 type SyncOption func(s *Sync)
 
 type Sync struct {
@@ -73,10 +82,6 @@ func (k *Sync) Init(_ context.Context) error {
 		return fmt.Errorf("unable to parse uri %s: %w", k.URI, err)
 	}
 
-	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
-		return fmt.Errorf("unable to v1beta1 types to scheme: %w", err)
-	}
-
 	// The created informer will not do resyncs if the given defaultEventHandlerResyncPeriod is zero.
 	// For more details on resync implications refer to tools/cache/shared_informer.go
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(k.dynamicClient, resyncPeriod, k.namespace, nil)
```

`Sync.Init`'s signature is unchanged, and neither caller distinguished that error
from the URI-parsing one, so this is not a breaking change.

No new dependency — `utilruntime` is already part of `k8s.io/apimachinery`. The
rest of the diff is the two tests described below.

### Testing

Two regression tests in `kubernetes_sync_test.go`:

- **`TestConcurrentInit`** — reproduces the reported crash directly: 16 goroutines
  calling `Sync.Init` concurrently. With the fix reverted this reports `DATA RACE`
  on 5 runs out of 5 (65–541 reports per run), pointing at `AddToScheme` ←
  `Sync.Init`; with the fix it passes. `make test` already runs `-race`, so this is
  caught in CI.
- **`TestSchemeRegisteredAtPackageInit`** — asserts the registration happened by
  package-init time, which holds without `-race` too. It captures the state from an
  `init()` rather than reading it in the test body, because `Sync.Init` registers
  the types as a side effect and the pre-existing `TestInit` calls it — read from a
  test function, the check passes whether or not the fix is present. I verified that
  false negative before settling on this shape.

Verified against `main` (`5c74b83`): all three modules build and vet clean;
`go test -race` passes for `./core/...` (19 packages), and for the touched package
under `-count=3` and three rounds of `-shuffle=on`; `golangci-lint` reports 0 issues
for it.

Also removed a now-redundant `v1beta1.AddToScheme` from `TestNotify` — package init
covers it, and it was a second global mutation from a test.

### One thing worth your call

While checking this I found that **nothing in-tree appears to consume the global
registration at all.** With the `init()` and the `k8s.io/client-go/kubernetes/scheme`
import deleted outright, all three modules build and the whole `kubernetes` package
test suite passes (only my new guard test fails, by construction). The real `dynamic`
client and `dynamicinformer` never touch `scheme.Scheme`; `toFFCfg` uses
`runtime.DefaultUnstructuredConverter`; only `dynamic/fake` consumes a scheme, and
the tests can pass their own.

So deleting the global mutation may be the better fix. I did not propose that here
because `core` is an importable module and dropping a global registration is an
observable change for downstream importers, which felt like your call rather than
mine. Happy to switch this PR to the deletion if you prefer it.
