### PR TITLE
chore: bump go to 1.27.0

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,7 +8,7 @@ env:
   PUBLISHABLE_ITEMS: '["flagd","flagd-proxy"]'
   REGISTRY: ghcr.io
   REPO_OWNER: ${{ github.repository_owner }}
-  DEFAULT_GO_VERSION: '~1.25'
+  DEFAULT_GO_VERSION: "~1.27"
   PUBLIC_KEY_FILE: publicKey.pub
   GOPRIVATE: buf.build/gen/go
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ FLAGD_PROXY_IMG ?= flagd-proxy:latest
 FLAGD_PROXY_IMG_ZD ?= flagd-proxy:zd
 
 DOCS_DIR ?= docs
+GOBIN := $(or $(shell go env GOBIN),$(shell go env GOPATH | cut -d: -f1)/bin)
 
 workspace-init: workspace-clean
 	go work init
@@ -74,13 +75,13 @@ uninstall:
 	rm /etc/systemd/system/flagd.service
 	rm -f $(DESTDIR)$(PREFIX)/bin/flagd
 lint:
-	go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
-	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run $(module)/...;)
+	go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.0
+	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOBIN}/golangci-lint run $(module)/...;)
 lint-fix:
-	go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
-	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOPATH}/bin/golangci-lint run --fix $(module)/...;)
+	go install -v github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.0
+	$(foreach module, $(ALL_GO_MOD_DIRS), ${GOBIN}/golangci-lint run --fix $(module)/...;)
 install-mockgen:
-	go install go.uber.org/mock/mockgen@v0.4.0
+	go install go.uber.org/mock/mockgen@v0.6.0
 mockgen: install-mockgen
 	cd core; mockgen -source=pkg/sync/http/http_sync.go -destination=pkg/sync/http/mock/http.go -package=syncmock
 	cd core; mockgen -source=pkg/sync/grpc/grpc_sync.go -destination=pkg/sync/grpc/mock/grpc.go -package=grpcmock

--- a/core/pkg/evaluator/json.go
+++ b/core/pkg/evaluator/json.go
@@ -24,14 +24,16 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+type contextKey string
+
 const (
 	SelectorMetadataKey = "scope"
 	flagdPropertiesKey  = "$flagd"
 	// targetingKeyKey is used to extract the targetingKey to bucket on in fractional
 	// evaluation if the user did not supply the optional bucketing property.
-	targetingKeyKey = "targetingKey"
-	Disabled        = "DISABLED"
-	ProtoVersionKey = "__flagd.protoVersion__" // used to mark if the request is coming from an older proto source, which has different fallback behavior
+	targetingKeyKey            = "targetingKey"
+	Disabled                   = "DISABLED"
+	ProtoVersionKey contextKey = "__flagd.protoVersion__" // used to mark if the request is coming from an older proto source, which has different fallback behavior
 )
 
 func addSchemaResource(compiler *jsonschema.Compiler, url string, schemaData string) error {
@@ -326,7 +328,6 @@ func resolve[T constraints](ctx context.Context, reqID string, key string, conte
 func (je *Resolver) evaluateVariant(ctx context.Context, reqID string, flagKey string, evalCtx map[string]any) (
 	variant string, variants map[string]interface{}, reason string, metadata map[string]interface{}, err error,
 ) {
-
 	var selector store.Selector
 	s := ctx.Value(store.SelectorContextKey{})
 	if s != nil {

--- a/core/pkg/evaluator/mock/ievaluator.go
+++ b/core/pkg/evaluator/mock/ievaluator.go
@@ -23,6 +23,7 @@ import (
 type MockIEvaluator struct {
 	ctrl     *gomock.Controller
 	recorder *MockIEvaluatorMockRecorder
+	isgomock struct{}
 }
 
 // MockIEvaluatorMockRecorder is the mock recorder for MockIEvaluator.
@@ -43,9 +44,9 @@ func (m *MockIEvaluator) EXPECT() *MockIEvaluatorMockRecorder {
 }
 
 // ResolveAllValues mocks base method.
-func (m *MockIEvaluator) ResolveAllValues(ctx context.Context, reqID string, context map[string]any) ([]evaluator.AnyValue, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveAllValues(ctx context.Context, reqID string, arg2 map[string]any) ([]evaluator.AnyValue, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, context)
+	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, arg2)
 	ret0, _ := ret[0].([]evaluator.AnyValue)
 	ret1, _ := ret[1].(model.Metadata)
 	ret2, _ := ret[2].(error)
@@ -53,29 +54,29 @@ func (m *MockIEvaluator) ResolveAllValues(ctx context.Context, reqID string, con
 }
 
 // ResolveAllValues indicates an expected call of ResolveAllValues.
-func (mr *MockIEvaluatorMockRecorder) ResolveAllValues(ctx, reqID, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveAllValues(ctx, reqID, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAllValues", reflect.TypeOf((*MockIEvaluator)(nil).ResolveAllValues), ctx, reqID, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAllValues", reflect.TypeOf((*MockIEvaluator)(nil).ResolveAllValues), ctx, reqID, arg2)
 }
 
 // ResolveAsAnyValue mocks base method.
-func (m *MockIEvaluator) ResolveAsAnyValue(ctx context.Context, reqID, flagKey string, context map[string]any) evaluator.AnyValue {
+func (m *MockIEvaluator) ResolveAsAnyValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) evaluator.AnyValue {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveAsAnyValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveAsAnyValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(evaluator.AnyValue)
 	return ret0
 }
 
 // ResolveAsAnyValue indicates an expected call of ResolveAsAnyValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveAsAnyValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveAsAnyValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAsAnyValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveAsAnyValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAsAnyValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveAsAnyValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveBooleanValue mocks base method.
-func (m *MockIEvaluator) ResolveBooleanValue(ctx context.Context, reqID, flagKey string, context map[string]any) (bool, string, string, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveBooleanValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (bool, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveBooleanValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveBooleanValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -85,15 +86,15 @@ func (m *MockIEvaluator) ResolveBooleanValue(ctx context.Context, reqID, flagKey
 }
 
 // ResolveBooleanValue indicates an expected call of ResolveBooleanValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveBooleanValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveBooleanValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBooleanValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveBooleanValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBooleanValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveBooleanValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveFloatValue mocks base method.
-func (m *MockIEvaluator) ResolveFloatValue(ctx context.Context, reqID, flagKey string, context map[string]any) (float64, string, string, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveFloatValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (float64, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveFloatValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveFloatValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -103,15 +104,15 @@ func (m *MockIEvaluator) ResolveFloatValue(ctx context.Context, reqID, flagKey s
 }
 
 // ResolveFloatValue indicates an expected call of ResolveFloatValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveFloatValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveFloatValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFloatValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveFloatValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFloatValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveFloatValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveIntValue mocks base method.
-func (m *MockIEvaluator) ResolveIntValue(ctx context.Context, reqID, flagKey string, context map[string]any) (int64, string, string, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveIntValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (int64, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveIntValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveIntValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -121,15 +122,15 @@ func (m *MockIEvaluator) ResolveIntValue(ctx context.Context, reqID, flagKey str
 }
 
 // ResolveIntValue indicates an expected call of ResolveIntValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveIntValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveIntValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIntValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveIntValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIntValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveIntValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveObjectValue mocks base method.
-func (m *MockIEvaluator) ResolveObjectValue(ctx context.Context, reqID, flagKey string, context map[string]any) (map[string]any, string, string, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveObjectValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (map[string]any, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveObjectValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveObjectValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(map[string]any)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -139,15 +140,15 @@ func (m *MockIEvaluator) ResolveObjectValue(ctx context.Context, reqID, flagKey 
 }
 
 // ResolveObjectValue indicates an expected call of ResolveObjectValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveObjectValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveObjectValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveObjectValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveObjectValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveObjectValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveObjectValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveStringValue mocks base method.
-func (m *MockIEvaluator) ResolveStringValue(ctx context.Context, reqID, flagKey string, context map[string]any) (string, string, string, model.Metadata, error) {
+func (m *MockIEvaluator) ResolveStringValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (string, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveStringValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveStringValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -157,9 +158,9 @@ func (m *MockIEvaluator) ResolveStringValue(ctx context.Context, reqID, flagKey 
 }
 
 // ResolveStringValue indicates an expected call of ResolveStringValue.
-func (mr *MockIEvaluatorMockRecorder) ResolveStringValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIEvaluatorMockRecorder) ResolveStringValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveStringValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveStringValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveStringValue", reflect.TypeOf((*MockIEvaluator)(nil).ResolveStringValue), ctx, reqID, flagKey, arg3)
 }
 
 // SetState mocks base method.
@@ -180,6 +181,7 @@ func (mr *MockIEvaluatorMockRecorder) SetState(payload any) *gomock.Call {
 type MockIResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockIResolverMockRecorder
+	isgomock struct{}
 }
 
 // MockIResolverMockRecorder is the mock recorder for MockIResolver.
@@ -200,9 +202,9 @@ func (m *MockIResolver) EXPECT() *MockIResolverMockRecorder {
 }
 
 // ResolveAllValues mocks base method.
-func (m *MockIResolver) ResolveAllValues(ctx context.Context, reqID string, context map[string]any) ([]evaluator.AnyValue, model.Metadata, error) {
+func (m *MockIResolver) ResolveAllValues(ctx context.Context, reqID string, arg2 map[string]any) ([]evaluator.AnyValue, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, context)
+	ret := m.ctrl.Call(m, "ResolveAllValues", ctx, reqID, arg2)
 	ret0, _ := ret[0].([]evaluator.AnyValue)
 	ret1, _ := ret[1].(model.Metadata)
 	ret2, _ := ret[2].(error)
@@ -210,29 +212,29 @@ func (m *MockIResolver) ResolveAllValues(ctx context.Context, reqID string, cont
 }
 
 // ResolveAllValues indicates an expected call of ResolveAllValues.
-func (mr *MockIResolverMockRecorder) ResolveAllValues(ctx, reqID, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveAllValues(ctx, reqID, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAllValues", reflect.TypeOf((*MockIResolver)(nil).ResolveAllValues), ctx, reqID, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAllValues", reflect.TypeOf((*MockIResolver)(nil).ResolveAllValues), ctx, reqID, arg2)
 }
 
 // ResolveAsAnyValue mocks base method.
-func (m *MockIResolver) ResolveAsAnyValue(ctx context.Context, reqID, flagKey string, context map[string]any) evaluator.AnyValue {
+func (m *MockIResolver) ResolveAsAnyValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) evaluator.AnyValue {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveAsAnyValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveAsAnyValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(evaluator.AnyValue)
 	return ret0
 }
 
 // ResolveAsAnyValue indicates an expected call of ResolveAsAnyValue.
-func (mr *MockIResolverMockRecorder) ResolveAsAnyValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveAsAnyValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAsAnyValue", reflect.TypeOf((*MockIResolver)(nil).ResolveAsAnyValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveAsAnyValue", reflect.TypeOf((*MockIResolver)(nil).ResolveAsAnyValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveBooleanValue mocks base method.
-func (m *MockIResolver) ResolveBooleanValue(ctx context.Context, reqID, flagKey string, context map[string]any) (bool, string, string, model.Metadata, error) {
+func (m *MockIResolver) ResolveBooleanValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (bool, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveBooleanValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveBooleanValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -242,15 +244,15 @@ func (m *MockIResolver) ResolveBooleanValue(ctx context.Context, reqID, flagKey 
 }
 
 // ResolveBooleanValue indicates an expected call of ResolveBooleanValue.
-func (mr *MockIResolverMockRecorder) ResolveBooleanValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveBooleanValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBooleanValue", reflect.TypeOf((*MockIResolver)(nil).ResolveBooleanValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBooleanValue", reflect.TypeOf((*MockIResolver)(nil).ResolveBooleanValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveFloatValue mocks base method.
-func (m *MockIResolver) ResolveFloatValue(ctx context.Context, reqID, flagKey string, context map[string]any) (float64, string, string, model.Metadata, error) {
+func (m *MockIResolver) ResolveFloatValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (float64, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveFloatValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveFloatValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(float64)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -260,15 +262,15 @@ func (m *MockIResolver) ResolveFloatValue(ctx context.Context, reqID, flagKey st
 }
 
 // ResolveFloatValue indicates an expected call of ResolveFloatValue.
-func (mr *MockIResolverMockRecorder) ResolveFloatValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveFloatValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFloatValue", reflect.TypeOf((*MockIResolver)(nil).ResolveFloatValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveFloatValue", reflect.TypeOf((*MockIResolver)(nil).ResolveFloatValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveIntValue mocks base method.
-func (m *MockIResolver) ResolveIntValue(ctx context.Context, reqID, flagKey string, context map[string]any) (int64, string, string, model.Metadata, error) {
+func (m *MockIResolver) ResolveIntValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (int64, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveIntValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveIntValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -278,15 +280,15 @@ func (m *MockIResolver) ResolveIntValue(ctx context.Context, reqID, flagKey stri
 }
 
 // ResolveIntValue indicates an expected call of ResolveIntValue.
-func (mr *MockIResolverMockRecorder) ResolveIntValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveIntValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIntValue", reflect.TypeOf((*MockIResolver)(nil).ResolveIntValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIntValue", reflect.TypeOf((*MockIResolver)(nil).ResolveIntValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveObjectValue mocks base method.
-func (m *MockIResolver) ResolveObjectValue(ctx context.Context, reqID, flagKey string, context map[string]any) (map[string]any, string, string, model.Metadata, error) {
+func (m *MockIResolver) ResolveObjectValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (map[string]any, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveObjectValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveObjectValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(map[string]any)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -296,15 +298,15 @@ func (m *MockIResolver) ResolveObjectValue(ctx context.Context, reqID, flagKey s
 }
 
 // ResolveObjectValue indicates an expected call of ResolveObjectValue.
-func (mr *MockIResolverMockRecorder) ResolveObjectValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveObjectValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveObjectValue", reflect.TypeOf((*MockIResolver)(nil).ResolveObjectValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveObjectValue", reflect.TypeOf((*MockIResolver)(nil).ResolveObjectValue), ctx, reqID, flagKey, arg3)
 }
 
 // ResolveStringValue mocks base method.
-func (m *MockIResolver) ResolveStringValue(ctx context.Context, reqID, flagKey string, context map[string]any) (string, string, string, model.Metadata, error) {
+func (m *MockIResolver) ResolveStringValue(ctx context.Context, reqID, flagKey string, arg3 map[string]any) (string, string, string, model.Metadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolveStringValue", ctx, reqID, flagKey, context)
+	ret := m.ctrl.Call(m, "ResolveStringValue", ctx, reqID, flagKey, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -314,7 +316,7 @@ func (m *MockIResolver) ResolveStringValue(ctx context.Context, reqID, flagKey s
 }
 
 // ResolveStringValue indicates an expected call of ResolveStringValue.
-func (mr *MockIResolverMockRecorder) ResolveStringValue(ctx, reqID, flagKey, context any) *gomock.Call {
+func (mr *MockIResolverMockRecorder) ResolveStringValue(ctx, reqID, flagKey, arg3 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveStringValue", reflect.TypeOf((*MockIResolver)(nil).ResolveStringValue), ctx, reqID, flagKey, context)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveStringValue", reflect.TypeOf((*MockIResolver)(nil).ResolveStringValue), ctx, reqID, flagKey, arg3)
 }

--- a/core/pkg/sync/builder/mock/syncbuilder.go
+++ b/core/pkg/sync/builder/mock/syncbuilder.go
@@ -22,6 +22,7 @@ import (
 type MockISyncBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockISyncBuilderMockRecorder
+	isgomock struct{}
 }
 
 // MockISyncBuilderMockRecorder is the mock recorder for MockISyncBuilder.
@@ -42,39 +43,40 @@ func (m *MockISyncBuilder) EXPECT() *MockISyncBuilderMockRecorder {
 }
 
 // SyncFromURI mocks base method.
-func (m *MockISyncBuilder) SyncFromURI(uri string, logger *logger.Logger) (sync.ISync, error) {
+func (m *MockISyncBuilder) SyncFromURI(uri string, arg1 *logger.Logger) (sync.ISync, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncFromURI", uri, logger)
+	ret := m.ctrl.Call(m, "SyncFromURI", uri, arg1)
 	ret0, _ := ret[0].(sync.ISync)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SyncFromURI indicates an expected call of SyncFromURI.
-func (mr *MockISyncBuilderMockRecorder) SyncFromURI(uri, logger any) *gomock.Call {
+func (mr *MockISyncBuilderMockRecorder) SyncFromURI(uri, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFromURI", reflect.TypeOf((*MockISyncBuilder)(nil).SyncFromURI), uri, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFromURI", reflect.TypeOf((*MockISyncBuilder)(nil).SyncFromURI), uri, arg1)
 }
 
 // SyncsFromConfig mocks base method.
-func (m *MockISyncBuilder) SyncsFromConfig(sourceConfig []sync.SourceConfig, logger *logger.Logger) ([]sync.ISync, error) {
+func (m *MockISyncBuilder) SyncsFromConfig(sourceConfig []sync.SourceConfig, arg1 *logger.Logger) ([]sync.ISync, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncsFromConfig", sourceConfig, logger)
+	ret := m.ctrl.Call(m, "SyncsFromConfig", sourceConfig, arg1)
 	ret0, _ := ret[0].([]sync.ISync)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SyncsFromConfig indicates an expected call of SyncsFromConfig.
-func (mr *MockISyncBuilderMockRecorder) SyncsFromConfig(sourceConfig, logger any) *gomock.Call {
+func (mr *MockISyncBuilderMockRecorder) SyncsFromConfig(sourceConfig, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncsFromConfig", reflect.TypeOf((*MockISyncBuilder)(nil).SyncsFromConfig), sourceConfig, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncsFromConfig", reflect.TypeOf((*MockISyncBuilder)(nil).SyncsFromConfig), sourceConfig, arg1)
 }
 
 // MockIK8sClientBuilder is a mock of IK8sClientBuilder interface.
 type MockIK8sClientBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockIK8sClientBuilderMockRecorder
+	isgomock struct{}
 }
 
 // MockIK8sClientBuilderMockRecorder is the mock recorder for MockIK8sClientBuilder.

--- a/core/pkg/sync/grpc/credentials/mock/builder.go
+++ b/core/pkg/sync/grpc/credentials/mock/builder.go
@@ -20,6 +20,7 @@ import (
 type MockBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockBuilderMockRecorder
+	isgomock struct{}
 }
 
 // MockBuilderMockRecorder is the mock recorder for MockBuilder.

--- a/core/pkg/sync/grpc/grpc_sync.go
+++ b/core/pkg/sync/grpc/grpc_sync.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-feature/flagd/core/pkg/sync"
 	grpccredential "github.com/open-feature/flagd/core/pkg/sync/grpc/credentials"
 	_ "github.com/open-feature/flagd/core/pkg/sync/grpc/nameresolvers" // initialize custom resolvers e.g. envoy.Init()
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -39,7 +40,7 @@ type FlagSyncServiceClient interface {
 	syncv1grpc.FlagSyncServiceClient
 }
 type FlagSyncServiceClientResponse interface {
-	syncv1grpc.FlagSyncService_SyncFlagsClient
+	grpc.ServerStreamingClient[v1.SyncFlagsResponse]
 }
 
 type Sync struct {
@@ -109,7 +110,7 @@ func (g *Sync) contextWithHeaders(ctx context.Context) context.Context {
 }
 
 func (g *Sync) ReSync(ctx context.Context, dataSync chan<- sync.DataSync) error {
-	res, err := g.client.FetchAllFlags(g.contextWithHeaders(ctx), &v1.FetchAllFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+	res, err := g.client.FetchAllFlags(g.contextWithHeaders(ctx), &v1.FetchAllFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector}) //nolint:staticcheck // Deprecated: migrate to Flagd-Selector header
 	if err != nil {
 		err = fmt.Errorf("error fetching all flags: %w", err)
 		g.Logger.Error(err.Error())
@@ -128,25 +129,23 @@ func (g *Sync) IsReady() bool {
 }
 
 func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
-	g.Logger.Info(fmt.Sprintf("starting sync from %s", g.URI))
+	g.Logger.Info("starting sync", zap.String("uri", g.URI))
 
 	// Initialize SyncFlags client. This fails if server connection establishment fails (ex:- grpc server offline)
-	g.Logger.Debug(fmt.Sprintf("initial stream connection to %s", g.URI))
-	syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+	g.Logger.Debug("initial stream connection", zap.String("uri", g.URI))
+	syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector}) //nolint:staticcheck // Deprecated: migrate to Flagd-Selector header
 	if err != nil {
 		return fmt.Errorf("unable to sync flags: %w", err)
 	}
 
-	g.Logger.Debug(fmt.Sprintf("watching %s for changes", g.URI))
+	g.Logger.Debug("watching for changes", zap.String("uri", g.URI))
 
 	// Initial stream listening. Error will be logged and continue and retry connection establishment
-	err = g.handleFlagSync(syncClient, dataSync)
-	if err == nil {
+	err = g.handleFlagSync(syncClient, dataSync) //nolint:staticcheck
+	if err != nil {                              //nolint:staticcheck
 		// This should not happen as handleFlagSync expects to return with an error
-		return nil
+		g.Logger.Warn("error with stream listener", zap.Error(err))
 	}
-
-	g.Logger.Warn(fmt.Sprintf("error with stream listener: %s", err.Error()))
 
 	// retry connection establishment
 	for {
@@ -156,9 +155,9 @@ func (g *Sync) Sync(ctx context.Context, dataSync chan<- sync.DataSync) error {
 			return nil
 		}
 
-		err = g.handleFlagSync(syncClient, dataSync)
-		if err != nil {
-			g.Logger.Warn(fmt.Sprintf("error with stream listener: %s", err.Error()))
+		err = g.handleFlagSync(syncClient, dataSync) //nolint:staticcheck
+		if err != nil {                              //nolint:staticcheck
+			g.Logger.Warn("error with stream listener", zap.Error(err))
 			continue
 		}
 	}
@@ -193,7 +192,7 @@ func (g *Sync) connectWithRetry(
 
 		g.Logger.Warn(fmt.Sprintf("connection re-establishment attempt in-progress for grpc target: %s", g.URI))
 
-		syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector})
+		syncClient, err := g.client.SyncFlags(g.contextWithHeaders(ctx), &v1.SyncFlagsRequest{ProviderId: g.ProviderID, Selector: g.Selector}) //nolint:staticcheck // Deprecated: migrate to Flagd-Selector header
 		if err != nil {
 			g.Logger.Debug(fmt.Sprintf("error opening service client: %s", err.Error()))
 			continue
@@ -205,7 +204,7 @@ func (g *Sync) connectWithRetry(
 }
 
 // handleFlagSync wraps the stream listening and push updates through dataSync channel
-func (g *Sync) handleFlagSync(stream syncv1grpc.FlagSyncService_SyncFlagsClient, dataSync chan<- sync.DataSync) error {
+func (g *Sync) handleFlagSync(stream syncv1grpc.FlagSyncService_SyncFlagsClient, dataSync chan<- sync.DataSync) error { //nolint:staticcheck
 	g.ready.Store(true)
 
 	for {

--- a/core/pkg/sync/grpc/mock/grpc.go
+++ b/core/pkg/sync/grpc/mock/grpc.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	syncv1grpc "buf.build/gen/go/open-feature/flagd/grpc/go/flagd/sync/v1/syncv1grpc"
 	syncv1 "buf.build/gen/go/open-feature/flagd/protocolbuffers/go/flagd/sync/v1"
 	gomock "go.uber.org/mock/gomock"
 	grpc "google.golang.org/grpc"
@@ -24,6 +23,7 @@ import (
 type MockFlagSyncServiceClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockFlagSyncServiceClientMockRecorder
+	isgomock struct{}
 }
 
 // MockFlagSyncServiceClientMockRecorder is the mock recorder for MockFlagSyncServiceClient.
@@ -84,14 +84,14 @@ func (mr *MockFlagSyncServiceClientMockRecorder) GetMetadata(ctx, in any, opts .
 }
 
 // SyncFlags mocks base method.
-func (m *MockFlagSyncServiceClient) SyncFlags(ctx context.Context, in *syncv1.SyncFlagsRequest, opts ...grpc.CallOption) (syncv1grpc.FlagSyncService_SyncFlagsClient, error) {
+func (m *MockFlagSyncServiceClient) SyncFlags(ctx context.Context, in *syncv1.SyncFlagsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[syncv1.SyncFlagsResponse], error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SyncFlags", varargs...)
-	ret0, _ := ret[0].(syncv1grpc.FlagSyncService_SyncFlagsClient)
+	ret0, _ := ret[0].(grpc.ServerStreamingClient[syncv1.SyncFlagsResponse])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -107,6 +107,7 @@ func (mr *MockFlagSyncServiceClientMockRecorder) SyncFlags(ctx, in any, opts ...
 type MockFlagSyncServiceClientResponse struct {
 	ctrl     *gomock.Controller
 	recorder *MockFlagSyncServiceClientResponseMockRecorder
+	isgomock struct{}
 }
 
 // MockFlagSyncServiceClientResponseMockRecorder is the mock recorder for MockFlagSyncServiceClientResponse.

--- a/core/pkg/sync/http/mock/http.go
+++ b/core/pkg/sync/http/mock/http.go
@@ -20,6 +20,7 @@ import (
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
+	isgomock struct{}
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.

--- a/core/pkg/utils/hash.go
+++ b/core/pkg/utils/hash.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GenerateSha(body []byte) string {
-	hasher := sha3.New256()
+	hasher := sha3.New256() //nolint:govet
 	hasher.Write(canonicalize(body))
 	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 }

--- a/flagd-proxy/build.Dockerfile
+++ b/flagd-proxy/build.Dockerfile
@@ -1,6 +1,6 @@
 # Main Dockerfile for flagd builds
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 
 WORKDIR /src
 

--- a/flagd-proxy/go.mod
+++ b/flagd-proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-feature/flagd/flagd-proxy
 
-go 1.25.5
+go 1.27.0
 
 require (
 	buf.build/gen/go/open-feature/flagd/grpc/go v1.6.1-20260217192757-1388a552fc3c.1

--- a/flagd-proxy/pkg/service/handler.go
+++ b/flagd-proxy/pkg/service/handler.go
@@ -29,7 +29,7 @@ func (nh *handler) SyncFlags(
 	defer cancel()
 	errChan := make(chan error)
 	dataSync := make(chan sync.DataSync)
-	nh.syncStore.RegisterSubscription(ctx, request.GetSelector(), request, dataSync, errChan)
+	nh.syncStore.RegisterSubscription(ctx, request.GetSelector(), request, dataSync, errChan) //nolint:staticcheck // Deprecated: migrate to Flagd-Selector header
 	for {
 		select {
 		case e := <-errChan:
@@ -52,7 +52,7 @@ func (nh *handler) FetchAllFlags(
 	ctx context.Context,
 	request *syncv12.FetchAllFlagsRequest,
 ) (*syncv12.FetchAllFlagsResponse, error) {
-	data, err := nh.syncStore.FetchAllFlags(ctx, request, request.GetSelector())
+	data, err := nh.syncStore.FetchAllFlags(ctx, request, request.GetSelector()) //nolint:staticcheck // Deprecated: migrate to Flagd-Selector header
 	if err != nil {
 		return &syncv12.FetchAllFlagsResponse{}, fmt.Errorf("error fetching all flags from sync store: %w", err)
 	}

--- a/flagd/build.Dockerfile
+++ b/flagd/build.Dockerfile
@@ -1,6 +1,6 @@
 # Main Dockerfile for flagd builds
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 
 WORKDIR /src
 

--- a/flagd/go.mod
+++ b/flagd/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-feature/flagd/flagd
 
-go 1.25.5
+go 1.27.0
 
 require (
 	buf.build/gen/go/open-feature/flagd/connectrpc/go v1.19.1-20260217192757-1388a552fc3c.2

--- a/flagd/pkg/service/flag-evaluation/mock/eventstream.go
+++ b/flagd/pkg/service/flag-evaluation/mock/eventstream.go
@@ -20,6 +20,7 @@ import (
 type MockeventStreamSenderV2 struct {
 	ctrl     *gomock.Controller
 	recorder *MockeventStreamSenderV2MockRecorder
+	isgomock struct{}
 }
 
 // MockeventStreamSenderV2MockRecorder is the mock recorder for MockeventStreamSenderV2.

--- a/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/ofrep_service.go
@@ -39,7 +39,7 @@ func NewOfrepService(
 ) (*Service, error) {
 	corsMiddleware := corsmw.New(origins)
 
-	var h http.Handler = NewOfrepHandler(
+	h := NewOfrepHandler(
 		cfg.Logger,
 		evaluator,
 		contextValues,

--- a/flagd/pkg/service/middleware/mock/interface.go
+++ b/flagd/pkg/service/middleware/mock/interface.go
@@ -20,6 +20,7 @@ import (
 type MockIMiddleware struct {
 	ctrl     *gomock.Controller
 	recorder *MockIMiddlewareMockRecorder
+	isgomock struct{}
 }
 
 // MockIMiddlewareMockRecorder is the mock recorder for MockIMiddleware.

--- a/flagd/profile.Dockerfile
+++ b/flagd/profile.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile with pprof profiler
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
## This PR

<!-- add the description of the PR here -->

- bump go to 1.27.0
- bump golangci-lint and gomock as side effect of the bump

### Notes

<!-- any additional notes for this PR -->

- core package stays on 1.25 for maximum backward compatibility support
