### PR TITLE
chore: OFREP ETag response based on full response body.

### DIFF
--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -107,16 +107,10 @@ func (rec *responseRecorder) flush() {
 	}
 }
 
-// ifNoneMatch reports whether any of the client's If-None-Match field values selects the
-// representation tagged with etag. Per RFC 9110 §13.1.2 the field is either "*" or a list of
-// entity tags, repeated fields extend that list, and the comparison is weak.
-//
-// net/http parses this too, but scanETag and checkIfNoneMatch are unexported, and the one
-// exported way in, http.ServeContent, answers a failed precondition on a non-GET method with 412
-// rather than the 304 OFREP asks for on this POST route.
-//
-// The scan is more forgiving than net/http's, which abandons the whole field on the first entry
-// that is not a syntactically valid entity tag.
+// ifNoneMatch reports whether any If-None-Match value selects the representation tagged with etag.
+// Per RFC 9110 13.1.2 the field is "*" or a weakly-compared list of entity tags. 
+// Hand-rolled because net/http's parser is unexported and its only public path (ServeContent) answers 412,
+// not the 304 OFREP wants on this POST route.
 func ifNoneMatch(fields []string, etag string) bool {
 	for _, field := range fields {
 		for _, candidate := range splitETagList(field) {

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -25,7 +25,7 @@ func conditionalETag(next http.Handler) http.Handler {
 		etag := bodyETag(rec.body.Bytes())
 		w.Header().Set("ETag", quoteETag(etag))
 
-		if clientETag := r.Header.Get("If-None-Match"); clientETag != "" && normalizeETag(clientETag) == etag {
+		if ifNoneMatch(r.Header.Values("If-None-Match"), etag) {
 			w.Header().Del("Content-Type")
 			w.Header().Del("Content-Length")
 			w.WriteHeader(http.StatusNotModified)
@@ -71,9 +71,67 @@ func bodyETag(body []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// normalizeETag lets quoted and unquoted forms compare equal.
+// ifNoneMatch reports whether any of the client's If-None-Match field values selects the
+// representation tagged with etag. Per RFC 9110 §13.1.2 the field is either "*" or a list of
+// entity tags, repeated fields extend that list, and the comparison is weak.
+//
+// net/http parses this too, but scanETag and checkIfNoneMatch are unexported, and the one
+// exported way in, http.ServeContent, answers a failed precondition on a non-GET method with 412
+// rather than the 304 OFREP asks for on this POST route.
+//
+// The scan is more forgiving than net/http's, which abandons the whole field on the first entry
+// that is not a syntactically valid entity tag. A malformed entry is compared as an opaque token
+// instead, so neither it nor an unquoted tag hides a valid tag listed beside it. Erring this way
+// only ever costs a client the bandwidth of a body it already holds.
+func ifNoneMatch(fields []string, etag string) bool {
+	for _, field := range fields {
+		for _, candidate := range splitETagList(field) {
+			if candidate == "*" || normalizeETag(candidate) == etag {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// splitETagList splits a list of entity tags on its commas. A comma inside a quoted tag belongs
+// to the tag, so the split tracks quoting instead of reaching for strings.Split.
+func splitETagList(list string) []string {
+	var (
+		tags    []string
+		current strings.Builder
+		quoted  bool
+	)
+
+	flush := func() {
+		if tag := strings.TrimSpace(current.String()); tag != "" {
+			tags = append(tags, tag)
+		}
+		current.Reset()
+	}
+
+	for i := 0; i < len(list); i++ {
+		switch c := list[i]; {
+		case c == '"':
+			quoted = !quoted
+			current.WriteByte(c)
+		case c == ',' && !quoted:
+			flush()
+		default:
+			current.WriteByte(c)
+		}
+	}
+	flush()
+
+	return tags
+}
+
+// normalizeETag reduces an entity tag to the opaque value the weak comparison function looks at:
+// neither the quotes nor a weakness prefix carries meaning there. Dropping the quotes also lets
+// the unquoted form a lenient client may send compare equal.
 func normalizeETag(etag string) string {
-	return strings.Trim(etag, `"`)
+	return strings.Trim(strings.TrimPrefix(etag, "W/"), `"`)
 }
 
 func quoteETag(etag string) string {

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -1,0 +1,81 @@
+package ofrep
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+)
+
+// conditionalETag tags a 200 with a strong ETag over the bytes the handler wrote, and answers 304
+// when the client's If-None-Match matches. Hashing the response rather than the flag configuration
+// keeps the validator correct for context-dependent values; the trade is that producing the tag
+// needs the response, so a 304 saves bandwidth, not work.
+func conditionalETag(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		if rec.status != http.StatusOK {
+			rec.flush()
+			return
+		}
+
+		etag := bodyETag(rec.body.Bytes())
+		w.Header().Set("ETag", quoteETag(etag))
+
+		if clientETag := r.Header.Get("If-None-Match"); clientETag != "" && normalizeETag(clientETag) == etag {
+			w.Header().Del("Content-Type")
+			w.Header().Del("Content-Length")
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		rec.flush()
+	})
+}
+
+type responseRecorder struct {
+	http.ResponseWriter
+
+	status  int
+	body    bytes.Buffer
+	written bool
+}
+
+func (rec *responseRecorder) WriteHeader(status int) {
+	if rec.written {
+		return
+	}
+	rec.status = status
+	rec.written = true
+}
+
+func (rec *responseRecorder) Write(b []byte) (int, error) {
+	if !rec.written {
+		rec.WriteHeader(http.StatusOK)
+	}
+	return rec.body.Write(b)
+}
+
+func (rec *responseRecorder) flush() {
+	rec.ResponseWriter.WriteHeader(rec.status)
+	if rec.body.Len() > 0 {
+		_, _ = rec.ResponseWriter.Write(rec.body.Bytes())
+	}
+}
+
+func bodyETag(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+// normalizeETag lets quoted and unquoted forms compare equal.
+func normalizeETag(etag string) string {
+	return strings.Trim(etag, `"`)
+}
+
+func quoteETag(etag string) string {
+	return `"` + etag + `"`
+}

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -131,32 +131,31 @@ func ifNoneMatch(fields []string, etag string) bool {
 
 // splitETagList splits a list of entity tags on its commas. A comma inside a quoted tag belongs
 // to the tag, so the split tracks quoting instead of reaching for strings.Split.
-func splitETagList(list string) []string {
-	var (
-		tags    []string
-		current strings.Builder
-		quoted  bool
-	)
-
-	flush := func() {
-		if tag := strings.TrimSpace(current.String()); tag != "" {
-			tags = append(tags, tag)
+func splitETagList(list string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		var (
+			start  int
+			quoted bool
+		)
+		flush := func(end int) bool {
+			if tag := strings.TrimSpace(list[start:end]); tag != "" {
+				if !yield(tag) {
+					return false
+				}
+			}
+			return true
 		}
-		current.Reset()
-	}
-
-	for i := 0; i < len(list); i++ {
-		switch c := list[i]; {
-		case c == '"':
-			quoted = !quoted
-			current.WriteByte(c)
-		case c == ',' && !quoted:
-			flush()
-		default:
-			current.WriteByte(c)
+		for i := 0; i < len(list); i++ {
+			switch c := list[i]; {
+			case c == '"':
+				quoted = !quoted
+			case c == ',' && !quoted:
+				if !flush(i) {
+					return
+				}
+				start = i + 1
+			}
 		}
+		flush(len(list))
 	}
-	flush()
-
-	return tags
 }

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -4,17 +4,21 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"hash"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 // conditionalETag tags a 200 with a strong ETag over the bytes the handler wrote, and answers 304
 // when the client's If-None-Match matches. Hashing the response rather than the flag configuration
-// keeps the validator correct for context-dependent values; the trade is that producing the tag
-// needs the response, so a 304 saves bandwidth, not work.
+// keeps the validator correct for context-dependent values.
 func conditionalETag(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rec := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		body := getBodyBuffer()
+		defer putBodyBuffer(body)
+
+		rec := newResponseRecorder(w, body)
 		next.ServeHTTP(rec, r)
 
 		if rec.status != http.StatusOK {
@@ -22,7 +26,7 @@ func conditionalETag(next http.Handler) http.Handler {
 			return
 		}
 
-		etag := bodyETag(rec.body.Bytes())
+		etag := rec.etag()
 		w.Header().Set("ETag", quoteETag(etag))
 
 		if ifNoneMatch(r.Header.Values("If-None-Match"), etag) {
@@ -36,12 +40,42 @@ func conditionalETag(next http.Handler) http.Handler {
 	})
 }
 
+// bodyBuffers recycles response buffers: consecutive bulk evaluations are close in size, so a
+// recycled buffer already holds the capacity the next one needs.
+var bodyBuffers = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// getBodyBuffer lends out an empty buffer.
+func getBodyBuffer() *bytes.Buffer {
+	buf := bodyBuffers.Get().(*bytes.Buffer)
+	buf.Reset()
+
+	return buf
+}
+
+// putBodyBuffer returns a buffer whatever it grew to.
+func putBodyBuffer(buf *bytes.Buffer) {
+	bodyBuffers.Put(buf)
+}
+
 type responseRecorder struct {
 	http.ResponseWriter
 
 	status  int
-	body    bytes.Buffer
+	body    *bytes.Buffer
+	digest  hash.Hash
 	written bool
+}
+
+// newResponseRecorder records into body, hashing as it goes.
+func newResponseRecorder(w http.ResponseWriter, body *bytes.Buffer) *responseRecorder {
+	return &responseRecorder{
+		ResponseWriter: w,
+		status:         http.StatusOK,
+		body:           body,
+		digest:         sha256.New(),
+	}
 }
 
 func (rec *responseRecorder) WriteHeader(status int) {
@@ -56,7 +90,13 @@ func (rec *responseRecorder) Write(b []byte) (int, error) {
 	if !rec.written {
 		rec.WriteHeader(http.StatusOK)
 	}
+	_, _ = rec.digest.Write(b) // never errors
+
 	return rec.body.Write(b)
+}
+
+func (rec *responseRecorder) etag() string {
+	return hex.EncodeToString(rec.digest.Sum(nil))
 }
 
 func (rec *responseRecorder) flush() {
@@ -64,11 +104,6 @@ func (rec *responseRecorder) flush() {
 	if rec.body.Len() > 0 {
 		_, _ = rec.ResponseWriter.Write(rec.body.Bytes())
 	}
-}
-
-func bodyETag(body []byte) string {
-	sum := sha256.Sum256(body)
-	return hex.EncodeToString(sum[:])
 }
 
 // ifNoneMatch reports whether any of the client's If-None-Match field values selects the
@@ -80,9 +115,7 @@ func bodyETag(body []byte) string {
 // rather than the 304 OFREP asks for on this POST route.
 //
 // The scan is more forgiving than net/http's, which abandons the whole field on the first entry
-// that is not a syntactically valid entity tag. A malformed entry is compared as an opaque token
-// instead, so neither it nor an unquoted tag hides a valid tag listed beside it. Erring this way
-// only ever costs a client the bandwidth of a body it already holds.
+// that is not a syntactically valid entity tag.
 func ifNoneMatch(fields []string, etag string) bool {
 	for _, field := range fields {
 		for _, candidate := range splitETagList(field) {

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"hash"
+	"iter"
 	"net/http"
 	"strings"
 	"sync"
@@ -108,12 +109,12 @@ func (rec *responseRecorder) flush() {
 }
 
 // ifNoneMatch reports whether any If-None-Match value selects the representation tagged with etag.
-// Per RFC 9110 13.1.2 the field is "*" or a weakly-compared list of entity tags. 
+// Per RFC 9110 13.1.2 the field is "*" or a weakly-compared list of entity tags.
 // Hand-rolled because net/http's parser is unexported and its only public path (ServeContent) answers 412,
 // not the 304 OFREP wants on this POST route.
 func ifNoneMatch(fields []string, etag string) bool {
 	for _, field := range fields {
-		for _, candidate := range splitETagList(field) {
+		for candidate := range splitETagList(field) {
 			if candidate == "*" {
 				return true
 			}

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag.go
@@ -13,7 +13,7 @@ import (
 // conditionalETag tags a 200 with a strong ETag over the bytes the handler wrote, and answers 304
 // when the client's If-None-Match matches. Hashing the response rather than the flag configuration
 // keeps the validator correct for context-dependent values.
-func conditionalETag(next http.Handler) http.Handler {
+func conditionalETag(configEtagDiffers func(*http.Request) bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := getBodyBuffer()
 		defer putBodyBuffer(body)
@@ -27,9 +27,10 @@ func conditionalETag(next http.Handler) http.Handler {
 		}
 
 		etag := rec.etag()
-		w.Header().Set("ETag", quoteETag(etag))
+		w.Header().Set("ETag", etag)
 
-		if ifNoneMatch(r.Header.Values("If-None-Match"), etag) {
+		// ADR-0008 §9: a differing flagConfigEtag dictates a 200 no validator may downgrade.
+		if !configEtagDiffers(r) && ifNoneMatch(r.Header.Values("If-None-Match"), etag) {
 			w.Header().Del("Content-Type")
 			w.Header().Del("Content-Length")
 			w.WriteHeader(http.StatusNotModified)
@@ -96,7 +97,7 @@ func (rec *responseRecorder) Write(b []byte) (int, error) {
 }
 
 func (rec *responseRecorder) etag() string {
-	return hex.EncodeToString(rec.digest.Sum(nil))
+	return `"` + hex.EncodeToString(rec.digest.Sum(nil)) + `"`
 }
 
 func (rec *responseRecorder) flush() {
@@ -119,7 +120,13 @@ func (rec *responseRecorder) flush() {
 func ifNoneMatch(fields []string, etag string) bool {
 	for _, field := range fields {
 		for _, candidate := range splitETagList(field) {
-			if candidate == "*" || normalizeETag(candidate) == etag {
+			if candidate == "*" {
+				return true
+			}
+
+			// a lenient client may drop the quotes the generated tag carries
+			candidate = strings.TrimPrefix(candidate, "W/")
+			if candidate == etag || `"`+candidate+`"` == etag {
 				return true
 			}
 		}
@@ -158,15 +165,4 @@ func splitETagList(list string) []string {
 	flush()
 
 	return tags
-}
-
-// normalizeETag reduces an entity tag to the opaque value the weak comparison function looks at:
-// neither the quotes nor a weakness prefix carries meaning there. Dropping the quotes also lets
-// the unquoted form a lenient client may send compare equal.
-func normalizeETag(etag string) string {
-	return strings.Trim(strings.TrimPrefix(etag, "W/"), `"`)
-}
-
-func quoteETag(etag string) string {
-	return `"` + etag + `"`
 }

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
@@ -12,6 +12,19 @@ import (
 func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest.ResponseRecorder {
 	t.Helper()
 
+	var fields []string
+	if ifNoneMatch != "" {
+		fields = []string{ifNoneMatch}
+	}
+
+	return serveWithETagFields(t, status, body, fields)
+}
+
+// serveWithETagFields sends one If-None-Match header line per field, which is how a client spreads
+// its validators over repeated fields instead of one list.
+func serveWithETagFields(t *testing.T, status int, body string, ifNoneMatch []string) *httptest.ResponseRecorder {
+	t.Helper()
+
 	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
@@ -19,8 +32,8 @@ func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest
 	}))
 
 	req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil)
-	if ifNoneMatch != "" {
-		req.Header.Set("If-None-Match", ifNoneMatch)
+	for _, field := range ifNoneMatch {
+		req.Header.Add("If-None-Match", field)
 	}
 
 	recorder := httptest.NewRecorder()
@@ -78,6 +91,57 @@ func TestConditionalETag_StaleValidatorIsServedFresh(t *testing.T) {
 	assert.NotEqual(t, `"stale"`, recorder.Header().Get("ETag"))
 }
 
+// If-None-Match is a list, not a single value: any member matching under weak comparison is a hit.
+func TestConditionalETag_ValidatorListForms(t *testing.T) {
+	const body = `{"flags":[]}`
+	current := serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag")
+	require.NotEmpty(t, current)
+
+	for name, tests := range map[string]struct {
+		ifNoneMatch string
+		want        int
+	}{
+		"wildcard":                     {`*`, http.StatusNotModified},
+		"current tag last in list":     {`"stale", ` + current, http.StatusNotModified},
+		"current tag first in list":    {current + `, "stale"`, http.StatusNotModified},
+		"weak current tag":             {`W/` + current, http.StatusNotModified},
+		"weak current tag in list":     {`W/"stale", W/` + current, http.StatusNotModified},
+		"unquoted current tag in list": {`"stale",` + normalizeETag(current), http.StatusNotModified},
+		"empty list entries":           {`, ,` + current, http.StatusNotModified},
+		"only stale tags":              {`"stale", W/"staler"`, http.StatusOK},
+		"empty list":                   {`,`, http.StatusOK},
+		// net/http stops scanning at the first entry that is not a valid entity tag, which would
+		// let junk hide the tag beside it. This scan compares the junk and carries on.
+		"malformed entry beside a valid tag": {`bogus, ` + current, http.StatusNotModified},
+		"unterminated quoted tag":            {`"` + normalizeETag(current), http.StatusNotModified},
+		// The wildcard has to be the whole entry, which is stricter than net/http.
+		"wildcard with trailing junk": {`*junk`, http.StatusOK},
+		// A comma inside a quoted tag belongs to the tag, so this is one stale validator rather
+		// than a list whose members happen to bracket the current tag.
+		"comma inside a quoted tag": {`"` + normalizeETag(current) + `,` + normalizeETag(current) + `"`, http.StatusOK},
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := serveWithETag(t, http.StatusOK, body, tests.ifNoneMatch)
+
+			assert.Equal(t, tests.want, recorder.Code)
+			assert.Equal(t, current, recorder.Header().Get("ETag"), "the tag names the representation either way")
+		})
+	}
+}
+
+// Repeated header fields carry the same meaning as one comma-joined list.
+func TestConditionalETag_RepeatedValidatorFields(t *testing.T) {
+	const body = `{"flags":[]}`
+	current := serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag")
+	require.NotEmpty(t, current)
+
+	recorder := serveWithETagFields(t, http.StatusOK, body, []string{`"stale"`, current})
+	assert.Equal(t, http.StatusNotModified, recorder.Code)
+
+	stale := serveWithETagFields(t, http.StatusOK, body, []string{`"stale"`, `"staler"`})
+	assert.Equal(t, http.StatusOK, stale.Code)
+}
+
 // A stale validator must not 304 an error body.
 func TestConditionalETag_NonOKResponsesAreNotTagged(t *testing.T) {
 	for _, status := range []int{
@@ -107,6 +171,31 @@ func TestConditionalETag_ImplicitOK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.NotEmpty(t, recorder.Header().Get("ETag"))
 	assert.Equal(t, `{"flags":[]}`, recorder.Body.String())
+}
+
+func TestSplitETagList(t *testing.T) {
+	for name, tests := range map[string]struct {
+		list string
+		want []string
+	}{
+		"empty":               {"", nil},
+		"single tag":          {`"abc"`, []string{`"abc"`}},
+		"list":                {`"abc", "def"`, []string{`"abc"`, `"def"`}},
+		"list without spaces": {`"abc","def"`, []string{`"abc"`, `"def"`}},
+		"weak tags":           {`W/"abc", W/"def"`, []string{`W/"abc"`, `W/"def"`}},
+		"wildcard":            {`*`, []string{`*`}},
+		"unquoted tag":        {`abc`, []string{`abc`}},
+		"empty entries":       {`, "abc" , ,`, []string{`"abc"`}},
+		"only separators":     {` , `, nil},
+		"comma inside a tag":  {`"a,b"`, []string{`"a,b"`}},
+		"comma inside a tag in a list": {
+			`"a,b", "c"`, []string{`"a,b"`, `"c"`},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tests.want, splitETagList(tests.list))
+		})
+	}
 }
 
 // An empty 200 is still a representation, so it gets a validator.

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
@@ -1,0 +1,118 @@
+package ofrep
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil)
+	if ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", ifNoneMatch)
+	}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestConditionalETag_HashesWrittenBytes(t *testing.T) {
+	const body = `{"flags":[{"key":"a","value":true}],"metadata":{}}`
+
+	first := serveWithETag(t, http.StatusOK, body, "")
+	require.Equal(t, http.StatusOK, first.Code)
+	assert.Equal(t, body, first.Body.String(), "the body must pass through untouched")
+
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	assert.Equal(t, quoteETag(bodyETag([]byte(body))), etag, "the tag must be the hash of the written bytes")
+
+	t.Run("identical bytes yield the same tag", func(t *testing.T) {
+		assert.Equal(t, etag, serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag"))
+	})
+
+	t.Run("any byte difference yields a new tag", func(t *testing.T) {
+		changed := serveWithETag(t, http.StatusOK, `{"flags":[{"key":"a","value":false}],"metadata":{}}`, "")
+		assert.NotEqual(t, etag, changed.Header().Get("ETag"))
+	})
+}
+
+func TestConditionalETag_NotModified(t *testing.T) {
+	const body = `{"flags":[]}`
+	etag := serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	recorder := serveWithETag(t, http.StatusOK, body, etag)
+
+	assert.Equal(t, http.StatusNotModified, recorder.Code)
+	assert.Equal(t, etag, recorder.Header().Get("ETag"), "a 304 must still name the representation")
+	assert.Empty(t, recorder.Body.String(), "a 304 must not carry a body")
+	assert.Empty(t, recorder.Header().Get("Content-Type"), "a 304 must not describe a body it does not have")
+}
+
+func TestConditionalETag_UnquotedValidatorMatches(t *testing.T) {
+	const body = `{"flags":[]}`
+	etag := serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag")
+
+	recorder := serveWithETag(t, http.StatusOK, body, normalizeETag(etag))
+	assert.Equal(t, http.StatusNotModified, recorder.Code)
+}
+
+func TestConditionalETag_StaleValidatorIsServedFresh(t *testing.T) {
+	recorder := serveWithETag(t, http.StatusOK, `{"flags":[]}`, `"stale"`)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, `{"flags":[]}`, recorder.Body.String())
+	assert.NotEqual(t, `"stale"`, recorder.Header().Get("ETag"))
+}
+
+// A stale validator must not 304 an error body.
+func TestConditionalETag_NonOKResponsesAreNotTagged(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadRequest,
+		http.StatusInternalServerError,
+		http.StatusRequestEntityTooLarge,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			body := `{"errorDetails":"nope"}`
+			recorder := serveWithETag(t, status, body, quoteETag(bodyETag([]byte(body))))
+
+			assert.Equal(t, status, recorder.Code)
+			assert.Empty(t, recorder.Header().Get("ETag"))
+			assert.Equal(t, body, recorder.Body.String())
+		})
+	}
+}
+
+func TestConditionalETag_ImplicitOK(t *testing.T) {
+	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"flags":[]}`))
+	}))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.NotEmpty(t, recorder.Header().Get("ETag"))
+	assert.Equal(t, `{"flags":[]}`, recorder.Body.String())
+}
+
+// An empty 200 is still a representation, so it gets a validator.
+func TestConditionalETag_EmptyBody(t *testing.T) {
+	recorder := serveWithETag(t, http.StatusOK, "", "")
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, quoteETag(bodyETag(nil)), recorder.Header().Get("ETag"))
+}

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -215,7 +216,7 @@ func TestSplitETagList(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tests.want, splitETagList(tests.list))
+			assert.Equal(t, tests.want, slices.Collect(splitETagList(tests.list)))
 		})
 	}
 }

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
@@ -1,13 +1,23 @@
 package ofrep
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// bodyETag recomputes the tag in one shot, so the assertions cross-check the recorder's incremental
+// digest rather than restating it.
+func bodyETag(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
 
 func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest.ResponseRecorder {
 	t.Helper()
@@ -204,4 +214,43 @@ func TestConditionalETag_EmptyBody(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, quoteETag(bodyETag(nil)), recorder.Header().Get("ETag"))
+}
+
+// A large body followed by a small one lands the small response in a recycled buffer whose capacity
+// still holds the large one's bytes.
+func TestConditionalETag_RecycledBufferCarriesNoStaleBytes(t *testing.T) {
+	const small = `{"flags":[]}`
+	large := strings.Repeat(small, 512)
+
+	require.Equal(t, large, serveWithETag(t, http.StatusOK, large, "").Body.String())
+
+	recorder := serveWithETag(t, http.StatusOK, small, "")
+	assert.Equal(t, small, recorder.Body.String(), "the recycled buffer must not prepend the previous body")
+	assert.Equal(t, quoteETag(bodyETag([]byte(small))), recorder.Header().Get("ETag"),
+		"the digest must cover this response only")
+}
+
+// benchWriter keeps httptest.NewRecorder's per-iteration allocations out of the measurement.
+type benchWriter struct{ header http.Header }
+
+func (w *benchWriter) Header() http.Header         { return w.header }
+func (w *benchWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *benchWriter) WriteHeader(int)             {}
+
+// BenchmarkConditionalETag guards B/op: the pool should keep it far below the body size.
+func BenchmarkConditionalETag(b *testing.B) {
+	body := []byte(`{"flags":[` + strings.Repeat(`{"key":"flag","value":true,"reason":"STATIC"},`, 512) + `]}`)
+	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil)
+	w := &benchWriter{header: http.Header{}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(w, req)
+	}
 }

--- a/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/etag_test.go
@@ -16,8 +16,16 @@ import (
 // digest rather than restating it.
 func bodyETag(body []byte) string {
 	sum := sha256.Sum256(body)
-	return hex.EncodeToString(sum[:])
+	return `"` + hex.EncodeToString(sum[:]) + `"`
 }
+
+func unquote(etag string) string { return strings.Trim(etag, `"`) }
+
+// quotedETag is a strong entity-tag: exactly one pair of quotes around the hex digest.
+const quotedETag = `^"[0-9a-f]{64}"$`
+
+// noConfigEtagVeto isolates the header path; the veto is covered in sse_bulk_test.go.
+func noConfigEtagVeto(*http.Request) bool { return false }
 
 func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest.ResponseRecorder {
 	t.Helper()
@@ -35,7 +43,7 @@ func serveWithETag(t *testing.T, status int, body, ifNoneMatch string) *httptest
 func serveWithETagFields(t *testing.T, status int, body string, ifNoneMatch []string) *httptest.ResponseRecorder {
 	t.Helper()
 
-	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := conditionalETag(noConfigEtagVeto, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
@@ -60,7 +68,8 @@ func TestConditionalETag_HashesWrittenBytes(t *testing.T) {
 
 	etag := first.Header().Get("ETag")
 	require.NotEmpty(t, etag)
-	assert.Equal(t, quoteETag(bodyETag([]byte(body))), etag, "the tag must be the hash of the written bytes")
+	assert.Regexp(t, quotedETag, etag, "the tag must carry exactly one pair of quotes")
+	assert.Equal(t, bodyETag([]byte(body)), etag, "the tag must be the hash of the written bytes")
 
 	t.Run("identical bytes yield the same tag", func(t *testing.T) {
 		assert.Equal(t, etag, serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag"))
@@ -89,7 +98,7 @@ func TestConditionalETag_UnquotedValidatorMatches(t *testing.T) {
 	const body = `{"flags":[]}`
 	etag := serveWithETag(t, http.StatusOK, body, "").Header().Get("ETag")
 
-	recorder := serveWithETag(t, http.StatusOK, body, normalizeETag(etag))
+	recorder := serveWithETag(t, http.StatusOK, body, unquote(etag))
 	assert.Equal(t, http.StatusNotModified, recorder.Code)
 }
 
@@ -116,19 +125,22 @@ func TestConditionalETag_ValidatorListForms(t *testing.T) {
 		"current tag first in list":    {current + `, "stale"`, http.StatusNotModified},
 		"weak current tag":             {`W/` + current, http.StatusNotModified},
 		"weak current tag in list":     {`W/"stale", W/` + current, http.StatusNotModified},
-		"unquoted current tag in list": {`"stale",` + normalizeETag(current), http.StatusNotModified},
+		"unquoted current tag in list": {`"stale",` + unquote(current), http.StatusNotModified},
 		"empty list entries":           {`, ,` + current, http.StatusNotModified},
 		"only stale tags":              {`"stale", W/"staler"`, http.StatusOK},
 		"empty list":                   {`,`, http.StatusOK},
 		// net/http stops scanning at the first entry that is not a valid entity tag, which would
 		// let junk hide the tag beside it. This scan compares the junk and carries on.
 		"malformed entry beside a valid tag": {`bogus, ` + current, http.StatusNotModified},
-		"unterminated quoted tag":            {`"` + normalizeETag(current), http.StatusNotModified},
+		// Comparison is against the quoted tag, so a bare tag matches and a half-quoted one cannot.
+		"unterminated quoted tag": {`"` + unquote(current), http.StatusOK},
 		// The wildcard has to be the whole entry, which is stricter than net/http.
 		"wildcard with trailing junk": {`*junk`, http.StatusOK},
+		// The wildcard is matched before the weakness prefix is trimmed, so W/* is not one.
+		"weak wildcard": {`W/*`, http.StatusOK},
 		// A comma inside a quoted tag belongs to the tag, so this is one stale validator rather
 		// than a list whose members happen to bracket the current tag.
-		"comma inside a quoted tag": {`"` + normalizeETag(current) + `,` + normalizeETag(current) + `"`, http.StatusOK},
+		"comma inside a quoted tag": {`"` + unquote(current) + `,` + unquote(current) + `"`, http.StatusOK},
 	} {
 		t.Run(name, func(t *testing.T) {
 			recorder := serveWithETag(t, http.StatusOK, body, tests.ifNoneMatch)
@@ -161,7 +173,7 @@ func TestConditionalETag_NonOKResponsesAreNotTagged(t *testing.T) {
 	} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			body := `{"errorDetails":"nope"}`
-			recorder := serveWithETag(t, status, body, quoteETag(bodyETag([]byte(body))))
+			recorder := serveWithETag(t, status, body, bodyETag([]byte(body)))
 
 			assert.Equal(t, status, recorder.Code)
 			assert.Empty(t, recorder.Header().Get("ETag"))
@@ -171,7 +183,7 @@ func TestConditionalETag_NonOKResponsesAreNotTagged(t *testing.T) {
 }
 
 func TestConditionalETag_ImplicitOK(t *testing.T) {
-	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := conditionalETag(noConfigEtagVeto, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"flags":[]}`))
 	}))
 
@@ -213,11 +225,10 @@ func TestConditionalETag_EmptyBody(t *testing.T) {
 	recorder := serveWithETag(t, http.StatusOK, "", "")
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, quoteETag(bodyETag(nil)), recorder.Header().Get("ETag"))
+	assert.Equal(t, bodyETag(nil), recorder.Header().Get("ETag"))
 }
 
-// A large body followed by a small one lands the small response in a recycled buffer whose capacity
-// still holds the large one's bytes.
+// A small response lands in a recycled buffer whose capacity still holds the large one's bytes.
 func TestConditionalETag_RecycledBufferCarriesNoStaleBytes(t *testing.T) {
 	const small = `{"flags":[]}`
 	large := strings.Repeat(small, 512)
@@ -226,7 +237,7 @@ func TestConditionalETag_RecycledBufferCarriesNoStaleBytes(t *testing.T) {
 
 	recorder := serveWithETag(t, http.StatusOK, small, "")
 	assert.Equal(t, small, recorder.Body.String(), "the recycled buffer must not prepend the previous body")
-	assert.Equal(t, quoteETag(bodyETag([]byte(small))), recorder.Header().Get("ETag"),
+	assert.Equal(t, bodyETag([]byte(small)), recorder.Header().Get("ETag"),
 		"the digest must cover this response only")
 }
 
@@ -240,7 +251,7 @@ func (w *benchWriter) WriteHeader(int)             {}
 // BenchmarkConditionalETag guards B/op: the pool should keep it far below the body size.
 func BenchmarkConditionalETag(b *testing.B) {
 	body := []byte(`{"flags":[` + strings.Repeat(`{"key":"flag","value":true,"reason":"STATIC"},`, 512) + `]}`)
-	handler := conditionalETag(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := conditionalETag(noConfigEtagVeto, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 	}))

--- a/flagd/pkg/service/flag-evaluation/ofrep/handler.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/handler.go
@@ -31,10 +31,9 @@ const (
 	bulkEvaluation   = "/ofrep/v1/evaluate/{path:flags\\/|flags}"
 )
 
-// configVersioner resolves the current config ETag / last-modified time for an SSE channel so
-// the bulk handler can serve conditional (ETag/304) responses consistent with the SSE stream.
-// Implemented by the OFREP SSE change tracker; nil when SSE is disabled. ok is false whenever no
-// stream for the channel is live, which is the normal state before a client connects.
+// configVersioner resolves when the flag configuration behind an SSE channel last changed, for the
+// ADR-0008 flagConfigLastModified metadata. Implemented by the SSE change tracker; nil when SSE is
+// disabled, and ok is false until a stream for the channel is live.
 type configVersioner interface {
 	Version(channel string) (etag string, lastModified int64, ok bool)
 }
@@ -94,13 +93,14 @@ func NewOfrepHandler(
 		}).Handler(http.HandlerFunc(h.HandleFlagEvaluation)),
 	).Methods("POST")
 
+	// conditionalETag sits inside the metrics middleware so a 304 is recorded as a 304.
 	router.Handle(bulkEvaluation,
 		metricsmw.NewHTTPMetric(metricsmw.Config{
 			Service:        serviceName,
 			MetricRecorder: metricsRecorder,
 			Logger:         logger,
 			HandlerID:      bulkEvaluation,
-		}).Handler(http.HandlerFunc(h.HandleBulkEvaluation)),
+		}).Handler(conditionalETag(http.HandlerFunc(h.HandleBulkEvaluation))),
 	).Methods("POST")
 
 	return otelhttp.NewHandler(router, "flagd.ofrep")
@@ -172,12 +172,8 @@ func (h *handler) HandleBulkEvaluation(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := context.WithValue(r.Context(), store.SelectorContextKey{}, selector)
 
-	// Conditional evaluation (ADR-0008): short-circuit with 304 when the client already holds
-	// the current config version.
-	lastModified, notModified := h.applyConditionalETag(w, r, selectorExpression)
-	if notModified {
-		w.WriteHeader(http.StatusNotModified)
-		return
+	if trigger := r.URL.Query().Get(flagConfigEtagParam); trigger != "" {
+		h.Logger.Debug(fmt.Sprintf("bulk refetch triggered by %s=%s", flagConfigEtagParam, trigger))
 	}
 
 	evaluations, metadata, err := h.evaluator.ResolveAllValues(ctx, requestID, evaluationContext)
@@ -196,28 +192,21 @@ func (h *handler) HandleBulkEvaluation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.writeJSONToResponse(http.StatusOK,
-		h.bulkResponse(selectorExpression, evaluations, metadata, lastModified), w)
+		h.bulkResponse(selectorExpression, evaluations, metadata, h.configLastModified(selectorExpression)), w)
 }
 
-// applyConditionalETag resolves the current config version for the selector, sets the ETag
-// response header, and reports the lastModified time plus whether the request can be answered
-// with 304 Not Modified. It is a no-op (returns notModified=false) when SSE/versioning is off.
-func (h *handler) applyConditionalETag(w http.ResponseWriter, r *http.Request, channel string) (lastModified int64, notModified bool) {
+// configLastModified reports when the flag configuration behind the selector last changed, or 0
+// when nothing is tracking it. The tracker's config ETag is deliberately unused: it describes the
+// configuration, not the response, so it cannot validate this endpoint's cache.
+func (h *handler) configLastModified(channel string) int64 {
 	if h.versioner == nil {
-		return 0, false
+		return 0
 	}
-	etag, lastModified, ok := h.versioner.Version(channel)
-	if !ok || etag == "" {
-		return lastModified, false
+	_, lastModified, ok := h.versioner.Version(channel)
+	if !ok {
+		return 0
 	}
-	w.Header().Set("ETag", quoteETag(etag))
-
-	if trigger := r.URL.Query().Get(flagConfigEtagParam); trigger != "" {
-		h.Logger.Debug(fmt.Sprintf("bulk refetch triggered by %s=%s", flagConfigEtagParam, trigger))
-	}
-
-	clientCacheETag := r.Header.Get("If-None-Match")
-	return lastModified, clientCacheETag != "" && normalizeETag(clientCacheETag) == etag
+	return lastModified
 }
 
 // bulkResponse assembles the OFREP bulk response, adding the ADR-0008 eventStreams block and
@@ -259,18 +248,8 @@ func (h *handler) eventStreams(selectorExpression string) []ofrep.EventStream {
 
 // flagConfigEtagParam is the ADR-0008 query parameter carrying the config version that an SSE
 // refetch event advertised. It is trigger metadata only; the conditional response is decided by
-// the If-None-Match header. See applyConditionalETag.
+// the If-None-Match header.
 const flagConfigEtagParam = "flagConfigEtag"
-
-// normalizeETag strips optional surrounding quotes so quoted and unquoted forms compare equal.
-func normalizeETag(etag string) string {
-	return strings.Trim(etag, `"`)
-}
-
-// quoteETag wraps a bare ETag value in the double quotes required by the HTTP ETag header.
-func quoteETag(etag string) string {
-	return `"` + etag + `"`
-}
 
 func (h *handler) writeJSONToResponse(status int, payload interface{}, w http.ResponseWriter) {
 	// first marshal payload

--- a/flagd/pkg/service/flag-evaluation/ofrep/handler.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/handler.go
@@ -172,10 +172,6 @@ func (h *handler) HandleBulkEvaluation(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := context.WithValue(r.Context(), store.SelectorContextKey{}, selector)
 
-	if trigger := r.URL.Query().Get(flagConfigEtagParam); trigger != "" {
-		h.Logger.Debug(fmt.Sprintf("bulk refetch triggered by %s=%s", flagConfigEtagParam, trigger))
-	}
-
 	evaluations, metadata, err := h.evaluator.ResolveAllValues(ctx, requestID, evaluationContext)
 	if h.metricsRecorder != nil {
 		for _, evaluation := range evaluations {

--- a/flagd/pkg/service/flag-evaluation/ofrep/handler.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/handler.go
@@ -100,7 +100,7 @@ func NewOfrepHandler(
 			MetricRecorder: metricsRecorder,
 			Logger:         logger,
 			HandlerID:      bulkEvaluation,
-		}).Handler(conditionalETag(http.HandlerFunc(h.HandleBulkEvaluation))),
+		}).Handler(conditionalETag(h.configEtagDiffers, http.HandlerFunc(h.HandleBulkEvaluation))),
 	).Methods("POST")
 
 	return otelhttp.NewHandler(router, "flagd.ofrep")
@@ -247,9 +247,25 @@ func (h *handler) eventStreams(selectorExpression string) []ofrep.EventStream {
 }
 
 // flagConfigEtagParam is the ADR-0008 query parameter carrying the config version that an SSE
-// refetch event advertised. It is trigger metadata only; the conditional response is decided by
-// the If-None-Match header.
+// refetch event advertised.
 const flagConfigEtagParam = "flagConfigEtag"
+
+// configEtagDiffers reports whether the client's flagConfigEtag names a config version other than
+// the one its selector resolves to now. A param that cannot be compared does not differ.
+func (h *handler) configEtagDiffers(r *http.Request) bool {
+	trigger := r.URL.Query().Get(flagConfigEtagParam)
+	if trigger == "" || h.versioner == nil {
+		return false
+	}
+
+	current, _, ok := h.versioner.Version(r.Header.Get(service.FLAGD_SELECTOR_HEADER))
+	if !ok {
+		return false
+	}
+
+	// quoted so the shared scan accepts the param bare, quoted, or weak
+	return !ifNoneMatch([]string{trigger}, `"`+current+`"`)
+}
 
 func (h *handler) writeJSONToResponse(status int, payload interface{}, w http.ResponseWriter) {
 	// first marshal payload

--- a/flagd/pkg/service/flag-evaluation/ofrep/sse/event.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/sse/event.go
@@ -10,7 +10,7 @@ const eventName = "message"
 
 type refetchPayload struct {
 	Type         string `json:"type"`
-	Etag         string `json:"etag,omitempty"`
+	Etag         string `json:"etag,omitempty"` // config version token, not an HTTP entity-tag
 	LastModified int64  `json:"lastModified,omitempty"`
 }
 

--- a/flagd/pkg/service/flag-evaluation/ofrep/sse/service_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/sse/service_test.go
@@ -2,6 +2,7 @@ package sse
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +64,11 @@ func TestService_PublishesRefetchOnChange(t *testing.T) {
 	select {
 	case ev := <-stream.Events:
 		assert.Equal(t, eventName, ev.Event())
-		assert.Contains(t, ev.Data(), refetchEventType)
+
+		var payload refetchPayload
+		require.NoError(t, json.Unmarshal([]byte(ev.Data()), &payload))
+		assert.Equal(t, refetchEventType, payload.Type)
+		assert.NotEmpty(t, payload.Etag, "the event must carry the config version")
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for refetch event on channel fs1")
 	}

--- a/flagd/pkg/service/flag-evaluation/ofrep/sse_bulk_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/sse_bulk_test.go
@@ -2,6 +2,7 @@ package ofrep
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -43,103 +44,158 @@ func newBulkRequest(t *testing.T, selectorHeader, clientEtag string) *http.Reque
 	return req
 }
 
+// serveBulk mirrors the production route, so conditionalETag is exercised.
 func serveBulk(h handler, req *http.Request) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
 	router := mux.NewRouter()
-	router.HandleFunc(bulkEvaluation, h.HandleBulkEvaluation)
+	router.Handle(bulkEvaluation, conditionalETag(http.HandlerFunc(h.HandleBulkEvaluation)))
 	router.ServeHTTP(recorder, req)
 	return recorder
 }
 
-func TestHandleBulkEvaluation_NotModified(t *testing.T) {
-	log := logger.NewLogger(nil, false)
-	eval := mock.NewMockIEvaluator(gomock.NewController(t))
-	// evaluation must be skipped on a 304
-	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+func bulkRequestWithContext(t *testing.T, evalContext map[string]any, clientEtag string) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(ofrep.Request{Context: evalContext})
+	require.NoError(t, err)
 
-	h := handler{
-		Logger:                log,
-		evaluator:             eval,
-		versioner:             fakeVersioner{etag: "abc123", ok: true},
-		sseEnabled:            true,
-		sseInactivityDelaySec: 120,
+	req, err := http.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Host = "flagd.example:8016"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(svc.FLAGD_SELECTOR_HEADER, "flagSetId=fs1")
+	if clientEtag != "" {
+		req.Header.Set("If-None-Match", clientEtag)
 	}
-
-	recorder := serveBulk(h, newBulkRequest(t, "flagSetId=fs1", `"abc123"`))
-
-	assert.Equal(t, http.StatusNotModified, recorder.Code)
-	assert.Equal(t, `"abc123"`, recorder.Header().Get("ETag"))
+	return req
 }
 
-// The 304 decision must use If-None-Match (the client's cached version), not the ADR-0008
-// flagConfigEtag change-trigger metadata.
+func boolFlag(key string, value bool) evaluator.AnyValue {
+	variant := "off"
+	if value {
+		variant = "on"
+	}
+	return evaluator.AnyValue{Value: value, Variant: variant, Reason: model.StaticReason, FlagKey: key}
+}
+
+func TestHandleBulkEvaluation_ETagCoversResponseBody(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+
+	serve := func(values []evaluator.AnyValue, clientEtag string) *httptest.ResponseRecorder {
+		eval := mock.NewMockIEvaluator(gomock.NewController(t))
+		eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(values, model.Metadata{}, nil)
+
+		h := handler{Logger: log, evaluator: eval}
+		return serveBulk(h, newBulkRequest(t, "flagSetId=fs1", clientEtag))
+	}
+
+	first := serve([]evaluator.AnyValue{boolFlag("a", true)}, "")
+	require.Equal(t, http.StatusOK, first.Code)
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	t.Run("identical response yields the same validator", func(t *testing.T) {
+		again := serve([]evaluator.AnyValue{boolFlag("a", true)}, "")
+		assert.Equal(t, etag, again.Header().Get("ETag"))
+	})
+
+	t.Run("matching validator yields an empty 304", func(t *testing.T) {
+		conditional := serve([]evaluator.AnyValue{boolFlag("a", true)}, etag)
+		assert.Equal(t, http.StatusNotModified, conditional.Code)
+		assert.Equal(t, etag, conditional.Header().Get("ETag"))
+		assert.Empty(t, conditional.Body.String(), "a 304 must not carry a body")
+	})
+
+	t.Run("a changed evaluated value invalidates the validator", func(t *testing.T) {
+		changed := serve([]evaluator.AnyValue{boolFlag("a", false)}, etag)
+		require.Equal(t, http.StatusOK, changed.Code, "a different resolved value must not be served as 304")
+		assert.NotEqual(t, etag, changed.Header().Get("ETag"))
+	})
+}
+
+// Regression test for the config-scoped validator: ofrep-web only drops its cached ETag when
+// targetingKey changes, so any other context change sent a stale If-None-Match and was answered
+// 304 with evaluations for the previous context.
+func TestHandleBulkEvaluation_ContextChangeInvalidatesETag(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+
+	// same flag configuration throughout; only the context differs
+	serve := func(evalContext map[string]any, clientEtag string) *httptest.ResponseRecorder {
+		eval := mock.NewMockIEvaluator(gomock.NewController(t))
+		eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, ec map[string]any) ([]evaluator.AnyValue, model.Metadata, error) {
+				return []evaluator.AnyValue{boolFlag("discount-banner", ec["plan"] == "pro")}, model.Metadata{}, nil
+			})
+
+		h := handler{
+			Logger:     log,
+			evaluator:  eval,
+			versioner:  fakeVersioner{etag: "unchanged-config", lastModified: 1700000000, ok: true},
+			sseEnabled: true,
+		}
+		return serveBulk(h, bulkRequestWithContext(t, evalContext, clientEtag))
+	}
+
+	free := serve(map[string]any{"targetingKey": "user-1", "plan": "free"}, "")
+	require.Equal(t, http.StatusOK, free.Code)
+	freeEtag := free.Header().Get("ETag")
+	require.NotEmpty(t, freeEtag)
+
+	// targetingKey is unchanged, so ofrep-web keeps sending the cached validator
+	pro := serve(map[string]any{"targetingKey": "user-1", "plan": "pro"}, freeEtag)
+
+	require.Equal(t, http.StatusOK, pro.Code,
+		"a context change must be served fresh even when the flag configuration is untouched")
+	assert.NotEqual(t, freeEtag, pro.Header().Get("ETag"))
+
+	var resp ofrep.BulkEvaluationResponse
+	require.NoError(t, json.Unmarshal(pro.Body.Bytes(), &resp))
+	require.Len(t, resp.Flags, 1)
+	flag, ok := resp.Flags[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, flag["value"], "the response must carry values for the new context")
+}
+
+// The 304 decision must use If-None-Match, not the ADR-0008 flagConfigEtag trigger metadata.
 func TestHandleBulkEvaluation_ConditionalUsesIfNoneMatch(t *testing.T) {
 	log := logger.NewLogger(nil, false)
-	const current = "etag-v2"
+	values := []evaluator.AnyValue{boolFlag("a", true)}
 
-	tests := []struct {
-		name           string
-		flagConfigEtag string // query param (change-trigger metadata)
-		ifNoneMatch    string // header (cache validator)
-		wantStatus     int
-		wantEval       bool
-	}{
-		{
-			name:           "stale cache echoing new trigger etag is served fresh (regression)",
-			flagConfigEtag: "etag-v2",
-			ifNoneMatch:    `"etag-v1"`,
-			wantStatus:     http.StatusOK,
-			wantEval:       true,
-		},
-		{
-			name:        "current cache validator yields 304",
-			ifNoneMatch: `"etag-v2"`,
-			wantStatus:  http.StatusNotModified,
-			wantEval:    false,
-		},
-		{
-			name:           "trigger etag alone (no validator) is served fresh",
-			flagConfigEtag: "etag-v2",
-			wantStatus:     http.StatusOK,
-			wantEval:       true,
-		},
+	serve := func(t *testing.T, query, ifNoneMatch string) *httptest.ResponseRecorder {
+		t.Helper()
+		eval := mock.NewMockIEvaluator(gomock.NewController(t))
+		eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(values, model.Metadata{}, nil)
+
+		req, err := http.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags"+query, bytes.NewReader([]byte{}))
+		require.NoError(t, err)
+		req.Header.Set(svc.FLAGD_SELECTOR_HEADER, "flagSetId=fs1")
+		if ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+
+		h := handler{Logger: log, evaluator: eval, versioner: fakeVersioner{etag: "cfg", ok: true}, sseEnabled: true}
+		return serveBulk(h, req)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			eval := mock.NewMockIEvaluator(gomock.NewController(t))
-			expect := eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
-				Return([]evaluator.AnyValue{}, model.Metadata{}, nil)
-			if tt.wantEval {
-				expect.Times(1)
-			} else {
-				expect.Times(0)
-			}
+	current := serve(t, "", "").Header().Get("ETag")
+	require.NotEmpty(t, current)
 
-			h := handler{
-				Logger:     log,
-				evaluator:  eval,
-				versioner:  fakeVersioner{etag: current, ok: true},
-				sseEnabled: true,
-			}
+	t.Run("current validator yields 304", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotModified, serve(t, "", current).Code)
+	})
 
-			url := "/ofrep/v1/evaluate/flags"
-			if tt.flagConfigEtag != "" {
-				url += "?flagConfigEtag=" + tt.flagConfigEtag
-			}
-			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader([]byte{}))
-			require.NoError(t, err)
-			req.Header.Set(svc.FLAGD_SELECTOR_HEADER, "flagSetId=fs1")
-			if tt.ifNoneMatch != "" {
-				req.Header.Set("If-None-Match", tt.ifNoneMatch)
-			}
+	t.Run("stale validator is served fresh", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "", `"stale"`).Code)
+	})
 
-			recorder := serveBulk(h, req)
+	t.Run("trigger etag alone is not a validator", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=cfg", "").Code)
+	})
 
-			assert.Equal(t, tt.wantStatus, recorder.Code)
-			assert.Equal(t, `"`+current+`"`, recorder.Header().Get("ETag"))
-		})
-	}
+	t.Run("trigger etag does not override a stale validator", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=cfg", `"stale"`).Code)
+	})
 }
 
 func TestHandleBulkEvaluation_AdvertisesEventStreams(t *testing.T) {
@@ -219,7 +275,7 @@ func TestHandleBulkEvaluation_AdvertisesEventStreams(t *testing.T) {
 			recorder := serveBulk(h, newBulkRequest(t, tt.selectorHeader, ""))
 
 			require.Equal(t, http.StatusOK, recorder.Code)
-			assert.Equal(t, `"etag-1"`, recorder.Header().Get("ETag"))
+			assert.NotEmpty(t, recorder.Header().Get("ETag"))
 
 			var resp ofrep.BulkEvaluationResponse
 			require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
@@ -241,23 +297,21 @@ func TestHandleBulkEvaluation_SSEDisabled_NoEventStreams(t *testing.T) {
 	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return([]evaluator.AnyValue{}, model.Metadata{}, nil)
 
-	// sseEnabled false, no versioner: behaves like the legacy handler
 	h := handler{Logger: log, evaluator: eval}
 
 	recorder := serveBulk(h, newBulkRequest(t, "", ""))
 
 	require.Equal(t, http.StatusOK, recorder.Code)
-	assert.Empty(t, recorder.Header().Get("ETag"))
+	// the validator describes the response, so it is offered regardless of SSE
+	assert.NotEmpty(t, recorder.Header().Get("ETag"))
 
 	var resp ofrep.BulkEvaluationResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	assert.Empty(t, resp.EventStreams)
 }
 
-// TestHandleBulkEvaluation_NoLiveStream_NoETag pins the contract that follows from tracking
-// versions per live subscription: with no stream open there is no cache validator to offer, so
-// the response is a plain 200 that still advertises eventStreams.
-func TestHandleBulkEvaluation_NoLiveStream_NoETag(t *testing.T) {
+// The validator comes from the response, so it needs no live subscription.
+func TestHandleBulkEvaluation_NoLiveStream_StillHasETag(t *testing.T) {
 	log := logger.NewLogger(nil, false)
 	eval := mock.NewMockIEvaluator(gomock.NewController(t))
 	eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -273,8 +327,8 @@ func TestHandleBulkEvaluation_NoLiveStream_NoETag(t *testing.T) {
 
 	recorder := serveBulk(h, newBulkRequest(t, "flagSetId=fs1", `"stale-etag"`))
 
-	require.Equal(t, http.StatusOK, recorder.Code, "without a tracked version we must not serve a 304")
-	assert.Empty(t, recorder.Header().Get("ETag"))
+	require.Equal(t, http.StatusOK, recorder.Code, "a stale validator must be served fresh")
+	assert.NotEmpty(t, recorder.Header().Get("ETag"))
 
 	var resp ofrep.BulkEvaluationResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))

--- a/flagd/pkg/service/flag-evaluation/ofrep/sse_bulk_test.go
+++ b/flagd/pkg/service/flag-evaluation/ofrep/sse_bulk_test.go
@@ -48,7 +48,7 @@ func newBulkRequest(t *testing.T, selectorHeader, clientEtag string) *http.Reque
 func serveBulk(h handler, req *http.Request) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
 	router := mux.NewRouter()
-	router.Handle(bulkEvaluation, conditionalETag(http.HandlerFunc(h.HandleBulkEvaluation)))
+	router.Handle(bulkEvaluation, conditionalETag(h.configEtagDiffers, http.HandlerFunc(h.HandleBulkEvaluation)))
 	router.ServeHTTP(recorder, req)
 	return recorder
 }
@@ -156,7 +156,8 @@ func TestHandleBulkEvaluation_ContextChangeInvalidatesETag(t *testing.T) {
 	assert.Equal(t, true, flag["value"], "the response must carry values for the new context")
 }
 
-// The 304 decision must use If-None-Match, not the ADR-0008 flagConfigEtag trigger metadata.
+// ADR-0008 §9: a differing flagConfigEtag dictates a 200 no validator may downgrade. Absent that
+// veto, the param takes no part in the decision.
 func TestHandleBulkEvaluation_ConditionalUsesIfNoneMatch(t *testing.T) {
 	log := logger.NewLogger(nil, false)
 	values := []evaluator.AnyValue{boolFlag("a", true)}
@@ -189,12 +190,74 @@ func TestHandleBulkEvaluation_ConditionalUsesIfNoneMatch(t *testing.T) {
 		assert.Equal(t, http.StatusOK, serve(t, "", `"stale"`).Code)
 	})
 
-	t.Run("trigger etag alone is not a validator", func(t *testing.T) {
-		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=cfg", "").Code)
+	t.Run("matching trigger etag alone is not a validator", func(t *testing.T) {
+		recorder := serve(t, "?flagConfigEtag=cfg", "")
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, current, recorder.Header().Get("ETag"), "the 200 still names the representation")
 	})
 
-	t.Run("trigger etag does not override a stale validator", func(t *testing.T) {
+	t.Run("differing trigger etag alone is served fresh", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=differs", "").Code)
+	})
+
+	t.Run("matching trigger etag does not rescue a stale validator", func(t *testing.T) {
 		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=cfg", `"stale"`).Code)
+	})
+
+	t.Run("differing trigger etag is not downgraded by a matching validator", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=differs", current).Code)
+	})
+
+	t.Run("matching trigger etag leaves normal conditional handling alone", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotModified, serve(t, "?flagConfigEtag=cfg", current).Code)
+	})
+
+	// A parse failure would read as "differs" and veto the 304, so a 304 proves the quoting parsed.
+	for name, query := range map[string]string{
+		"quoted trigger etag":      "?flagConfigEtag=%22cfg%22",
+		"weak quoted trigger etag": "?flagConfigEtag=W/%22cfg%22",
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, http.StatusNotModified, serve(t, query, current).Code)
+		})
+	}
+
+	t.Run("quoted differing trigger etag still vetoes", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=%22differs%22", current).Code)
+	})
+}
+
+// An uncomparable trigger etag neither grants a 304 nor vetoes one.
+func TestHandleBulkEvaluation_UncomparableTriggerEtag(t *testing.T) {
+	log := logger.NewLogger(nil, false)
+
+	serve := func(t *testing.T, query, ifNoneMatch string) *httptest.ResponseRecorder {
+		t.Helper()
+		eval := mock.NewMockIEvaluator(gomock.NewController(t))
+		eval.EXPECT().ResolveAllValues(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]evaluator.AnyValue{boolFlag("a", true)}, model.Metadata{}, nil)
+
+		req, err := http.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags"+query, bytes.NewReader([]byte{}))
+		require.NoError(t, err)
+		req.Header.Set(svc.FLAGD_SELECTOR_HEADER, "flagSetId=fs1")
+		if ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+
+		h := handler{Logger: log, evaluator: eval, versioner: fakeVersioner{etag: "cfg", ok: false}, sseEnabled: true}
+		return serveBulk(h, req)
+	}
+
+	current := serve(t, "", "").Header().Get("ETag")
+	require.NotEmpty(t, current)
+
+	t.Run("alone it grants nothing", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, serve(t, "?flagConfigEtag=anything", "").Code)
+	})
+
+	t.Run("it does not veto the validator", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotModified, serve(t, "?flagConfigEtag=anything", current).Code)
 	})
 }
 

--- a/flagd/pkg/service/middleware/cors/cors.go
+++ b/flagd/pkg/service/middleware/cors/cors.go
@@ -36,6 +36,8 @@ func New(allowedOrigins []string) *Middleware {
 				"Grpc-Message",
 				"Grpc-Status",
 				"Grpc-Status-Details-Bin",
+				// not safelisted, so browsers cannot read it to send If-None-Match
+				"ETag",
 			},
 		}),
 	}

--- a/flagd/pkg/service/middleware/cors/cors_test.go
+++ b/flagd/pkg/service/middleware/cors/cors_test.go
@@ -3,6 +3,7 @@ package cors
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-feature/flagd/flagd/pkg/service/middleware/mock"
@@ -41,4 +42,24 @@ func TestMiddleware(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// Without this a browser cannot read the ETag cross-origin, so it never sends If-None-Match and
+// the OFREP bulk endpoint's 304 path is unreachable.
+func TestMiddleware_ExposesETag(t *testing.T) {
+	handler := New([]string{"*"}).Handler(http.HandlerFunc(
+		func(writer http.ResponseWriter, _ *http.Request) {
+			writer.Header().Set("ETag", `"abc123"`)
+			writer.WriteHeader(http.StatusOK)
+		},
+	))
+
+	req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	exposed := recorder.Header().Get("Access-Control-Expose-Headers")
+	require.Contains(t, strings.ToLower(exposed), "etag")
 }


### PR DESCRIPTION
## This PR
The current ETag response from ofrep is based on the config version/context targeting key. There's a whole bunch of other attributes that are possible to change in the OFREP response that could invalidate the configuration and need to be taken into account of the response here.

This allows namely, the SSE URL to update between requests even if no other response values change. Without this, the old connection would be maintained and not updated/refreshes.

I wrote the etag handling as a middleware as this should be discrete from any actual body writing/response editing. The middleware should act discrete from the actual response and be a mutator to the headers/response code alone. 