### PR TITLE
feat!: make file poll interval configurable

### DIFF
--- a/core/pkg/sync/builder/syncbuilder.go
+++ b/core/pkg/sync/builder/syncbuilder.go
@@ -150,6 +150,7 @@ func (sb *SyncBuilder) newFsNotify(uri string, logger *logger.Logger) *file.Sync
 	return file.NewFileSync(
 		regFile.ReplaceAllString(uri, ""),
 		file.FSNOTIFY,
+		0, // poll interval is unused by the fsnotify watcher
 		logger.WithFields(
 			zap.String("component", "sync"),
 			zap.String("sync", syncProviderFsNotify),
@@ -162,6 +163,7 @@ func (sb *SyncBuilder) newFileInfo(uri string, logger *logger.Logger) *file.Sync
 	return file.NewFileSync(
 		regFile.ReplaceAllString(uri, ""),
 		file.FILEINFO,
+		0, // 0 => use the fileinfo watcher's default poll interval
 		logger.WithFields(
 			zap.String("component", "sync"),
 			zap.String("sync", syncProviderFileInfo),

--- a/core/pkg/sync/file/fileinfo_watcher.go
+++ b/core/pkg/sync/file/fileinfo_watcher.go
@@ -38,7 +38,7 @@ type fileInfoWatcher struct {
 const defaultFileInfoPollIntervalMs = 1000
 
 // NewFileInfoWatcher returns a new fileInfoWatcher
-func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger, pollIntervalMs int) Watcher {
+func NewFileInfoWatcher(ctx context.Context, pollIntervalMs int, logger *logger.Logger) Watcher {
 	if pollIntervalMs <= 0 {
 		pollIntervalMs = defaultFileInfoPollIntervalMs
 	}

--- a/core/pkg/sync/file/fileinfo_watcher.go
+++ b/core/pkg/sync/file/fileinfo_watcher.go
@@ -35,8 +35,13 @@ type fileInfoWatcher struct {
 	wg sync.WaitGroup
 }
 
+const defaultFileInfoPollIntervalMs = 1000
+
 // NewFileInfoWatcher returns a new fileInfoWatcher
-func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger) Watcher {
+func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger, pollIntervalMs int) Watcher {
+	if pollIntervalMs <= 0 {
+		pollIntervalMs = defaultFileInfoPollIntervalMs
+	}
 	fiw := &fileInfoWatcher{
 		evChan:   make(chan fsnotify.Event, 32),
 		erChan:   make(chan error, 32),
@@ -45,7 +50,7 @@ func NewFileInfoWatcher(ctx context.Context, logger *logger.Logger) Watcher {
 		watches:  make(map[string]fs.FileInfo),
 		done:     make(chan struct{}),
 	}
-	fiw.run(ctx, (1 * time.Second))
+	fiw.run(ctx, time.Duration(pollIntervalMs)*time.Millisecond)
 	return fiw
 }
 

--- a/core/pkg/sync/file/filepath_sync.go
+++ b/core/pkg/sync/file/filepath_sync.go
@@ -77,7 +77,7 @@ func (fs *Sync) Init(ctx context.Context) error {
 		}
 		fs.watcher = w
 	case FILEINFO:
-		w := NewFileInfoWatcher(ctx, fs.Logger, fs.pollIntervalMs)
+		w := NewFileInfoWatcher(ctx, fs.pollIntervalMs, fs.Logger)
 		fs.watcher = w
 	default:
 		return fmt.Errorf("unknown watcher type: '%s'", fs.watchType)

--- a/core/pkg/sync/file/filepath_sync.go
+++ b/core/pkg/sync/file/filepath_sync.go
@@ -41,18 +41,20 @@ type Sync struct {
 	URI    string
 	Logger *logger.Logger
 	// watchType indicates how to watch the file FSNOTIFY|FILEINFO
-	watchType string
-	watcher   Watcher
-	ready     bool
-	Mux       *msync.RWMutex
+	watchType      string
+	pollIntervalMs int
+	watcher        Watcher
+	ready          bool
+	Mux            *msync.RWMutex
 }
 
-func NewFileSync(uri string, watchType string, logger *logger.Logger) *Sync {
+func NewFileSync(uri string, watchType string, pollIntervalMs int, logger *logger.Logger) *Sync {
 	return &Sync{
-		URI:       uri,
-		watchType: watchType,
-		Logger:    logger,
-		Mux:       &msync.RWMutex{},
+		URI:            uri,
+		watchType:      watchType,
+		pollIntervalMs: pollIntervalMs,
+		Logger:         logger,
+		Mux:            &msync.RWMutex{},
 	}
 }
 
@@ -75,7 +77,7 @@ func (fs *Sync) Init(ctx context.Context) error {
 		}
 		fs.watcher = w
 	case FILEINFO:
-		w := NewFileInfoWatcher(ctx, fs.Logger)
+		w := NewFileInfoWatcher(ctx, fs.Logger, fs.pollIntervalMs)
 		fs.watcher = w
 	default:
 		return fmt.Errorf("unknown watcher type: '%s'", fs.watchType)

--- a/core/pkg/sync/file/filepath_sync_test.go
+++ b/core/pkg/sync/file/filepath_sync_test.go
@@ -392,3 +392,20 @@ func TestReAddWatcher_ContextCancelled(t *testing.T) {
 		t.Errorf("expected prompt return on cancellation, took %s", elapsed)
 	}
 }
+
+// TestNewFileSync_PollIntervalMs verifies the poll interval (in milliseconds) is threaded through the
+// constructor so the FILEINFO watcher can use it.
+func TestNewFileSync_PollIntervalMs(t *testing.T) {
+	want := 250
+	fs := NewFileSync("/tmp/flags.json", FILEINFO, want, logger.NewLogger(nil, false))
+
+	if fs.pollIntervalMs != want {
+		t.Errorf("expected pollIntervalMs %d, got %d", want, fs.pollIntervalMs)
+	}
+	if fs.watchType != FILEINFO {
+		t.Errorf("expected watchType %q, got %q", FILEINFO, fs.watchType)
+	}
+	if fs.URI != "/tmp/flags.json" {
+		t.Errorf("unexpected URI %q", fs.URI)
+	}
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- makes the poll interval for files configurable instead of the previously hard-coded 1s

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

In scope of https://github.com/open-feature/go-sdk-contrib/issues/936 - needed in order to introduce `offlinePollIntervalMs` in the go-sdk-contrib flagd provider (as it wraps flagd core)


