### PR TITLE
docs: include new endpoints and examples

### DIFF
--- a/docs/reference/cheat-sheet.md
+++ b/docs/reference/cheat-sheet.md
@@ -19,6 +19,15 @@ Recommended tools:
 
     Output is generally JSON, and can be pretty-printed by piping into `jq` (ie: `curl ... | jq`)
 
+!!! note "Protocols and tabs"
+
+    flagd exposes the same functionality over multiple protocols, so the examples below are tabbed.
+    Not every operation supports every protocol (streaming methods, for example, are gRPC only).
+
+    - **HTTP (REST)** - plain `curl` against [OFREP](https://openfeature.dev/docs/reference/other-technologies/ofrep/) (evaluation) or `GET /v1/flags` (sync). The simplest path.
+    - **HTTP (Connect)** - the gRPC service methods as HTTP/JSON via the [Connect protocol](https://connectrpc.com/docs/protocol/); plain `curl` with `Content-Type: application/json`, no gRPC client required.
+    - **gRPC (grpcurl)** - the native gRPC services, using [grpcurl](https://github.com/fullstorydev/grpcurl) (needs the proto files, see [below](#proto-files-for-grpcurl)).
+
 ## Sample Flag Definitions
 
 The examples below use these sample flag definition files. Download them to follow along:
@@ -28,23 +37,23 @@ The examples below use these sample flag definition files. Download them to foll
 
 The `app-flags` set includes:
 
-| Flag Key | Type | Description |
-|----------|------|-------------|
-| `simple-boolean` | boolean | Static boolean flag |
-| `simple-string` | string | Static string flag |
-| `simple-number` | integer | Static numeric flag |
-| `simple-object` | object | Static object flag |
-| `user-tier-flag` | string | Context-sensitive flag based on `tier` |
+| Flag Key              | Type    | Description                                    |
+| --------------------- | ------- | ---------------------------------------------- |
+| `simple-boolean`      | boolean | Static boolean flag                            |
+| `simple-string`       | string  | Static string flag                             |
+| `simple-number`       | integer | Static numeric flag                            |
+| `simple-object`       | object  | Static object flag                             |
+| `user-tier-flag`      | string  | Context-sensitive flag based on `tier`         |
 | `email-based-feature` | boolean | Context-sensitive flag based on `email` domain |
-| `region-config` | object | Context-sensitive flag based on `region` |
+| `region-config`       | object  | Context-sensitive flag based on `region`       |
 
 The `payment-flags` set includes:
 
-| Flag Key | Type | Description |
-|----------|------|-------------|
-| `payment-provider` | string | Static payment provider selection |
+| Flag Key                 | Type    | Description                                   |
+| ------------------------ | ------- | --------------------------------------------- |
+| `payment-provider`       | string  | Static payment provider selection             |
 | `max-transaction-amount` | integer | Context-sensitive based on `account-verified` |
-| `enable-crypto-payments` | boolean | Context-sensitive based on `country` |
+| `enable-crypto-payments` | boolean | Context-sensitive based on `country`          |
 
 ---
 
@@ -108,60 +117,184 @@ The `payment-flags` set includes:
 !!! note
     The remaining examples use Docker, but all CLI flags work identically with the binary.
 
+### Default ports
+
+| Port | Protocol    | Service                                                                          |
+| ---- | ----------- | -------------------------------------------------------------------------------- |
+| 8013 | gRPC + HTTP | Flag evaluation (evaluation.proto, also served as HTTP/JSON via Connect)         |
+| 8014 | HTTP        | Management (health checks, metrics)                                              |
+| 8015 | gRPC + HTTP | Flag sync (sync.proto, also served as HTTP/JSON via Connect and `GET /v1/flags`) |
+| 8016 | HTTP        | OFREP (OpenFeature Remote Evaluation Protocol)                                   |
+
+### Proto files for grpcurl
+
+flagd does not support gRPC reflection, so `grpcurl` needs the proto files to serialize requests and responses.
+Clone the schemas repo (or download the protos from [buf.build/open-feature/flagd](https://buf.build/open-feature/flagd)) and point `$PROTO_DIR` at them:
+
+```shell
+git clone git@github.com:open-feature/flagd-schemas.git
+PROTO_DIR="flagd-schemas/protobuf/"
+```
+
 ---
 
-## OFREP API (HTTP)
+## Evaluating flags
 
-The [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/docs/reference/other-technologies/ofrep/) API is available on port `8016` by default.
+### Evaluate a single flag
 
-### Evaluate a Single Flag
+=== "HTTP (REST)"
 
-```shell
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-boolean'
-```
+    OFREP, on port `8016`:
 
-Response:
+    ```shell
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-boolean'
+    ```
 
-```jsonc
-{
-  "key": "simple-boolean",
-  "reason": "STATIC",
-  "variant": "on",
-  "value": true,
-  "metadata": {}
-}
-```
+    Response:
 
-### Evaluate Different Flag Types
+    ```jsonc
+    {
+      "key": "simple-boolean",
+      "reason": "STATIC",
+      "variant": "on",
+      "value": true,
+      "metadata": {}
+    }
+    ```
 
-```shell
-# String flag
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-string'
+=== "HTTP (Connect)"
 
-# Number flag
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-number'
+    The evaluation service as HTTP/JSON, on port `8013`:
 
-# Object flag
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-object'
-```
+    ```shell
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveBoolean' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "simple-boolean", "context": {}}'
+    ```
 
-### Evaluate Multiple Flags (Bulk Evaluation)
+    Response:
 
-```shell
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags'
-```
+    ```jsonc
+    {
+      "value": true,
+      "reason": "STATIC",
+      "variant": "on",
+      "metadata": {}
+    }
+    ```
 
-Response:
+=== "gRPC (grpcurl)"
 
-```jsonc
-{
-  "flags": [
-    {"key": "simple-boolean", "reason": "STATIC", "variant": "on", "value": true, "metadata": {}},
-    {"key": "simple-string", "reason": "STATIC", "variant": "greeting", "value": "Hello, World!", "metadata": {}},
-    {"key": "simple-number", "reason": "STATIC", "variant": "medium", "value": 50, "metadata": {}}
-  ]
-}
-```
+    ```shell
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "simple-boolean", "context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveBoolean
+    ```
+
+### Evaluate different flag types
+
+=== "HTTP (REST)"
+
+    ```shell
+    # String flag
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-string'
+
+    # Number flag
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-number'
+
+    # Object flag
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/simple-object'
+    ```
+
+=== "HTTP (Connect)"
+
+    Each type has its own method. Note `ResolveInt` encodes the value as a JSON string (`"50"`), per proto3 JSON:
+
+    ```shell
+    # String flag
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveString' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "simple-string", "context": {}}'
+
+    # Number flag (ResolveInt or ResolveFloat)
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveInt' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "simple-number", "context": {}}'
+
+    # Object flag
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveObject' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "simple-object", "context": {}}'
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    # String flag
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "simple-string", "context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveString
+
+    # Number flag (ResolveInt or ResolveFloat)
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "simple-number", "context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveInt
+
+    # Object flag
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "simple-object", "context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveObject
+    ```
+
+### Evaluate all flags
+
+=== "HTTP (REST)"
+
+    OFREP bulk evaluation returns every flag in one response:
+
+    ```shell
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags'
+    ```
+
+    Response:
+
+    ```jsonc
+    {
+      "flags": [
+        {"key": "simple-boolean", "reason": "STATIC", "variant": "on", "value": true, "metadata": {}},
+        {"key": "simple-string", "reason": "STATIC", "variant": "greeting", "value": "Hello, World!", "metadata": {}},
+        {"key": "simple-number", "reason": "STATIC", "variant": "medium", "value": 50, "metadata": {}}
+      ]
+    }
+    ```
+
+=== "HTTP (Connect)"
+
+    `ResolveAll` lives in the `v1` evaluation service:
+
+    ```shell
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v1.Service/ResolveAll' \
+      -H 'Content-Type: application/json' \
+      -d '{"context": {}}'
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v1/evaluation.proto \
+      -d '{"context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v1.Service/ResolveAll
+    ```
 
 ---
 
@@ -171,38 +304,72 @@ Response:
 
 Pass evaluation context in the request body to trigger targeting rules:
 
-```shell
-# Evaluate with email context (triggers email-based-feature targeting)
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/email-based-feature' \
-  -H 'Content-Type: application/json' \
-  -d '{"context": {"email": "user@example.com"}}'
-```
+=== "HTTP (REST)"
 
-Response (email matches `@example.com`):
+    ```shell
+    # Evaluate with email context (triggers email-based-feature targeting)
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/email-based-feature' \
+      -H 'Content-Type: application/json' \
+      -d '{"context": {"email": "user@example.com"}}'
+    ```
 
-```jsonc
-{
-  "key": "email-based-feature",
-  "reason": "TARGETING_MATCH",
-  "variant": "on",
-  "value": true,
-  "metadata": {}
-}
-```
+    Response (email matches `@example.com`):
 
-```shell
-# Evaluate with tier context
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/user-tier-flag' \
-  -H 'Content-Type: application/json' \
-  -d '{"context": {"tier": "premium"}}'
-```
+    ```jsonc
+    {
+      "key": "email-based-feature",
+      "reason": "TARGETING_MATCH",
+      "variant": "on",
+      "value": true,
+      "metadata": {}
+    }
+    ```
 
-```shell
-# Bulk evaluation with multiple context values
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
-  -H 'Content-Type: application/json' \
-  -d '{"context": {"email": "admin@example.com", "tier": "enterprise", "region": "us"}}'
-```
+    ```shell
+    # Evaluate with tier context
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/user-tier-flag' \
+      -H 'Content-Type: application/json' \
+      -d '{"context": {"tier": "premium"}}'
+    ```
+
+    ```shell
+    # Bulk evaluation with multiple context values
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
+      -H 'Content-Type: application/json' \
+      -d '{"context": {"email": "admin@example.com", "tier": "enterprise", "region": "us"}}'
+    ```
+
+=== "HTTP (Connect)"
+
+    ```shell
+    # Evaluate with email context (triggers email-based-feature targeting)
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveBoolean' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "email-based-feature", "context": {"email": "user@example.com"}}'
+
+    # Evaluate with tier context
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveString' \
+      -H 'Content-Type: application/json' \
+      -d '{"flagKey": "user-tier-flag", "context": {"tier": "premium"}}'
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    # Evaluate with email context (triggers email-based-feature targeting)
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "email-based-feature", "context": {"email": "user@example.com"}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveBoolean
+
+    # Evaluate with tier context
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -d '{"flagKey": "user-tier-flag", "context": {"tier": "premium"}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveString
+    ```
 
 ### Context from Static Values
 
@@ -276,75 +443,64 @@ docker run --rm -it \
 
 Filter evaluations by flag set (`flagSetId`):
 
-```shell
-# Evaluate only flags from the app flag set
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
-  -H 'Flagd-Selector: flagSetId=app-flags'
+=== "HTTP (REST)"
 
-# Evaluate only flags from the payments flag set
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
-  -H 'Flagd-Selector: flagSetId=payment-flags'
+    ```shell
+    # Evaluate only flags from the app flag set
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
+      -H 'Flagd-Selector: flagSetId=app-flags'
 
-# Single flag evaluation with selector
-curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/payment-provider' \
-  -H 'Flagd-Selector: flagSetId=payment-flags'
-```
+    # Evaluate only flags from the payments flag set
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags' \
+      -H 'Flagd-Selector: flagSetId=payment-flags'
+
+    # Single flag evaluation with selector
+    curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags/payment-provider' \
+      -H 'Flagd-Selector: flagSetId=payment-flags'
+    ```
+
+=== "HTTP (Connect)"
+
+    ```shell
+    # Single flag evaluation with selector
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v2.Service/ResolveBoolean' \
+      -H 'Content-Type: application/json' \
+      -H 'Flagd-Selector: flagSetId=app-flags' \
+      -d '{"flagKey": "simple-boolean", "context": {}}'
+
+    # ResolveAll with selector
+    curl -X POST 'http://localhost:8013/flagd.evaluation.v1.Service/ResolveAll' \
+      -H 'Content-Type: application/json' \
+      -H 'Flagd-Selector: flagSetId=payment-flags' \
+      -d '{"context": {}}'
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    # Single flag evaluation with selector
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
+      -H 'Flagd-Selector: flagSetId=app-flags' \
+      -d '{"flagKey": "simple-boolean", "context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v2.Service/ResolveBoolean
+
+    # ResolveAll with selector
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/evaluation/v1/evaluation.proto \
+      -H 'Flagd-Selector: flagSetId=payment-flags' \
+      -d '{"context": {}}' \
+      localhost:8013 \
+      flagd.evaluation.v1.Service/ResolveAll
+    ```
 
 ---
 
-## gRPC Evaluation API (evaluation.proto)
+## Event Stream
 
-The gRPC evaluation service is available on port `8013` by default.
-Use [grpcurl](https://github.com/fullstorydev/grpcurl) to interact with it.
-
-!!! note "Proto files required"
-    flagd does not support gRPC reflection. You must provide the proto files to grpcurl so it knows how to serialize/deserialize requests and responses.
-    Clone the flagd repo or download the protos from [buf.build/open-feature/flagd](https://buf.build/open-feature/flagd).
-
-```shell
-# Clone the repo for proto files
-git clone git@github.com:open-feature/flagd-schemas.git
-PROTO_DIR="flagd-schemas/protobuf/"
-```
-
-### Evaluate Flags by Type
-
-```shell
-# Boolean flag
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
-  -d '{"flagKey": "simple-boolean", "context": {}}' \
-  localhost:8013 \
-  flagd.evaluation.v2.Service/ResolveBoolean
-
-# String flag
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
-  -d '{"flagKey": "simple-string", "context": {}}' \
-  localhost:8013 \
-  flagd.evaluation.v2.Service/ResolveString
-
-# With context
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
-  -d '{"flagKey": "user-tier-flag", "context": {"tier": "enterprise"}}' \
-  localhost:8013 \
-  flagd.evaluation.v2.Service/ResolveString
-```
-
-### Evaluate All Flags
-
-```shell
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v1/evaluation.proto \
-  -d '{"context": {}}' \
-  localhost:8013 \
-  flagd.evaluation.v1.Service/ResolveAll
-```
-
-### Event Stream
-
-The `EventStream` is a server stream that pushes `configuration_change` events when flags change (used by RPC-mode providers for cache invalidation):
+The `EventStream` is a server stream that pushes `configuration_change` events when flags change (used by RPC-mode providers for cache invalidation).
+It is a streaming method; over HTTP it is available as Connect streaming, but `grpcurl` is the practical CLI:
 
 ```shell
 grpcurl -plaintext \
@@ -354,32 +510,9 @@ grpcurl -plaintext \
   flagd.evaluation.v1.Service/EventStream
 ```
 
-### Using Selector Header
-
-Filter which flags are evaluated using the `Flagd-Selector` header:
+The `Flagd-Selector` header also filters the stream, so it only reports `configuration_change` events for flags in the selected flag set(s):
 
 ```shell
-# Evaluate only flags from the app flag set
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v2/evaluation.proto \
-  -H 'Flagd-Selector: flagSetId=app-flags' \
-  -d '{"flagKey": "simple-boolean", "context": {}}' \
-  localhost:8013 \
-  flagd.evaluation.v2.Service/ResolveBoolean
-
-# ResolveAll with selector
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/evaluation/v1/evaluation.proto \
-  -H 'Flagd-Selector: flagSetId=payment-flags' \
-  -d '{"context": {}}' \
-  localhost:8013 \
-  flagd.evaluation.v1.Service/ResolveAll
-```
-
-The same header also filters the `EventStream`, so it only reports `configuration_change` events for flags in the selected flag set(s):
-
-```shell
-# Only receive change events for the payment flag set
 grpcurl -plaintext \
   -import-path "$PROTO_DIR" -proto flagd/evaluation/v1/evaluation.proto \
   -H 'Flagd-Selector: flagSetId=payment-flags' \
@@ -392,110 +525,165 @@ For the `EventStream`, the selector can only be supplied via the header; its req
 
 ---
 
-## gRPC Sync API (sync.proto)
+## Syncing Flag Configuration
 
-The gRPC sync service is available on port `8015` by default.
-This is used by in-process providers to fetch and sync flag configurations.
+The sync service (port `8015`) is used by in-process providers to fetch and stream flag configurations.
+It serves the gRPC `sync.proto` service and, on the same port, an HTTP `GET /v1/flags` endpoint (the unary equivalent of `FetchAllFlags`).
+Disable the HTTP endpoint with `--sync-http-enabled=false`.
 
-Use [grpcurl](https://github.com/fullstorydev/grpcurl) to interact with it.
+### Fetch all flags
 
-!!! note "Proto files required"
-    flagd does not support gRPC reflection. You must provide the proto files to grpcurl so it knows how to serialize/deserialize requests and responses.
-    Clone the flagd repo or download the protos from [buf.build/open-feature/flagd](https://buf.build/open-feature/flagd).
+=== "HTTP (REST)"
 
-### FetchAllFlags
+    `GET /v1/flags` returns the flag configuration document itself (the same string `FetchAllFlags` returns in its `flag_configuration` field):
 
-Get all flag configurations as a single response:
+    ```shell
+    curl http://localhost:8015/v1/flags
+    ```
+
+    Response:
+
+    ```jsonc
+    {
+      "flags": {
+        "simple-boolean": {
+          "state": "ENABLED",
+          "defaultVariant": "on",
+          "variants": {"on": true, "off": false}
+        }
+        // ...
+      }
+    }
+    ```
+
+=== "HTTP (Connect)"
+
+    `FetchAllFlags` as HTTP/JSON returns the document wrapped in an envelope:
+
+    ```shell
+    curl -X POST 'http://localhost:8015/flagd.sync.v1.FlagSyncService/FetchAllFlags' \
+      -H 'Content-Type: application/json' \
+      -d '{}'
+    ```
+
+    Response:
+
+    ```jsonc
+    {
+      "flagConfiguration": "{\"flags\":{\"simple-boolean\":{...}}}"
+    }
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
+      -d '{}' \
+      localhost:8015 \
+      flagd.sync.v1.FlagSyncService/FetchAllFlags
+    ```
+
+### Fetch all flags with a selector
+
+Filter which flag source's configuration is returned.
+
+=== "HTTP (REST)"
+
+    The selector is supplied with the `Flagd-Selector` header:
+
+    ```shell
+    # Fetch only the payment flags
+    curl -H 'Flagd-Selector: flagSetId=payment-flags' http://localhost:8015/v1/flags
+    ```
+
+    The endpoint distinguishes two outcomes:
+
+    | Result                                           | Example                       | Status                    |
+    | ------------------------------------------------ | ----------------------------- | ------------------------- |
+    | Selector is malformed or names an unknown filter | control characters, `bogus=1` | `400`                     |
+    | Valid filter that currently matches no flags     | `flagSetId=empty-set`         | `200` with `{"flags":{}}` |
+
+    An empty result is deliberately not an error: a flag set holding no flags is a normal state, and a downstream flagd syncing from this endpoint should not break when it happens.
+
+=== "HTTP (Connect)"
+
+    The selector may be supplied in the request body or with the `Flagd-Selector` header; if both are present, the header wins:
+
+    ```shell
+    curl -X POST 'http://localhost:8015/flagd.sync.v1.FlagSyncService/FetchAllFlags' \
+      -H 'Content-Type: application/json' \
+      -d '{"selector": "flagSetId=payment-flags"}'
+    ```
+
+=== "gRPC (grpcurl)"
+
+    ```shell
+    # Fetch only the app flags
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
+      -d '{"selector": "flagSetId=app-flags"}' \
+      localhost:8015 \
+      flagd.sync.v1.FlagSyncService/FetchAllFlags
+
+    # With provider ID for identification
+    grpcurl -plaintext \
+      -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
+      -d '{"providerId": "my-app-sidecar", "selector": "flagSetId=app-flags"}' \
+      localhost:8015 \
+      flagd.sync.v1.FlagSyncService/FetchAllFlags
+    ```
+
+    The `Flagd-Selector` header works as an alternative to the request body `selector` field; if both are supplied, the header takes precedence.
+
+### Streaming sync
+
+`SyncFlags` establishes a server-streaming connection that pushes the initial configuration and then streams updates whenever flags change.
+Like `EventStream` it is a streaming method (Connect streaming over HTTP, or native gRPC); `grpcurl` is the practical CLI:
 
 ```shell
 grpcurl -plaintext \
   -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
   -d '{}' \
   localhost:8015 \
-  flagd.sync.v1.FlagSyncService/FetchAllFlags
+  flagd.sync.v1.FlagSyncService/SyncFlags
 ```
-
-Response contains the complete flag configuration JSON:
-
-```jsonc
-{
-  "flagConfiguration": "{\"flags\":{\"simple-boolean\":{...}}}"
-}
-```
-
-### FetchAllFlags with Selector
-
-Filter which flag source's configuration is returned:
 
 ```shell
-# Fetch only flags from cheat-sheet-flags.json
+# Stream only changes to the app flags
 grpcurl -plaintext \
   -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
   -d '{"selector": "flagSetId=app-flags"}' \
   localhost:8015 \
-  flagd.sync.v1.FlagSyncService/FetchAllFlags
-
-# Fetch only payment flags
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -d '{"selector": "flagSetId=payment-flags"}' \
-  localhost:8015 \
-  flagd.sync.v1.FlagSyncService/FetchAllFlags
-
-# With provider ID for identification
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -d '{"providerId": "my-app-sidecar", "selector": "flagSetId=app-flags"}' \
-  localhost:8015 \
-  flagd.sync.v1.FlagSyncService/FetchAllFlags
-```
-
-### SyncFlags (Streaming)
-
-Establish a server-streaming connection that pushes flag configuration updates in real-time:
-
-```shell
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -d '{}' \
-  localhost:8015 \
   flagd.sync.v1.FlagSyncService/SyncFlags
 ```
 
-The stream outputs the initial flag configuration and continues streaming updates when flags change.
+### HTTP caching
 
-### SyncFlags with Selector
+`GET /v1/flags` responses carry both validators, so pollers can revalidate cheaply:
 
-```shell
-# Stream only changes to app flags
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -d '{"selector": "flagSetId=app-flags"}' \
-  localhost:8015 \
-  flagd.sync.v1.FlagSyncService/SyncFlags
+- `ETag` is computed from the response body, so it is exact for the requested selector.
+- `Last-Modified` is the last time flagd observed a change to **any** flag configuration, so it is conservative; it may cost a request a `304` it could have had, but never serves a stale one.
 
-# Stream with provider ID
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -d '{"providerId": "my-service", "selector": "flagSetId=app-flags"}' \
-  localhost:8015 \
-  flagd.sync.v1.FlagSyncService/SyncFlags
-```
-
-### Using Selector Header with Sync API
-
-The `Flagd-Selector` header can be used as an alternative to the request body selector field:
+`If-None-Match` and `If-Modified-Since` are both honored, with `If-None-Match` taking precedence when both are sent:
 
 ```shell
-grpcurl -plaintext \
-  -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
-  -H 'Flagd-Selector: flagSetId=app-flags' \
-  -d '{}' \
-  localhost:8015 \
-  flagd.sync.v1.FlagSyncService/FetchAllFlags
+curl -H 'If-None-Match: "<etag>"' -i http://localhost:8015/v1/flags   # 304 Not Modified
 ```
 
-If both header and request body contain a selector, the header takes precedence.
+### Chaining flagd instances
+
+Because `GET /v1/flags` returns an ordinary flag configuration document, another flagd instance can consume it directly as an HTTP sync source:
+
+```shell
+flagd start --uri http://localhost:8015/v1/flags
+```
+
+To sync only a subset, set the selector header on the source, which needs the `--sources` form:
+
+```shell
+flagd start --sources='[{"uri":"http://localhost:8015/v1/flags","provider":"http","headers":{"Flagd-Selector":"flagSetId=payment-flags"}}]'
+```
 
 ---
 
@@ -503,12 +691,12 @@ If both header and request body contain a selector, the header takes precedence.
 
 ### Ports
 
-| Port | Protocol | Service | Description |
-|------|----------|---------|-------------|
-| 8013 | gRPC | Evaluation | Flag evaluation API (evaluation.proto) |
-| 8014 | HTTP | Management | Health checks, metrics |
-| 8015 | gRPC | Sync | Flag sync for in-process providers (sync.proto) |
-| 8016 | HTTP | OFREP | OpenFeature Remote Evaluation Protocol |
+| Port | Protocol    | Service    | Description                                                            |
+| ---- | ----------- | ---------- | ---------------------------------------------------------------------- |
+| 8013 | gRPC / HTTP | Evaluation | Flag evaluation API (evaluation.proto, also HTTP/JSON via Connect)     |
+| 8014 | HTTP        | Management | Health checks, metrics                                                 |
+| 8015 | gRPC / HTTP | Sync       | Flag sync (sync.proto, also HTTP/JSON via Connect and `GET /v1/flags`) |
+| 8016 | HTTP        | OFREP      | OpenFeature Remote Evaluation Protocol                                 |
 
 ### Health Check
 

--- a/docs/reference/cheat-sheet.md
+++ b/docs/reference/cheat-sheet.md
@@ -22,7 +22,7 @@ Recommended tools:
 !!! note "Protocols and tabs"
 
     flagd exposes the same functionality over multiple protocols, so the examples below are tabbed.
-    Not every operation supports every protocol (streaming methods, for example, are gRPC only).
+    Not every operation supports every protocol. Streaming methods use native gRPC or Connect streaming over HTTP; OFREP exposes REST evaluation.
 
     - **HTTP (REST)** - plain `curl` against [OFREP](https://openfeature.dev/docs/reference/other-technologies/ofrep/) (evaluation) or `GET /v1/flags` (sync). The simplest path.
     - **HTTP (Connect)** - the gRPC service methods as HTTP/JSON via the [Connect protocol](https://connectrpc.com/docs/protocol/); plain `curl` with `Content-Type: application/json`, no gRPC client required.
@@ -650,7 +650,7 @@ grpcurl -plaintext \
 ```
 
 ```shell
-# Stream only changes to the app flags
+# Stream the app flags (initial config, then updates as they change)
 grpcurl -plaintext \
   -import-path "$PROTO_DIR" -proto flagd/sync/v1/sync.proto \
   -d '{"selector": "flagSetId=app-flags"}' \

--- a/docs/reference/flagd-ofrep.md
+++ b/docs/reference/flagd-ofrep.md
@@ -23,7 +23,7 @@ To evaluate all flags currently configured at flagd, use OFREP bulk evaluation r
 curl -X POST 'http://localhost:8016/ofrep/v1/evaluate/flags'
 ```
 
-See the [cheat sheet](./cheat-sheet.md#ofrep-api-http) for more OFREP examples including context-sensitive evaluation and selectors.
+See the [cheat sheet](./cheat-sheet.md#evaluating-flags) for more OFREP examples including context-sensitive evaluation and selectors.
 
 ## Monitoring
 

--- a/docs/reference/grpc-sync-service.md
+++ b/docs/reference/grpc-sync-service.md
@@ -53,7 +53,7 @@ final FlagdProvider flagdProvider =
                 .build());
 ```
 
-See the [cheat sheet](./cheat-sheet.md#grpc-sync-api-syncproto) for `grpcurl` examples using `FetchAllFlags` and `SyncFlags`.
+See the [cheat sheet](./cheat-sheet.md#syncing-flag-configuration) for `grpcurl` examples using `FetchAllFlags` and `SyncFlags`.
 
 ## Protocols
 
@@ -111,16 +111,15 @@ the other flagd services:
 curl -H 'Flagd-Selector: flagSetId=payments' http://localhost:8015/v1/flags
 ```
 
-The endpoint distinguishes three outcomes:
+The endpoint distinguishes two outcomes:
 
-| Result                                       | Example                           | Status                    |
-|----------------------------------------------|-----------------------------------|---------------------------|
-| Selector string is not well-formed           | control characters, invalid UTF-8 | `400`                     |
-| Well-formed, but names an unknown filter     | `bogus=1`                         | `404`                     |
-| Valid filter that currently matches no flags | `flagSetId=empty-set`             | `200` with `{"flags":{}}` |
+| Result                                           | Example                       | Status                    |
+| ------------------------------------------------ | ----------------------------- | ------------------------- |
+| Selector is malformed or names an unknown filter | control characters, `bogus=1` | `400`                     |
+| Valid filter that currently matches no flags     | `flagSetId=empty-set`         | `200` with `{"flags":{}}` |
 
-An empty result is deliberately not a `404`: a flag set holding no flags is a normal state, and a downstream flagd syncing from this endpoint should not break when it happens.
-The RPC surface reports both selector failures as `invalid_argument`, since it has no equivalent of the `400`/`404` split.
+An empty result is deliberately not an error: a flag set holding no flags is a normal state, and a downstream flagd syncing from this endpoint should not break when it happens.
+The RPC surface reports selector failures as `invalid_argument`.
 
 ### Caching
 

--- a/docs/reference/sync-configuration.md
+++ b/docs/reference/sync-configuration.md
@@ -148,6 +148,9 @@ sources:
 
 ### HTTP Configuration
 
+The HTTP sync polls the source every `interval` (default 5s). Polling is cheap when nothing has changed: flagd sends `If-None-Match` with the last `ETag`, and a `304 Not Modified` means a body need not be parsed.
+See [HTTP sync](../concepts/syncs.md#http-sync) for the client behavior and [gRPC Sync Service](./grpc-sync-service.md#caching) for the validators flagd emits when it serves flags.
+
 The HTTP Configuration also supports OAuth that allows to securely fetch feature flag configurations from an HTTP endpoint
 that requires OAuth-based authentication.
 


### PR DESCRIPTION
* adds new endpoints/protocols to cheat-sheet
* adds a few related docs elsewhere

Different protocols are now tabbed: 
<img width="791" height="553" alt="image" src="https://github.com/user-attachments/assets/cde42477-ea23-417c-901f-196ae0511b1f" />
