### PR TITLE
fix: wait for flag state before reporting ready

### DIFF
--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -117,6 +117,10 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 	for _, provider := range config.SyncProviders {
 		sources = append(sources, provider.URI)
 	}
+	sourceReadiness := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		sourceReadiness[source] = false
+	}
 
 	// build flag store, collect flag sources & fill sources details
 	store, err := store.NewStore(logger, sources)
@@ -214,7 +218,8 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 			MaxRequestBodyBytes:        config.MaxRequestBodyBytes,
 			MaxRequestHeaderBytes:      config.MaxRequestHeaderBytes,
 		},
-		Syncs: iSyncs,
+		Syncs:           iSyncs,
+		sourceReadiness: sourceReadiness,
 	}, nil
 }
 

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -27,6 +27,9 @@ type Runtime struct {
 	ServiceConfig     service.Configuration
 	Syncs             []sync.ISync
 
+	// sourceReadiness records whether each configured source has successfully updated the evaluator.
+	sourceReadiness map[string]bool
+
 	mu msync.Mutex
 }
 
@@ -119,6 +122,14 @@ func (r *Runtime) isReady() bool {
 			return false
 		}
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, ready := range r.sourceReadiness {
+		if !ready {
+			return false
+		}
+	}
 	return true
 }
 
@@ -131,6 +142,10 @@ func (r *Runtime) updateAndEmit(payload sync.DataSync) {
 	if err != nil {
 		r.Logger.Error(fmt.Sprintf("error setting state: %v", err))
 		return
+	}
+
+	if _, configured := r.sourceReadiness[payload.Source]; configured {
+		r.sourceReadiness[payload.Source] = true
 	}
 	r.SyncService.Emit(payload.Source)
 }

--- a/flagd/pkg/runtime/runtime_test.go
+++ b/flagd/pkg/runtime/runtime_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	evalmock "github.com/open-feature/flagd/core/pkg/evaluator/mock"
+	"github.com/open-feature/flagd/core/pkg/logger"
+	coresync "github.com/open-feature/flagd/core/pkg/sync"
+	flagsync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type readySync struct {
+	ready bool
+}
+
+func (s readySync) Init(context.Context) error {
+	return nil
+}
+
+func (s readySync) Sync(context.Context, chan<- coresync.DataSync) error {
+	return nil
+}
+
+func (s readySync) ReSync(context.Context, chan<- coresync.DataSync) error {
+	return nil
+}
+
+func (s readySync) IsReady() bool {
+	return s.ready
+}
+
+type recordingSyncService struct {
+	emitted []string
+}
+
+var _ flagsync.ISyncService = (*recordingSyncService)(nil)
+
+func (s *recordingSyncService) Start(context.Context) error {
+	return nil
+}
+
+func (s *recordingSyncService) Emit(source string) {
+	s.emitted = append(s.emitted, source)
+}
+
+func TestRuntimeReadinessRequiresSuccessfulStateForEverySource(t *testing.T) {
+	const (
+		firstSource  = "file:/first.flagd.json"
+		secondSource = "file:/second.flagd.json"
+	)
+
+	firstPayload := coresync.DataSync{Source: firstSource}
+	secondPayload := coresync.DataSync{Source: secondSource}
+	evaluatorError := errors.New("invalid flag configuration")
+
+	ctrl := gomock.NewController(t)
+	evaluator := evalmock.NewMockIEvaluator(ctrl)
+	evaluator.EXPECT().SetState(firstPayload).Return(evaluatorError)
+	evaluator.EXPECT().SetState(firstPayload).Return(nil)
+	evaluator.EXPECT().SetState(secondPayload).Return(nil)
+
+	syncService := &recordingSyncService{}
+	runtime := Runtime{
+		Evaluator:   evaluator,
+		Logger:      logger.NewLogger(nil, false),
+		SyncService: syncService,
+		Syncs: []coresync.ISync{
+			readySync{ready: true},
+			readySync{ready: true},
+		},
+		sourceReadiness: map[string]bool{
+			firstSource:  false,
+			secondSource: false,
+		},
+	}
+
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(firstPayload)
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(firstPayload)
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(secondPayload)
+	require.True(t, runtime.isReady())
+	require.Equal(t, []string{firstSource, secondSource}, syncService.emitted)
+}


### PR DESCRIPTION
## Summary

Make readiness wait until every configured sync source has successfully updated the evaluator. A sync provider can report that it is watching before the runtime has drained and applied its first payload; `/readyz` now stays unavailable during that gap and after a failed initial `SetState`.

The regression test covers two sources and an initial evaluator error so a single applied payload cannot make readiness pass.

Fixes #2047

## Testing

- `make test` (core, flagd, and flagd-proxy packages with race detection and coverage)
- `go test -race -cover -short ./flagd/pkg/runtime/...`
- Scoped `golangci-lint v2.13.2` on `flagd/pkg/runtime` — 0 issues
- Manual runtime verification with a freshly built binary and the sample file source on isolated ports: across three startup cycles, I polled `/readyz` and immediately evaluated `myBoolFlag` through OFREP. Each cycle returned HTTP 200 with `value: true`, with no `FLAG_NOT_FOUND` response.
