### PR TITLE
fix: wait for flag state before reporting ready

### DIFF
--- a/flagd/pkg/runtime/from_config.go
+++ b/flagd/pkg/runtime/from_config.go
@@ -117,6 +117,7 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 	for _, provider := range config.SyncProviders {
 		sources = append(sources, provider.URI)
 	}
+	sourceReadiness := make([]bool, len(config.SyncProviders))
 
 	// build flag store, collect flag sources & fill sources details
 	store, err := store.NewStore(logger, sources)
@@ -214,7 +215,8 @@ func FromConfig(logger *logger.Logger, version string, config Config) (*Runtime,
 			MaxRequestBodyBytes:        config.MaxRequestBodyBytes,
 			MaxRequestHeaderBytes:      config.MaxRequestHeaderBytes,
 		},
-		Syncs: iSyncs,
+		Syncs:           iSyncs,
+		sourceReadiness: sourceReadiness,
 	}, nil
 }
 

--- a/flagd/pkg/runtime/runtime.go
+++ b/flagd/pkg/runtime/runtime.go
@@ -27,7 +27,15 @@ type Runtime struct {
 	ServiceConfig     service.Configuration
 	Syncs             []sync.ISync
 
+	// sourceReadiness records whether each configured sync provider has successfully updated the evaluator.
+	sourceReadiness []bool
+
 	mu msync.Mutex
+}
+
+type providerDataSync struct {
+	payload       sync.DataSync
+	providerIndex int
 }
 
 //nolint:funlen
@@ -44,13 +52,13 @@ func (r *Runtime) Start() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	g, gCtx := errgroup.WithContext(ctx)
-	dataSync := make(chan sync.DataSync, len(r.Syncs))
+	dataSync := make(chan providerDataSync, len(r.Syncs))
 	// Initialize DataSync channel watcher
 	g.Go(func() error {
 		for {
 			select {
 			case data := <-dataSync:
-				r.updateAndEmit(data)
+				r.updateAndEmit(data.payload, data.providerIndex)
 			case <-gCtx.Done():
 				return nil
 			}
@@ -62,11 +70,30 @@ func (r *Runtime) Start() error {
 			return fmt.Errorf("sync provider Init returned error: %w", err)
 		}
 	}
-	// Start sync provider
-	for _, s := range r.Syncs {
-		p := s
+	// Start sync providers. Each provider has its own channel so the runtime can preserve
+	// provider identity even when two configured providers share a source URI.
+	for index, s := range r.Syncs {
+		p, providerIndex := s, index
+		providerData := make(chan sync.DataSync, 1)
 		g.Go(func() error {
-			if err := p.Sync(gCtx, dataSync); err != nil {
+			for {
+				select {
+				case data, ok := <-providerData:
+					if !ok {
+						return nil
+					}
+					select {
+					case dataSync <- providerDataSync{payload: data, providerIndex: providerIndex}:
+					case <-gCtx.Done():
+						return nil
+					}
+				case <-gCtx.Done():
+					return nil
+				}
+			}
+		})
+		g.Go(func() error {
+			if err := p.Sync(gCtx, providerData); err != nil {
 				return fmt.Errorf("sync provider returned error: %w", err)
 			}
 			return nil
@@ -119,11 +146,19 @@ func (r *Runtime) isReady() bool {
 			return false
 		}
 	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, ready := range r.sourceReadiness {
+		if !ready {
+			return false
+		}
+	}
 	return true
 }
 
 // updateAndEmit helps to update state, notify changes and trigger sync updates
-func (r *Runtime) updateAndEmit(payload sync.DataSync) {
+func (r *Runtime) updateAndEmit(payload sync.DataSync, providerIndex int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -131,6 +166,10 @@ func (r *Runtime) updateAndEmit(payload sync.DataSync) {
 	if err != nil {
 		r.Logger.Error(fmt.Sprintf("error setting state: %v", err))
 		return
+	}
+
+	if providerIndex < len(r.sourceReadiness) {
+		r.sourceReadiness[providerIndex] = true
 	}
 	r.SyncService.Emit(payload.Source)
 }

--- a/flagd/pkg/runtime/runtime_test.go
+++ b/flagd/pkg/runtime/runtime_test.go
@@ -1,0 +1,211 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	evalmock "github.com/open-feature/flagd/core/pkg/evaluator/mock"
+	"github.com/open-feature/flagd/core/pkg/logger"
+	"github.com/open-feature/flagd/core/pkg/service"
+	coresync "github.com/open-feature/flagd/core/pkg/sync"
+	flagsync "github.com/open-feature/flagd/flagd/pkg/service/flag-sync"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type readySync struct {
+	ready bool
+}
+
+func (s readySync) Init(context.Context) error {
+	return nil
+}
+
+func (s readySync) Sync(context.Context, chan<- coresync.DataSync) error {
+	return nil
+}
+
+func (s readySync) ReSync(context.Context, chan<- coresync.DataSync) error {
+	return nil
+}
+
+func (s readySync) IsReady() bool {
+	return s.ready
+}
+
+type recordingSyncService struct {
+	emitted []string
+}
+
+var _ flagsync.ISyncService = (*recordingSyncService)(nil)
+
+func (s *recordingSyncService) Start(context.Context) error {
+	return nil
+}
+
+func (s *recordingSyncService) Emit(source string) {
+	s.emitted = append(s.emitted, source)
+}
+
+type controlledSync struct {
+	payloads <-chan coresync.DataSync
+	started  chan<- struct{}
+}
+
+func (s controlledSync) Init(context.Context) error {
+	return nil
+}
+
+func (s controlledSync) Sync(ctx context.Context, dataSync chan<- coresync.DataSync) error {
+	select {
+	case s.started <- struct{}{}:
+	case <-ctx.Done():
+		return nil
+	}
+
+	for {
+		select {
+		case payload := <-s.payloads:
+			select {
+			case dataSync <- payload:
+			case <-ctx.Done():
+				return nil
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (s controlledSync) ReSync(context.Context, chan<- coresync.DataSync) error {
+	return nil
+}
+
+func (s controlledSync) IsReady() bool {
+	return true
+}
+
+type blockingEvaluationService struct {
+	stop <-chan struct{}
+}
+
+var _ service.IFlagEvaluationService = blockingEvaluationService{}
+
+func (s blockingEvaluationService) Serve(ctx context.Context, _ service.Configuration) error {
+	select {
+	case <-s.stop:
+		return errors.New("test complete")
+	case <-ctx.Done():
+		return nil
+	}
+}
+
+func (blockingEvaluationService) Notify(service.Notification) {}
+
+func (blockingEvaluationService) Shutdown() {}
+
+type blockingOfrepService struct{}
+
+func (blockingOfrepService) Start(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func requireSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runtime signal")
+	}
+}
+
+func TestRuntimeReadinessRequiresSuccessfulStateFromEveryProvider(t *testing.T) {
+	const source = "file:/shared.flagd.json"
+
+	payload := coresync.DataSync{Source: source}
+	evaluatorError := errors.New("invalid flag configuration")
+
+	ctrl := gomock.NewController(t)
+	evaluator := evalmock.NewMockIEvaluator(ctrl)
+	evaluator.EXPECT().SetState(payload).Return(evaluatorError)
+	evaluator.EXPECT().SetState(payload).Return(nil)
+	evaluator.EXPECT().SetState(payload).Return(nil)
+
+	syncService := &recordingSyncService{}
+	runtime := Runtime{
+		Evaluator:   evaluator,
+		Logger:      logger.NewLogger(nil, false),
+		SyncService: syncService,
+		Syncs: []coresync.ISync{
+			readySync{ready: true},
+			readySync{ready: true},
+		},
+		sourceReadiness: []bool{false, false},
+	}
+
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(payload, 0)
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(payload, 0)
+	require.False(t, runtime.isReady())
+
+	runtime.updateAndEmit(payload, 1)
+	require.True(t, runtime.isReady())
+	require.Equal(t, []string{source, source}, syncService.emitted)
+}
+
+func TestRuntimeStartTracksProvidersWithSameSourceSeparately(t *testing.T) {
+	const source = "file:/shared.flagd.json"
+
+	payload := coresync.DataSync{Source: source}
+	started := make(chan struct{}, 2)
+	firstProviderData := make(chan coresync.DataSync)
+	secondProviderData := make(chan coresync.DataSync)
+	updated := make(chan struct{}, 2)
+	stop := make(chan struct{})
+
+	ctrl := gomock.NewController(t)
+	evaluator := evalmock.NewMockIEvaluator(ctrl)
+	evaluator.EXPECT().SetState(payload).DoAndReturn(func(coresync.DataSync) error {
+		updated <- struct{}{}
+		return nil
+	}).Times(2)
+
+	runtime := Runtime{
+		Evaluator:         evaluator,
+		Logger:            logger.NewLogger(nil, false),
+		SyncService:       &recordingSyncService{},
+		OfrepService:      blockingOfrepService{},
+		EvaluationService: blockingEvaluationService{stop: stop},
+		Syncs: []coresync.ISync{
+			controlledSync{payloads: firstProviderData, started: started},
+			controlledSync{payloads: secondProviderData, started: started},
+		},
+		sourceReadiness: []bool{false, false},
+	}
+
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- runtime.Start()
+	}()
+
+	requireSignal(t, started)
+	requireSignal(t, started)
+
+	firstProviderData <- payload
+	requireSignal(t, updated)
+	require.False(t, runtime.isReady())
+
+	secondProviderData <- payload
+	requireSignal(t, updated)
+	require.True(t, runtime.isReady())
+
+	close(stop)
+	require.Error(t, <-startErr)
+}


### PR DESCRIPTION
## Summary

Make readiness wait until every configured sync source has successfully updated the evaluator. A sync provider can report that it is watching before the runtime has drained and applied its first payload; `/readyz` now stays unavailable during that gap and after a failed initial `SetState`.

Readiness is tracked per configured source URI. Once every source has applied state, an `initialized` flag is set and readiness only depends on the providers' watch state from then on.

The regression tests cover two configured sources, an initial evaluator error, and the runtime forwarding path, so a single applied payload cannot make readiness pass.

Fixes #2047

## Testing

- `go test -race -count=1 ./flagd/pkg/runtime/...`
- `go test -race -covermode=atomic -cover -short ./flagd/pkg/...`
- `go build ./...` and `go vet ./pkg/runtime/...` in `flagd/`, `gofmt -l` clean
- Manual runtime verification with a freshly built binary and the sample file source on isolated ports: across three startup cycles, I polled `/readyz` and immediately evaluated `myBoolFlag` through OFREP. Each cycle returned HTTP 200 with `value: true`, with no `FLAG_NOT_FOUND` response.
